### PR TITLE
Fix page ordering in get_recent_pages_with_blocks to use modified_at

### DIFF
--- a/packages/django-app/app/knowledge/repositories/page_repository.py
+++ b/packages/django-app/app/knowledge/repositories/page_repository.py
@@ -133,17 +133,13 @@ class PageRepository(BaseRepository):
 
     @classmethod
     def get_recent_pages_with_blocks(cls, user, limit=7) -> QuerySet:
-        """Get the most recent daily pages that have blocks, ordered by creation date (not modification date)"""
-
-        # Get pages that have blocks, ordered by their actual date (creation date)
+        """Get the most recently modified pages that have blocks."""
         pages_with_blocks = (
             cls.get_queryset()
             .filter(user=user)
             .annotate(block_count=Count("blocks"))
             .filter(block_count__gt=0)
-            .order_by("-date")[
-                :limit
-            ]  # Order by date field (creation date), not modified_at
+            .order_by("-modified_at")[:limit]
         )
         return pages_with_blocks
 


### PR DESCRIPTION
## Summary
Updated the `get_recent_pages_with_blocks` method to order pages by modification date (`modified_at`) instead of creation date (`date`), aligning the implementation with the updated docstring.

## Key Changes
- Changed ordering from `-date` (creation date) to `-modified_at` (modification date)
- Updated docstring from "most recent daily pages" to "most recently modified pages" for clarity
- Removed inline comment about ordering by creation date as it no longer applies
- Simplified the query by removing unnecessary comment clutter

## Implementation Details
The method now returns pages ordered by their last modification time rather than when they were created. This is more useful for retrieving recently worked-on pages, as users typically care about pages they've recently edited rather than when they were originally created.

https://claude.ai/code/session_01LdeUoUrrXksQsFNtXzY9P3