### PR TITLE
Move web service port mapping to docker-compose.override.yml

### DIFF
--- a/packages/django-app/docker-compose.override.yml
+++ b/packages/django-app/docker-compose.override.yml
@@ -1,0 +1,4 @@
+services:
+  web:
+    ports:
+      - "${WEB_PORT:-8000}:${WEB_PORT:-8000}"

--- a/packages/django-app/docker-compose.yml
+++ b/packages/django-app/docker-compose.yml
@@ -36,7 +36,5 @@ services:
       - "0.0.0.0:${WEB_PORT:-8000}"
     volumes:
       - .:/code
-    ports:
-      - "${WEB_PORT:-8000}:${WEB_PORT:-8000}"
     depends_on:
       - db


### PR DESCRIPTION
## Summary
Refactored Docker Compose configuration to separate environment-specific port mappings from the base service definition by moving the web service port configuration to an override file.

## Key Changes
- Created new `docker-compose.override.yml` file with web service port mapping (`${WEB_PORT:-8000}:${WEB_PORT:-8000}`)
- Removed port mapping from `docker-compose.yml` base configuration
- Retained command and volumes configuration in the base file

## Implementation Details
This change follows Docker Compose best practices by using the override file pattern to handle local development port configurations separately from the base service definition. The port mapping remains functionally identical with the same environment variable substitution (`${WEB_PORT:-8000}`), but is now isolated in the override file which is typically excluded from version control or used only in development environments.

https://claude.ai/code/session_01RSvzhKMM6vecakRygSKSHn