### PR TITLE
Add production deployment workflow

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,27 @@
+name: Deploy to Production
+
+on:
+  workflow_run:
+    workflows: ["Lint and Test"]
+    branches: [main]
+    types: [completed]
+
+jobs:
+  deploy:
+    name: Deploy to Production
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    environment: ci
+    steps:
+      - name: Deploy to VPS
+        uses: appleboy/ssh-action@v1
+        env:
+          PROD_DIR: ${{ vars.DO_PROD_DIR }}
+        with:
+          host: ${{ secrets.DO_SSH_HOST }}
+          username: ${{ secrets.DO_SSH_USER }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          envs: PROD_DIR
+          script: |
+            cd "$PROD_DIR/packages/django-app"
+            just update


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to automatically deploy the application to production when the lint and test workflow completes successfully on the main branch.

## Key Changes
- Added `.github/workflows/production.yml` workflow that:
  - Triggers after the "Lint and Test" workflow completes successfully on the main branch
  - Deploys to a DigitalOcean VPS via SSH using the `appleboy/ssh-action`
  - Executes the `just update` command in the Django app directory to pull latest changes and update the production environment
  - Uses GitHub secrets for SSH credentials (`DO_SSH_HOST`, `DO_SSH_USER`, `DO_SSH_KEY`)
  - Uses GitHub variables for the production directory path (`DO_PROD_DIR`)
  - Requires the `ci` environment approval

## Implementation Details
- The workflow is configured to only run when the preceding "Lint and Test" workflow succeeds, ensuring only validated code reaches production
- SSH credentials and sensitive configuration are stored as GitHub secrets and variables for security
- The deployment uses a simple `just update` command, delegating the actual update logic to the justfile recipe

https://claude.ai/code/session_011XeNeEysfNhSSKoZfyHBGX