### PR TITLE
Enhance markdown formatting with code blocks, quotes, and escapes

### DIFF
--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -3773,3 +3773,27 @@ kbd {
   text-decoration-color: var(--text-primary) !important;
   text-decoration-thickness: 2px !important;
 }
+
+.markdown-code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.875em;
+  background-color: var(--bg-secondary, rgba(0, 0, 0, 0.08));
+  border: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
+  border-radius: 3px;
+  padding: 0.1em 0.35em;
+}
+
+.markdown-quote {
+  display: inline;
+  border-left: 3px solid var(--text-secondary, #888);
+  padding-left: 0.5em;
+  color: var(--text-secondary, #888);
+  font-style: italic;
+}
+
+.markdown-highlight {
+  background-color: var(--highlight-bg, #ffe066);
+  color: var(--highlight-text, #333);
+  border-radius: 2px;
+  padding: 0.05em 0.2em;
+}

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -308,7 +308,7 @@ const BlockComponent = {
           @click="startEditing(block)"
           @touchstart="handleTouchStart"
           @touchend="handleContentTouchEnd"
-          v-html="formatContentWithTags(block.content)"
+          v-html="formatContentWithTags(block.content, block.block_type)"
         ></div>
         <textarea
           v-else

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/HistoricalSidebar.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/HistoricalSidebar.js
@@ -182,7 +182,10 @@ window.HistoricalSidebar = {
       let formatted = content;
 
       // Strip todo-state prefix from display since the checkbox already shows state
-      if (blockType && ["todo", "done", "later", "wontdo"].includes(blockType)) {
+      if (
+        blockType &&
+        ["todo", "done", "later", "wontdo"].includes(blockType)
+      ) {
         formatted = formatted.replace(/^(WONTDO|LATER|DONE|TODO)\s*:?\s*/i, "");
       }
 
@@ -208,13 +211,34 @@ window.HistoricalSidebar = {
         '<span class="markdown-quote">$1</span>'
       );
 
-      formatted = formatted.replace(/\*\*\*(.+?)\*\*\*/g, '<span class="markdown-bold-italic">$1</span>');
-      formatted = formatted.replace(/\*\*(.+?)\*\*/g, '<span class="markdown-bold">$1</span>');
-      formatted = formatted.replace(/__(.+?)__/g, '<span class="markdown-bold">$1</span>');
-      formatted = formatted.replace(/\*([^*]+?)\*/g, '<span class="markdown-italic">$1</span>');
-      formatted = formatted.replace(/_([^_]+?)_/g, '<span class="markdown-italic">$1</span>');
-      formatted = formatted.replace(/~~(.+?)~~/g, '<span class="markdown-strikethrough">$1</span>');
-      formatted = formatted.replace(/==(.+?)==/g, '<span class="markdown-highlight">$1</span>');
+      formatted = formatted.replace(
+        /\*\*\*(.+?)\*\*\*/g,
+        '<span class="markdown-bold-italic">$1</span>'
+      );
+      formatted = formatted.replace(
+        /\*\*(.+?)\*\*/g,
+        '<span class="markdown-bold">$1</span>'
+      );
+      formatted = formatted.replace(
+        /__(.+?)__/g,
+        '<span class="markdown-bold">$1</span>'
+      );
+      formatted = formatted.replace(
+        /\*([^*]+?)\*/g,
+        '<span class="markdown-italic">$1</span>'
+      );
+      formatted = formatted.replace(
+        /_([^_]+?)_/g,
+        '<span class="markdown-italic">$1</span>'
+      );
+      formatted = formatted.replace(
+        /~~(.+?)~~/g,
+        '<span class="markdown-strikethrough">$1</span>'
+      );
+      formatted = formatted.replace(
+        /==(.+?)==/g,
+        '<span class="markdown-highlight">$1</span>'
+      );
 
       // Restore escaped characters as literal text
       escapedChars.forEach((char, idx) => {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/HistoricalSidebar.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/HistoricalSidebar.js
@@ -176,11 +176,64 @@ window.HistoricalSidebar = {
       }
     },
 
-    formatContentWithTags(content) {
+    formatContentWithTags(content, blockType = null) {
       if (!content) return "";
 
+      let formatted = content;
+
+      // Strip todo-state prefix from display since the checkbox already shows state
+      if (blockType && ["todo", "done", "later", "wontdo"].includes(blockType)) {
+        formatted = formatted.replace(/^(WONTDO|LATER|DONE|TODO)\s*:?\s*/i, "");
+      }
+
+      // Extract backtick code spans first to protect them from other formatting
+      const codeSegments = [];
+      formatted = formatted.replace(/`([^`]+)`/g, (_match, code) => {
+        const idx = codeSegments.length;
+        codeSegments.push(code);
+        return `\x00CODE${idx}\x00`;
+      });
+
+      // Extract backslash-escaped characters to protect them from formatting
+      const escapedChars = [];
+      formatted = formatted.replace(/\\([*_~`\\#>])/g, (_match, char) => {
+        const idx = escapedChars.length;
+        escapedChars.push(char);
+        return `\x00ESC${idx}\x00`;
+      });
+
+      // Format lines starting with > as blockquotes
+      formatted = formatted.replace(
+        /^>\s?(.+)/gm,
+        '<span class="markdown-quote">$1</span>'
+      );
+
+      formatted = formatted.replace(/\*\*\*(.+?)\*\*\*/g, '<span class="markdown-bold-italic">$1</span>');
+      formatted = formatted.replace(/\*\*(.+?)\*\*/g, '<span class="markdown-bold">$1</span>');
+      formatted = formatted.replace(/__(.+?)__/g, '<span class="markdown-bold">$1</span>');
+      formatted = formatted.replace(/\*([^*]+?)\*/g, '<span class="markdown-italic">$1</span>');
+      formatted = formatted.replace(/_([^_]+?)_/g, '<span class="markdown-italic">$1</span>');
+      formatted = formatted.replace(/~~(.+?)~~/g, '<span class="markdown-strikethrough">$1</span>');
+      formatted = formatted.replace(/==(.+?)==/g, '<span class="markdown-highlight">$1</span>');
+
+      // Restore escaped characters as literal text
+      escapedChars.forEach((char, idx) => {
+        formatted = formatted.split(`\x00ESC${idx}\x00`).join(char);
+      });
+
+      // Restore code spans as inline code elements
+      codeSegments.forEach((code, idx) => {
+        const safeCode = code
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;");
+        formatted = formatted
+          .split(`\x00CODE${idx}\x00`)
+          .join(`<code class="markdown-code">${safeCode}</code>`);
+      });
+
       // Replace hashtags with clickable styled spans
-      return content.replace(
+      return formatted.replace(
         /#([a-zA-Z0-9_-]+)/g,
         '<span class="inline-tag clickable-tag" data-tag="$1">#$1</span>'
       );
@@ -300,7 +353,7 @@ window.HistoricalSidebar = {
                     
                     <!-- Content rows: recent blocks -->
                     <div v-if="page.recent_blocks && page.recent_blocks.length" class="page-content-rows" @click="handleTagClick">
-                      <div v-for="block in page.recent_blocks.slice(0, 2)" :key="block.uuid" class="block-preview" :class="{ 'completed': block.block_type === 'done' }" v-html="formatContentWithTags(truncateContent(block.content, 60))">
+                      <div v-for="block in page.recent_blocks.slice(0, 2)" :key="block.uuid" class="block-preview" :class="{ 'completed': block.block_type === 'done' }" v-html="formatContentWithTags(truncateContent(block.content, 60), block.block_type)">
                       </div>
                     </div>
                   </div>
@@ -332,7 +385,7 @@ window.HistoricalSidebar = {
                     >
                       {{ block.block_type === 'done' ? '☑' : '☐' }}
                     </span>
-                    <span class="item-content" :class="{ 'completed': block.block_type === 'done' }" v-html="formatContentWithTags(truncateContent(block.content, 100))"></span>
+                    <span class="item-content" :class="{ 'completed': block.block_type === 'done' }" v-html="formatContentWithTags(truncateContent(block.content, 100), block.block_type)"></span>
                   </div>
                 </div>
               </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -746,7 +746,10 @@ const Page = {
       let formatted = content;
 
       // Strip todo-state prefix from display since the checkbox already shows state
-      if (blockType && ["todo", "done", "later", "wontdo"].includes(blockType)) {
+      if (
+        blockType &&
+        ["todo", "done", "later", "wontdo"].includes(blockType)
+      ) {
         formatted = formatted.replace(/^(WONTDO|LATER|DONE|TODO)\s*:?\s*/i, "");
       }
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -740,10 +740,37 @@ const Page = {
       if (!result.success) throw new Error("failed to reorder siblings");
     },
 
-    formatContentWithTags(content) {
+    formatContentWithTags(content, blockType = null) {
       if (!content) return "";
 
       let formatted = content;
+
+      // Strip todo-state prefix from display since the checkbox already shows state
+      if (blockType && ["todo", "done", "later", "wontdo"].includes(blockType)) {
+        formatted = formatted.replace(/^(WONTDO|LATER|DONE|TODO)\s*:?\s*/i, "");
+      }
+
+      // Extract backtick code spans first to protect them from other formatting
+      const codeSegments = [];
+      formatted = formatted.replace(/`([^`]+)`/g, (_match, code) => {
+        const idx = codeSegments.length;
+        codeSegments.push(code);
+        return `\x00CODE${idx}\x00`;
+      });
+
+      // Extract backslash-escaped characters to protect them from formatting
+      const escapedChars = [];
+      formatted = formatted.replace(/\\([*_~`\\#>])/g, (_match, char) => {
+        const idx = escapedChars.length;
+        escapedChars.push(char);
+        return `\x00ESC${idx}\x00`;
+      });
+
+      // Format lines starting with > as blockquotes
+      formatted = formatted.replace(
+        /^>\s?(.+)/gm,
+        '<span class="markdown-quote">$1</span>'
+      );
 
       // Replace all bold and italic markdown ***text*** with styled spans (must be first)
       formatted = formatted.replace(
@@ -780,6 +807,28 @@ const Page = {
         /~~(.+?)~~/g,
         '<span class="markdown-strikethrough">$1</span>'
       );
+
+      // Replace highlight markdown ==text== with styled spans
+      formatted = formatted.replace(
+        /==(.+?)==/g,
+        '<span class="markdown-highlight">$1</span>'
+      );
+
+      // Restore escaped characters as literal text
+      escapedChars.forEach((char, idx) => {
+        formatted = formatted.split(`\x00ESC${idx}\x00`).join(char);
+      });
+
+      // Restore code spans as inline code elements
+      codeSegments.forEach((code, idx) => {
+        const safeCode = code
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;");
+        formatted = formatted
+          .split(`\x00CODE${idx}\x00`)
+          .join(`<code class="markdown-code">${safeCode}</code>`);
+      });
 
       // Replace hashtags with clickable styled spans
       return formatted.replace(

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/TaggedBlockDisplay.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/TaggedBlockDisplay.js
@@ -36,7 +36,7 @@ const TaggedBlockDisplay = {
             <span class="page-title">{{ block.page_type === 'daily' ? formatDate(block.page_title) : block.page_title }}</span>
             <span v-if="block.page_date" class="page-date">{{ formatDate(block.page_date) }}</span>
           </div>
-          <div v-html="formatContentWithTags(block.content)" class="block-text"></div>
+          <div v-html="formatContentWithTags(block.content, block.block_type)" class="block-text"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
This PR enhances the markdown formatting system across multiple components to support additional markdown syntax including inline code blocks, blockquotes, escaped characters, and highlight syntax. The changes improve content rendering consistency and add protection against unintended formatting.

## Key Changes

- **Enhanced `formatContentWithTags()` method** in three components (Page.js, HistoricalSidebar.js, BlockComponent.js, TaggedBlockDisplay.js):
  - Added `blockType` parameter to strip todo-state prefixes (TODO, DONE, LATER, WONTDO) from display since the checkbox already indicates state
  - Implemented backtick code span extraction and protection to prevent formatting inside code
  - Added backslash escape character support (`\*`, `\_`, `\~`, etc.) to allow literal markdown characters
  - Added blockquote formatting for lines starting with `>`
  - Added highlight syntax support for `==text==`
  - Implemented proper restoration of protected segments after formatting

- **Updated component calls** to pass `block.block_type` parameter:
  - BlockComponent.js: Pass block type when formatting content
  - HistoricalSidebar.js: Pass block type in two locations (recent blocks preview and todo list items)
  - TaggedBlockDisplay.js: Pass block type when formatting block content

- **Added CSS styling** for new markdown elements:
  - `.markdown-code`: Styled inline code with monospace font, background, and border
  - `.markdown-quote`: Styled blockquotes with left border and italic text
  - `.markdown-highlight`: Styled highlighted text with background color

## Implementation Details

The formatting now uses a protection mechanism with placeholder tokens (`\x00CODE${idx}\x00`, `\x00ESC${idx}\x00`) to preserve code spans and escaped characters from being affected by other markdown transformations. This ensures that:
- Code inside backticks won't be formatted as bold/italic/strikethrough
- Escaped characters are rendered literally
- All formatting is applied in the correct order with proper restoration

https://claude.ai/code/session_01Kt37wqebVo4PfGfkCw1q7d