### PR TITLE
Add staging image cleanup to remove Docker images after teardown

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -124,6 +124,7 @@ jobs:
             if [ -d "$STAGING_DIR/packages/django-app" ]; then
               cd "$STAGING_DIR/packages/django-app"
               just staging-down
+              just staging-cleanup-images
             fi
 
             docker volume rm "${VOLUME}" 2>/dev/null || true

--- a/packages/django-app/justfile
+++ b/packages/django-app/justfile
@@ -262,6 +262,10 @@ staging-seed:
 staging-logs LINES="100":
   docker compose logs --tail {{LINES}} -f
 
+# Remove Docker images built for the current staging environment
+staging-cleanup-images:
+  docker rmi ${COMPOSE_PROJECT_NAME}-web:latest 2>/dev/null || true
+
 # Clean up project Docker resources
 dcp-cleanup:
   docker compose stop


### PR DESCRIPTION
## Summary
Added a new `staging-cleanup-images` command to the justfile and integrated it into the staging cleanup workflow to properly remove Docker images built for the staging environment.

## Key Changes
- Added `staging-cleanup-images` justfile recipe that removes the Docker image for the current staging environment using the `COMPOSE_PROJECT_NAME` variable
- Updated the staging GitHub Actions workflow to call `just staging-cleanup-images` after `just staging-down` to ensure images are cleaned up during the staging teardown process
- Used error suppression (`2>/dev/null || true`) to gracefully handle cases where the image doesn't exist

## Implementation Details
- The cleanup command targets the image named `${COMPOSE_PROJECT_NAME}-web:latest`, which is the web service image built for the staging environment
- The command is non-blocking and won't fail the workflow if the image is already removed or doesn't exist
- This ensures complete cleanup of staging resources, preventing orphaned Docker images from accumulating

https://claude.ai/code/session_01JyTt7qM5DCL59ppSCtyywu