### PR TITLE
Fix block order not persisted to API during reorder operations

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -24,11 +24,13 @@ jobs:
           PR_BRANCH: ${{ github.head_ref }}
           PORT: ${{ steps.vars.outputs.port }}
           STAGING_BASE_DIR: ${{ vars.DO_STAGING_BASE_DIR }}
+          DJANGO_SUPERUSER_EMAIL: ${{ secrets.SUPERUSER_EMAIL }}
+          DJANGO_SUPERUSER_PASSWORD: ${{ secrets.SUPERUSER_PASSWORD }}
         with:
           host: ${{ secrets.DO_SSH_HOST }}
           username: ${{ secrets.DO_SSH_USER }}
           key: ${{ secrets.DO_SSH_KEY }}
-          envs: GITHUB_TOKEN,PR_NUM,PR_BRANCH,PORT,STAGING_BASE_DIR
+          envs: GITHUB_TOKEN,PR_NUM,PR_BRANCH,PORT,STAGING_BASE_DIR,DJANGO_SUPERUSER_EMAIL,DJANGO_SUPERUSER_PASSWORD
           script: |
             STAGING_DIR="${STAGING_BASE_DIR}/pr-${PR_NUM}"
             PG_PORT=$((5500 + PR_NUM))
@@ -71,6 +73,7 @@ jobs:
             just staging-up
             sleep 5
             just staging-migrate
+            just staging-create-superuser
 
       - name: Find existing comment
         uses: peter-evans/find-comment@v3

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -95,7 +95,7 @@ jobs:
 
             | | |
             |---|---|
-            | **URL** | http://${{ secrets.DO_SSH_HOST }}:${{ steps.vars.outputs.port }}/knowledge/ |
+            | **URL** | http://${{ vars.DO_STAGING_HOST }}:${{ steps.vars.outputs.port }}/knowledge/ |
             | **Branch** | `${{ github.head_ref }}` |
             | **Commit** | `${{ github.sha }}` |
             | **Status** | Deployed |

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -74,6 +74,7 @@ jobs:
             sleep 5
             just staging-migrate
             just staging-create-superuser
+            just staging-seed
 
       - name: Find existing comment
         uses: peter-evans/find-comment@v3
@@ -94,7 +95,7 @@ jobs:
 
             | | |
             |---|---|
-            | **Port** | `${{ steps.vars.outputs.port }}` |
+            | **URL** | http://${{ secrets.DO_SSH_HOST }}:${{ steps.vars.outputs.port }}/knowledge/ |
             | **Branch** | `${{ github.head_ref }}` |
             | **Commit** | `${{ github.sha }}` |
             | **Status** | Deployed |

--- a/packages/django-app/app/knowledge/commands/__init__.py
+++ b/packages/django-app/app/knowledge/commands/__init__.py
@@ -1,5 +1,4 @@
 from .create_block_command import CreateBlockCommand
-from .reorder_blocks_command import ReorderBlocksCommand
 from .create_page_command import CreatePageCommand
 from .delete_block_command import DeleteBlockCommand
 from .delete_page_command import DeletePageCommand
@@ -8,6 +7,7 @@ from .get_page_with_blocks_command import GetPageWithBlocksCommand
 from .get_tag_content_command import GetTagContentCommand
 from .get_user_pages_command import GetUserPagesCommand
 from .move_undone_todos_command import MoveUndoneTodosCommand
+from .reorder_blocks_command import ReorderBlocksCommand
 from .search_pages_command import SearchPagesCommand
 from .sync_block_tags_command import SyncBlockTagsCommand
 from .toggle_block_todo_command import ToggleBlockTodoCommand

--- a/packages/django-app/app/knowledge/commands/__init__.py
+++ b/packages/django-app/app/knowledge/commands/__init__.py
@@ -1,4 +1,5 @@
 from .create_block_command import CreateBlockCommand
+from .reorder_blocks_command import ReorderBlocksCommand
 from .create_page_command import CreatePageCommand
 from .delete_block_command import DeleteBlockCommand
 from .delete_page_command import DeletePageCommand

--- a/packages/django-app/app/knowledge/commands/reorder_blocks_command.py
+++ b/packages/django-app/app/knowledge/commands/reorder_blocks_command.py
@@ -1,0 +1,34 @@
+from django.core.exceptions import ValidationError
+
+from common.commands.abstract_base_command import AbstractBaseCommand
+
+from ..forms.reorder_blocks_form import ReorderBlocksForm
+from ..repositories import BlockRepository
+
+
+class ReorderBlocksCommand(AbstractBaseCommand):
+    """Command to batch-reorder blocks in a single operation."""
+
+    def __init__(self, form: ReorderBlocksForm) -> None:
+        self.form = form
+
+    def execute(self) -> bool:
+        super().execute()
+
+        user = self.form.cleaned_data["user"]
+        blocks_order_data = self.form.cleaned_data["blocks"]
+
+        normalized = [
+            {"uuid": str(item["uuid"]), "order": item["order"]}
+            for item in blocks_order_data
+        ]
+
+        success = BlockRepository.reorder_blocks(normalized, user=user)
+
+        if not success:
+            raise ValidationError(
+                "Failed to reorder blocks. Some blocks may not exist or "
+                "belong to a different user."
+            )
+
+        return True

--- a/packages/django-app/app/knowledge/forms/__init__.py
+++ b/packages/django-app/app/knowledge/forms/__init__.py
@@ -1,4 +1,5 @@
 from .create_block_form import CreateBlockForm
+from .reorder_blocks_form import ReorderBlocksForm
 from .create_page_form import CreatePageForm
 from .delete_block_form import DeleteBlockForm
 from .delete_page_form import DeletePageForm

--- a/packages/django-app/app/knowledge/forms/__init__.py
+++ b/packages/django-app/app/knowledge/forms/__init__.py
@@ -1,5 +1,4 @@
 from .create_block_form import CreateBlockForm
-from .reorder_blocks_form import ReorderBlocksForm
 from .create_page_form import CreatePageForm
 from .delete_block_form import DeleteBlockForm
 from .delete_page_form import DeletePageForm
@@ -8,6 +7,7 @@ from .get_page_with_blocks_form import GetPageWithBlocksForm
 from .get_tag_content_form import GetTagContentForm
 from .get_user_pages_form import GetUserPagesForm
 from .move_undone_todos_form import MoveUndoneTodosForm
+from .reorder_blocks_form import ReorderBlocksForm
 from .search_pages_form import SearchPagesForm
 from .sync_block_tags_form import SyncBlockTagsForm
 from .toggle_block_todo_form import ToggleBlockTodoForm

--- a/packages/django-app/app/knowledge/forms/reorder_blocks_form.py
+++ b/packages/django-app/app/knowledge/forms/reorder_blocks_form.py
@@ -1,0 +1,52 @@
+import uuid
+
+from django import forms
+from django.core.exceptions import ValidationError
+
+from common.forms import BaseForm
+from core.models import User
+from core.repositories import UserRepository
+
+
+class ReorderBlocksForm(BaseForm):
+    user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
+    blocks = forms.JSONField()
+
+    def clean_user(self) -> User:
+        user = self.cleaned_data.get("user")
+        if not user:
+            raise ValidationError("User is required")
+        return user
+
+    def clean_blocks(self) -> list:
+        blocks = self.cleaned_data.get("blocks")
+
+        if not isinstance(blocks, list):
+            raise ValidationError("blocks must be a list")
+
+        if len(blocks) == 0:
+            raise ValidationError("blocks list must not be empty")
+
+        for i, item in enumerate(blocks):
+            if not isinstance(item, dict):
+                raise ValidationError(f"Item at index {i} must be an object")
+
+            if "uuid" not in item:
+                raise ValidationError(f"Item at index {i} is missing 'uuid'")
+
+            if "order" not in item:
+                raise ValidationError(f"Item at index {i} is missing 'order'")
+
+            try:
+                uuid.UUID(str(item["uuid"]))
+            except (ValueError, AttributeError):
+                raise ValidationError(
+                    f"Item at index {i} has an invalid UUID: {item['uuid']!r}"
+                )
+
+            if not isinstance(item["order"], int) or item["order"] < 0:
+                raise ValidationError(
+                    f"Item at index {i} 'order' must be a non-negative integer"
+                )
+
+        return blocks

--- a/packages/django-app/app/knowledge/management/commands/seed_staging_data.py
+++ b/packages/django-app/app/knowledge/management/commands/seed_staging_data.py
@@ -1,0 +1,76 @@
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from knowledge.models import Block, Page
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = "Seed staging environment with sample blocks for today's daily note"
+
+    def handle(self, *args, **options):
+        user = User.objects.filter(is_superuser=True).first()
+        if not user:
+            self.stdout.write(self.style.ERROR("No superuser found. Run createsuperuser first."))
+            return
+
+        today = date.today()
+        date_str = today.strftime("%Y-%m-%d")
+
+        with transaction.atomic():
+            page, created = Page.objects.get_or_create(
+                user=user,
+                slug=date_str,
+                defaults={
+                    "title": date_str,
+                    "page_type": "daily",
+                    "date": today,
+                    "is_published": True,
+                },
+            )
+
+            if not created and Block.objects.filter(page=page).exists():
+                self.stdout.write(self.style.WARNING(f"Page {date_str} already has blocks, skipping."))
+                return
+
+            def block(content, order, parent=None, block_type="bullet"):
+                return Block.objects.create(
+                    user=user,
+                    page=page,
+                    content=content,
+                    block_type=block_type,
+                    order=order,
+                    parent=parent,
+                )
+
+            # Top-level blocks
+            focus = block("Today's Focus", order=0, block_type="heading")
+            block("Review and test block reordering", order=0, parent=focus, block_type="todo")
+            indent_todo = block("Indent and outdent nested blocks", order=1, parent=focus, block_type="todo")
+            block("Tab to indent a block", order=0, parent=indent_todo)
+            block("Shift+Tab to outdent", order=1, parent=indent_todo)
+            block("Double-space also indents on mobile", order=2, parent=indent_todo)
+            block("Move blocks up and down with the block menu", order=2, parent=focus, block_type="todo")
+            block("Set up staging environment", order=3, parent=focus, block_type="done")
+
+            notes = block("Notes", order=1, block_type="heading")
+            block("Block ordering now uses a single batch API call instead of N+1 requests", order=0, parent=notes)
+            perf = block("Performance improvements", order=1, parent=notes)
+            block("createBlockAfter and createBlockBefore batch sibling shifts", order=0, parent=perf)
+            block("moveBlockUp and moveBlockDown use one reorder call", order=1, parent=perf)
+            block("outdentBlock sibling shifts are now persisted correctly", order=2, parent=perf)
+            block("There's no way to predict the future except by creating it", order=2, parent=notes, block_type="quote")
+
+            ideas = block("Ideas", order=2, block_type="heading")
+            block("Add drag-and-drop block reordering", order=0, parent=ideas, block_type="todo")
+            block("Collapsible block sections", order=1, parent=ideas, block_type="todo")
+            context = block("Context", order=2, parent=ideas)
+            block("Blocks can be nested to any depth", order=0, parent=context)
+            block("Each block tracks its parent and order", order=1, parent=context)
+
+        action = "Created" if created else "Updated"
+        self.stdout.write(self.style.SUCCESS(f"{action} daily note {date_str} with sample blocks for {user.email}"))

--- a/packages/django-app/app/knowledge/management/commands/seed_staging_data.py
+++ b/packages/django-app/app/knowledge/management/commands/seed_staging_data.py
@@ -15,7 +15,9 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         user = User.objects.filter(is_superuser=True).first()
         if not user:
-            self.stdout.write(self.style.ERROR("No superuser found. Run createsuperuser first."))
+            self.stdout.write(
+                self.style.ERROR("No superuser found. Run createsuperuser first.")
+            )
             return
 
         today = date.today()
@@ -34,7 +36,9 @@ class Command(BaseCommand):
             )
 
             if not created and Block.objects.filter(page=page).exists():
-                self.stdout.write(self.style.WARNING(f"Page {date_str} already has blocks, skipping."))
+                self.stdout.write(
+                    self.style.WARNING(f"Page {date_str} already has blocks, skipping.")
+                )
                 return
 
             def block(content, order, parent=None, block_type="bullet"):
@@ -49,28 +53,77 @@ class Command(BaseCommand):
 
             # Top-level blocks
             focus = block("Today's Focus", order=0, block_type="heading")
-            block("Review and test block reordering", order=0, parent=focus, block_type="todo")
-            indent_todo = block("Indent and outdent nested blocks", order=1, parent=focus, block_type="todo")
+            block(
+                "Review and test block reordering",
+                order=0,
+                parent=focus,
+                block_type="todo",
+            )
+            indent_todo = block(
+                "Indent and outdent nested blocks",
+                order=1,
+                parent=focus,
+                block_type="todo",
+            )
             block("Tab to indent a block", order=0, parent=indent_todo)
             block("Shift+Tab to outdent", order=1, parent=indent_todo)
             block("Double-space also indents on mobile", order=2, parent=indent_todo)
-            block("Move blocks up and down with the block menu", order=2, parent=focus, block_type="todo")
-            block("Set up staging environment", order=3, parent=focus, block_type="done")
+            block(
+                "Move blocks up and down with the block menu",
+                order=2,
+                parent=focus,
+                block_type="todo",
+            )
+            block(
+                "Set up staging environment", order=3, parent=focus, block_type="done"
+            )
 
             notes = block("Notes", order=1, block_type="heading")
-            block("Block ordering now uses a single batch API call instead of N+1 requests", order=0, parent=notes)
+            block(
+                "Block ordering now uses a single batch API call instead of N+1 requests",
+                order=0,
+                parent=notes,
+            )
             perf = block("Performance improvements", order=1, parent=notes)
-            block("createBlockAfter and createBlockBefore batch sibling shifts", order=0, parent=perf)
-            block("moveBlockUp and moveBlockDown use one reorder call", order=1, parent=perf)
-            block("outdentBlock sibling shifts are now persisted correctly", order=2, parent=perf)
-            block("There's no way to predict the future except by creating it", order=2, parent=notes, block_type="quote")
+            block(
+                "createBlockAfter and createBlockBefore batch sibling shifts",
+                order=0,
+                parent=perf,
+            )
+            block(
+                "moveBlockUp and moveBlockDown use one reorder call",
+                order=1,
+                parent=perf,
+            )
+            block(
+                "outdentBlock sibling shifts are now persisted correctly",
+                order=2,
+                parent=perf,
+            )
+            block(
+                "There's no way to predict the future except by creating it",
+                order=2,
+                parent=notes,
+                block_type="quote",
+            )
 
             ideas = block("Ideas", order=2, block_type="heading")
-            block("Add drag-and-drop block reordering", order=0, parent=ideas, block_type="todo")
-            block("Collapsible block sections", order=1, parent=ideas, block_type="todo")
+            block(
+                "Add drag-and-drop block reordering",
+                order=0,
+                parent=ideas,
+                block_type="todo",
+            )
+            block(
+                "Collapsible block sections", order=1, parent=ideas, block_type="todo"
+            )
             context = block("Context", order=2, parent=ideas)
             block("Blocks can be nested to any depth", order=0, parent=context)
             block("Each block tracks its parent and order", order=1, parent=context)
 
         action = "Created" if created else "Updated"
-        self.stdout.write(self.style.SUCCESS(f"{action} daily note {date_str} with sample blocks for {user.email}"))
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{action} daily note {date_str} with sample blocks for {user.email}"
+            )
+        )

--- a/packages/django-app/app/knowledge/repositories/block_repository.py
+++ b/packages/django-app/app/knowledge/repositories/block_repository.py
@@ -142,19 +142,29 @@ class BlockRepository(BaseRepository):
         return max_order if max_order is not None else 0
 
     @classmethod
-    def reorder_blocks(cls, blocks_order_data: List[Dict[str, Any]]) -> bool:
-        """Reorder blocks based on provided order data
+    def reorder_blocks(cls, blocks_order_data: List[Dict[str, Any]], user=None) -> bool:
+        """Reorder blocks using a single bulk_update (2 queries instead of 2N).
 
         Args:
             blocks_order_data: List of dicts with 'uuid' and 'order' keys
+            user: Optional user to scope block lookup for ownership enforcement
         """
-        try:
-            for item in blocks_order_data:
-                block = cls.get_by_uuid(item["uuid"])
-                if block:
-                    block.order = item["order"]
-                    block.save(update_fields=["order"])
+        if not blocks_order_data:
             return True
+
+        try:
+            with transaction.atomic():
+                order_map = {item["uuid"]: item["order"] for item in blocks_order_data}
+                queryset = cls.get_queryset().filter(uuid__in=list(order_map.keys()))
+                if user is not None:
+                    queryset = queryset.filter(user=user)
+                blocks = list(queryset)
+                if len(blocks) != len(order_map):
+                    return False
+                for block in blocks:
+                    block.order = order_map[str(block.uuid)]
+                Block.objects.bulk_update(blocks, ["order"])
+                return True
         except Exception:
             return False
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -357,8 +357,11 @@ const Page = {
 
       // Shift existing blocks down by updating their orders
       for (const block of blocksToShift) {
-        await this.updateBlock(block, block.content, true);
         block.order = block.order + 1;
+        await window.apiService.updateBlock(block.uuid, {
+          order: block.order,
+          parent: block.parent ? block.parent.uuid : null,
+        });
       }
 
       // Create the new block at the desired position
@@ -376,8 +379,11 @@ const Page = {
 
       // Shift existing blocks down by updating their orders
       for (const block of blocksToShift) {
-        await this.updateBlock(block, block.content, true);
         block.order = block.order + 1;
+        await window.apiService.updateBlock(block.uuid, {
+          order: block.order,
+          parent: block.parent ? block.parent.uuid : null,
+        });
       }
 
       // Create the new block at the desired position
@@ -635,7 +641,7 @@ const Page = {
         const newOrder = block.parent.order + 1;
 
         // Update orders of siblings that come after the parent
-        this.updateSiblingOrders(grandparent, newOrder);
+        await this.updateSiblingOrders(grandparent, newOrder);
 
         const result = await window.apiService.updateBlock(block.uuid, {
           parent: grandparent ? grandparent.uuid : null,
@@ -700,13 +706,17 @@ const Page = {
       }
     },
 
-    updateSiblingOrders(parent, fromOrder) {
+    async updateSiblingOrders(parent, fromOrder) {
       const siblings = parent ? parent.children : this.directBlocks;
-      siblings.forEach((sibling) => {
+      for (const sibling of siblings) {
         if (sibling.order >= fromOrder) {
           sibling.order += 1;
+          await window.apiService.updateBlock(sibling.uuid, {
+            order: sibling.order,
+            parent: sibling.parent ? sibling.parent.uuid : null,
+          });
         }
-      });
+      }
     },
 
     formatContentWithTags(content) {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -350,22 +350,26 @@ const Page = {
         ? currentBlock.parent.children
         : this.directBlocks;
 
-      // Find all blocks that need to be shifted (same parent, order >= newOrder)
       const blocksToShift = siblings.filter(
         (block) => block.uuid !== currentBlock.uuid && block.order >= newOrder
       );
 
-      // Shift existing blocks down by updating their orders
-      for (const block of blocksToShift) {
-        block.order = block.order + 1;
-        await window.apiService.updateBlock(block.uuid, {
-          order: block.order,
-          parent: block.parent ? block.parent.uuid : null,
+      try {
+        const reorderPayload = blocksToShift.map((block) => {
+          block.order = block.order + 1;
+          return { uuid: block.uuid, order: block.order };
         });
-      }
 
-      // Create the new block at the desired position
-      await this.createBlock("", currentBlock.parent, newOrder);
+        if (reorderPayload.length > 0) {
+          const result = await window.apiService.reorderBlocks(reorderPayload);
+          if (!result.success) throw new Error("failed to reorder blocks");
+        }
+
+        await this.createBlock("", currentBlock.parent, newOrder);
+      } catch (error) {
+        console.error("failed to create block after:", error);
+        this.error = "failed to create block";
+      }
     },
 
     async createBlockBefore(currentBlock) {
@@ -374,20 +378,24 @@ const Page = {
         ? currentBlock.parent.children
         : this.directBlocks;
 
-      // Find all blocks that need to be shifted (same parent, order >= newOrder)
       const blocksToShift = siblings.filter((block) => block.order >= newOrder);
 
-      // Shift existing blocks down by updating their orders
-      for (const block of blocksToShift) {
-        block.order = block.order + 1;
-        await window.apiService.updateBlock(block.uuid, {
-          order: block.order,
-          parent: block.parent ? block.parent.uuid : null,
+      try {
+        const reorderPayload = blocksToShift.map((block) => {
+          block.order = block.order + 1;
+          return { uuid: block.uuid, order: block.order };
         });
-      }
 
-      // Create the new block at the desired position
-      await this.createBlock("", currentBlock.parent, newOrder);
+        if (reorderPayload.length > 0) {
+          const result = await window.apiService.reorderBlocks(reorderPayload);
+          if (!result.success) throw new Error("failed to reorder blocks");
+        }
+
+        await this.createBlock("", currentBlock.parent, newOrder);
+      } catch (error) {
+        console.error("failed to create block before:", error);
+        this.error = "failed to create block";
+      }
     },
 
     async moveBlockUp(block) {
@@ -409,16 +417,12 @@ const Page = {
         block.order = blockAbove.order;
         blockAbove.order = tempOrder;
 
-        // Update both blocks' orders in the API
-        await window.apiService.updateBlock(block.uuid, {
-          order: block.order,
-          parent: block.parent ? block.parent.uuid : null,
-        });
+        const result = await window.apiService.reorderBlocks([
+          { uuid: block.uuid, order: block.order },
+          { uuid: blockAbove.uuid, order: blockAbove.order },
+        ]);
 
-        await window.apiService.updateBlock(blockAbove.uuid, {
-          order: blockAbove.order,
-          parent: blockAbove.parent ? blockAbove.parent.uuid : null,
-        });
+        if (!result.success) throw new Error("reorder failed");
 
         // Update local state - re-sort siblings
         siblings.sort((a, b) => a.order - b.order);
@@ -450,16 +454,12 @@ const Page = {
         block.order = blockBelow.order;
         blockBelow.order = tempOrder;
 
-        // Update both blocks' orders in the API
-        await window.apiService.updateBlock(block.uuid, {
-          order: block.order,
-          parent: block.parent ? block.parent.uuid : null,
-        });
+        const result = await window.apiService.reorderBlocks([
+          { uuid: block.uuid, order: block.order },
+          { uuid: blockBelow.uuid, order: blockBelow.order },
+        ]);
 
-        await window.apiService.updateBlock(blockBelow.uuid, {
-          order: blockBelow.order,
-          parent: blockBelow.parent ? blockBelow.parent.uuid : null,
-        });
+        if (!result.success) throw new Error("reorder failed");
 
         // Update local state - re-sort siblings
         siblings.sort((a, b) => a.order - b.order);
@@ -708,15 +708,19 @@ const Page = {
 
     async updateSiblingOrders(parent, fromOrder) {
       const siblings = parent ? parent.children : this.directBlocks;
+      const reorderPayload = [];
+
       for (const sibling of siblings) {
         if (sibling.order >= fromOrder) {
           sibling.order += 1;
-          await window.apiService.updateBlock(sibling.uuid, {
-            order: sibling.order,
-            parent: sibling.parent ? sibling.parent.uuid : null,
-          });
+          reorderPayload.push({ uuid: sibling.uuid, order: sibling.order });
         }
       }
+
+      if (reorderPayload.length === 0) return;
+
+      const result = await window.apiService.reorderBlocks(reorderPayload);
+      if (!result.success) throw new Error("failed to reorder siblings");
     },
 
     formatContentWithTags(content) {

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -182,6 +182,13 @@ class ApiService {
     });
   }
 
+  async reorderBlocks(blocksOrderData) {
+    return await this.request("/knowledge/api/blocks/reorder/", {
+      method: "PUT",
+      body: JSON.stringify({ blocks: blocksOrderData }),
+    });
+  }
+
   async deleteBlock(blockUuid) {
     return await this.request("/knowledge/api/blocks/delete/", {
       method: "DELETE",

--- a/packages/django-app/app/knowledge/test/commands/test_reorder_blocks_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_reorder_blocks_command.py
@@ -1,0 +1,75 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from knowledge.commands import ReorderBlocksCommand
+from knowledge.forms import ReorderBlocksForm
+
+from ..helpers import BlockFactory, PageFactory, UserFactory
+
+
+class TestReorderBlocksCommand(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.page = PageFactory(user=cls.user)
+        cls.block_a = BlockFactory(user=cls.user, page=cls.page, order=0)
+        cls.block_b = BlockFactory(user=cls.user, page=cls.page, order=1)
+        cls.block_c = BlockFactory(user=cls.user, page=cls.page, order=2)
+
+    def _execute(self, blocks_data):
+        form = ReorderBlocksForm({"user": self.user.id, "blocks": blocks_data})
+        form.is_valid()
+        return ReorderBlocksCommand(form).execute()
+
+    def test_reorders_blocks(self):
+        self._execute(
+            [
+                {"uuid": str(self.block_a.uuid), "order": 2},
+                {"uuid": str(self.block_b.uuid), "order": 0},
+                {"uuid": str(self.block_c.uuid), "order": 1},
+            ]
+        )
+
+        self.block_a.refresh_from_db()
+        self.block_b.refresh_from_db()
+        self.block_c.refresh_from_db()
+
+        self.assertEqual(self.block_a.order, 2)
+        self.assertEqual(self.block_b.order, 0)
+        self.assertEqual(self.block_c.order, 1)
+
+    def test_raises_validation_error_for_another_users_block(self):
+        other_user = UserFactory()
+        other_block = BlockFactory(user=other_user, page=PageFactory(user=other_user))
+
+        form = ReorderBlocksForm(
+            {
+                "user": self.user.id,
+                "blocks": [{"uuid": str(other_block.uuid), "order": 0}],
+            }
+        )
+        form.is_valid()
+
+        with self.assertRaises(ValidationError):
+            ReorderBlocksCommand(form).execute()
+
+    def test_raises_validation_error_for_nonexistent_block(self):
+        form = ReorderBlocksForm(
+            {
+                "user": self.user.id,
+                "blocks": [{"uuid": str(uuid.uuid4()), "order": 0}],
+            }
+        )
+        form.is_valid()
+
+        with self.assertRaises(ValidationError):
+            ReorderBlocksCommand(form).execute()
+
+    def test_raises_for_invalid_form(self):
+        form = ReorderBlocksForm({"user": self.user.id, "blocks": []})
+        form.is_valid()
+
+        with self.assertRaises(ValidationError):
+            ReorderBlocksCommand(form).execute()

--- a/packages/django-app/app/knowledge/test/commands/test_reorder_blocks_form.py
+++ b/packages/django-app/app/knowledge/test/commands/test_reorder_blocks_form.py
@@ -1,0 +1,60 @@
+import uuid
+
+from django.test import TestCase
+
+from knowledge.forms import ReorderBlocksForm
+
+from ..helpers import UserFactory
+
+
+class TestReorderBlocksForm(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
+    def _form(self, blocks):
+        return ReorderBlocksForm({"user": self.user.id, "blocks": blocks})
+
+    def test_valid_data(self):
+        form = self._form(
+            [
+                {"uuid": str(uuid.uuid4()), "order": 0},
+                {"uuid": str(uuid.uuid4()), "order": 1},
+            ]
+        )
+        self.assertTrue(form.is_valid())
+
+    def test_invalid_when_blocks_is_empty_list(self):
+        form = self._form([])
+        self.assertFalse(form.is_valid())
+        self.assertIn("blocks", form.errors)
+
+    def test_invalid_when_blocks_is_not_a_list(self):
+        form = self._form("not-a-list")
+        self.assertFalse(form.is_valid())
+        self.assertIn("blocks", form.errors)
+
+    def test_invalid_when_uuid_missing(self):
+        form = self._form([{"order": 0}])
+        self.assertFalse(form.is_valid())
+        self.assertIn("blocks", form.errors)
+
+    def test_invalid_when_order_missing(self):
+        form = self._form([{"uuid": str(uuid.uuid4())}])
+        self.assertFalse(form.is_valid())
+        self.assertIn("blocks", form.errors)
+
+    def test_invalid_when_uuid_malformed(self):
+        form = self._form([{"uuid": "not-a-uuid", "order": 0}])
+        self.assertFalse(form.is_valid())
+        self.assertIn("blocks", form.errors)
+
+    def test_invalid_when_order_is_negative(self):
+        form = self._form([{"uuid": str(uuid.uuid4()), "order": -1}])
+        self.assertFalse(form.is_valid())
+        self.assertIn("blocks", form.errors)
+
+    def test_invalid_when_order_is_not_integer(self):
+        form = self._form([{"uuid": str(uuid.uuid4()), "order": "first"}])
+        self.assertFalse(form.is_valid())
+        self.assertIn("blocks", form.errors)

--- a/packages/django-app/app/knowledge/test/views/test_reorder_blocks_api.py
+++ b/packages/django-app/app/knowledge/test/views/test_reorder_blocks_api.py
@@ -1,0 +1,88 @@
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from knowledge.test.helpers import BlockFactory, PageFactory, UserFactory
+
+
+class TestReorderBlocksAPI(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.page = PageFactory(user=cls.user)
+        cls.block_a = BlockFactory(user=cls.user, page=cls.page, order=0)
+        cls.block_b = BlockFactory(user=cls.user, page=cls.page, order=1)
+        cls.block_c = BlockFactory(user=cls.user, page=cls.page, order=2)
+
+    def setUp(self):
+        self.client = APIClient()
+        token = Token.objects.create(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+
+    def test_reorders_blocks_successfully(self):
+        response = self.client.put(
+            "/knowledge/api/blocks/reorder/",
+            {
+                "blocks": [
+                    {"uuid": str(self.block_a.uuid), "order": 2},
+                    {"uuid": str(self.block_b.uuid), "order": 0},
+                    {"uuid": str(self.block_c.uuid), "order": 1},
+                ]
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["success"])
+
+        self.block_a.refresh_from_db()
+        self.block_b.refresh_from_db()
+        self.block_c.refresh_from_db()
+
+        self.assertEqual(self.block_a.order, 2)
+        self.assertEqual(self.block_b.order, 0)
+        self.assertEqual(self.block_c.order, 1)
+
+    def test_returns_400_for_empty_blocks(self):
+        response = self.client.put(
+            "/knowledge/api/blocks/reorder/",
+            {"blocks": []},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(response.data["success"])
+
+    def test_returns_400_for_invalid_uuid(self):
+        response = self.client.put(
+            "/knowledge/api/blocks/reorder/",
+            {"blocks": [{"uuid": "not-a-uuid", "order": 0}]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(response.data["success"])
+
+    def test_returns_401_without_authentication(self):
+        self.client.credentials()
+        response = self.client.put(
+            "/knowledge/api/blocks/reorder/",
+            {"blocks": [{"uuid": str(self.block_a.uuid), "order": 0}]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_cannot_reorder_another_users_blocks(self):
+        other_user = UserFactory()
+        other_block = BlockFactory(
+            user=other_user, page=PageFactory(user=other_user), order=0
+        )
+
+        response = self.client.put(
+            "/knowledge/api/blocks/reorder/",
+            {"blocks": [{"uuid": str(other_block.uuid), "order": 5}]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        other_block.refresh_from_db()
+        self.assertEqual(other_block.order, 0)

--- a/packages/django-app/app/knowledge/urls.py
+++ b/packages/django-app/app/knowledge/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path("api/blocks/", views.create_block, name="create_block"),
     path("api/blocks/update/", views.update_block, name="update_block"),
     path("api/blocks/delete/", views.delete_block, name="delete_block"),
+    path("api/blocks/reorder/", views.reorder_blocks, name="reorder_blocks"),
     path("api/blocks/toggle-todo/", views.toggle_block_todo, name="toggle_block_todo"),
     path(
         "api/blocks/move-undone-todos/",

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -542,7 +542,13 @@ def reorder_blocks(request):
             command = ReorderBlocksCommand(form)
             command.execute()
 
-            return Response({"success": True, "data": {"message": "Blocks reordered successfully"}, "errors": None})
+            return Response(
+                {
+                    "success": True,
+                    "data": {"message": "Blocks reordered successfully"},
+                    "errors": None,
+                }
+            )
         else:
             return Response(
                 {"success": False, "data": None, "errors": form.errors},

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -17,6 +17,7 @@ from knowledge.commands import (
     GetTagContentCommand,
     GetUserPagesCommand,
     MoveUndoneTodosCommand,
+    ReorderBlocksCommand,
     SearchPagesCommand,
     ToggleBlockTodoCommand,
     UpdateBlockCommand,
@@ -35,6 +36,7 @@ from knowledge.forms import (
     GetTagContentForm,
     GetUserPagesForm,
     MoveUndoneTodosForm,
+    ReorderBlocksForm,
     SearchPagesForm,
     ToggleBlockTodoForm,
     UpdateBlockForm,
@@ -521,6 +523,43 @@ def delete_block(request):
             "errors": {"non_field_errors": [str(e)]},
         }
         return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+@api_view(["PUT"])
+@permission_classes([IsAuthenticated])
+def reorder_blocks(request):
+    """Batch reorder blocks in a single request.
+
+    Accepts: {"blocks": [{"uuid": "...", "order": N}, ...]}
+    """
+    try:
+        data = request.data.copy()
+        data["user"] = request.user.id
+
+        form = ReorderBlocksForm(data)
+
+        if form.is_valid():
+            command = ReorderBlocksCommand(form)
+            command.execute()
+
+            return Response({"success": True, "data": {"message": "Blocks reordered successfully"}, "errors": None})
+        else:
+            return Response(
+                {"success": False, "data": None, "errors": form.errors},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+    except ValidationError as e:
+        return Response(
+            {"success": False, "data": None, "errors": {"non_field_errors": [str(e)]}},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    except Exception as e:
+        return Response(
+            {"success": False, "data": None, "errors": {"non_field_errors": [str(e)]}},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
 
 
 @api_view(["POST"])

--- a/packages/django-app/app/manage.py
+++ b/packages/django-app/app/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/packages/django-app/docker-compose.prod.yml
+++ b/packages/django-app/docker-compose.prod.yml
@@ -1,0 +1,4 @@
+services:
+  web:
+    ports:
+      - "127.0.0.1:${WEB_PORT:-8000}:${WEB_PORT:-8000}"

--- a/packages/django-app/docker-compose.staging.yml
+++ b/packages/django-app/docker-compose.staging.yml
@@ -1,4 +1,0 @@
-services:
-  web:
-    ports:
-      - "0.0.0.0:${WEB_PORT:-8000}:${WEB_PORT:-8000}"

--- a/packages/django-app/docker-compose.staging.yml
+++ b/packages/django-app/docker-compose.staging.yml
@@ -1,0 +1,4 @@
+services:
+  web:
+    ports:
+      - "0.0.0.0:${WEB_PORT:-8000}:${WEB_PORT:-8000}"

--- a/packages/django-app/docker-compose.yml
+++ b/packages/django-app/docker-compose.yml
@@ -37,6 +37,6 @@ services:
     volumes:
       - .:/code
     ports:
-      - "127.0.0.1:${WEB_PORT:-8000}:${WEB_PORT:-8000}"
+      - "${WEB_PORT:-8000}:${WEB_PORT:-8000}"
     depends_on:
       - db

--- a/packages/django-app/justfile
+++ b/packages/django-app/justfile
@@ -242,16 +242,16 @@ ps:
 
 # Staging environment commands (run from a staging directory, e.g. ~/brainspread-stuff/environments/pr-5/packages/django-app)
 staging-up:
-  docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d --build
+  docker compose up -d --build
 
 staging-down:
-  docker compose -f docker-compose.yml -f docker-compose.staging.yml down -v
+  docker compose down -v
 
 staging-migrate:
-  docker compose -f docker-compose.yml -f docker-compose.staging.yml run --rm -w /code/app web python manage.py migrate
+  docker compose run --rm -w /code/app web python manage.py migrate
 
 staging-create-superuser:
-  docker compose -f docker-compose.yml -f docker-compose.staging.yml run --rm \
+  docker compose run --rm \
     -e DJANGO_SUPERUSER_EMAIL \
     -e DJANGO_SUPERUSER_PASSWORD \
     -w /code/app web python manage.py createsuperuser --noinput || true

--- a/packages/django-app/justfile
+++ b/packages/django-app/justfile
@@ -389,10 +389,10 @@ alias p := prepush
 # Update production - pull, build, migrate, restart
 update:
   git pull origin main
-  docker compose build web
+  docker compose -f docker-compose.yml -f docker-compose.prod.yml build web
   just migrate
   docker compose stop web
-  docker compose -f docker compose.yml up -d web
+  docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d web
 
 # AI Tools
 # start playwright mcp server

--- a/packages/django-app/justfile
+++ b/packages/django-app/justfile
@@ -256,6 +256,9 @@ staging-create-superuser:
     -e DJANGO_SUPERUSER_PASSWORD \
     -w /code/app web python manage.py createsuperuser --noinput || true
 
+staging-seed:
+  docker compose run --rm -w /code/app web python manage.py seed_staging_data
+
 staging-logs LINES="100":
   docker compose logs --tail {{LINES}} -f
 

--- a/packages/django-app/justfile
+++ b/packages/django-app/justfile
@@ -242,16 +242,16 @@ ps:
 
 # Staging environment commands (run from a staging directory, e.g. ~/brainspread-stuff/environments/pr-5/packages/django-app)
 staging-up:
-  docker compose up -d --build
+  docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d --build
 
 staging-down:
-  docker compose down -v
+  docker compose -f docker-compose.yml -f docker-compose.staging.yml down -v
 
 staging-migrate:
-  docker compose run --rm -w /code/app web python manage.py migrate
+  docker compose -f docker-compose.yml -f docker-compose.staging.yml run --rm -w /code/app web python manage.py migrate
 
 staging-create-superuser:
-  docker compose run --rm \
+  docker compose -f docker-compose.yml -f docker-compose.staging.yml run --rm \
     -e DJANGO_SUPERUSER_EMAIL \
     -e DJANGO_SUPERUSER_PASSWORD \
     -w /code/app web python manage.py createsuperuser --noinput || true

--- a/packages/django-app/justfile
+++ b/packages/django-app/justfile
@@ -250,6 +250,12 @@ staging-down:
 staging-migrate:
   docker compose run --rm -w /code/app web python manage.py migrate
 
+staging-create-superuser:
+  docker compose run --rm \
+    -e DJANGO_SUPERUSER_EMAIL \
+    -e DJANGO_SUPERUSER_PASSWORD \
+    -w /code/app web python manage.py createsuperuser --noinput || true
+
 staging-logs LINES="100":
   docker compose logs --tail {{LINES}} -f
 


### PR DESCRIPTION
- createBlockAfter/createBlockBefore: increment block.order before calling the API (previously called this.updateBlock which omits order, then incremented locally, so sibling shifts were never saved to the DB)
- updateSiblingOrders: make async and send API updates for each shifted sibling (previously only updated local state, so outdentBlock's sibling shifts were lost on reload)
- outdentBlock: await the now-async updateSiblingOrders call

Fixes #2

https://claude.ai/code/session_017TBJ5k6eVzPJmotjx5VpDU