### PR TITLE
Add keyboard navigation support to menus and interactive elements

### DIFF
--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -1358,12 +1358,16 @@ kbd {
   z-index: 1;
 }
 
-.block:hover .block-collapse-toggle {
+.block:hover .block-collapse-toggle,
+.block-collapse-toggle:focus {
   opacity: 1;
 }
 
-.block-collapse-toggle:hover {
+.block-collapse-toggle:hover,
+.block-collapse-toggle:focus {
   color: var(--text-primary);
+  outline: 2px solid var(--border-primary);
+  outline-offset: 1px;
 }
 
 .block-menu {
@@ -1384,7 +1388,8 @@ kbd {
   transition: opacity 0.2s ease;
 }
 
-.block:hover .block-menu {
+.block:hover .block-menu,
+.block-menu:focus {
   opacity: 1;
 }
 
@@ -1395,10 +1400,13 @@ kbd {
   }
 }
 
-.block-menu:hover {
+.block-menu:hover,
+.block-menu:focus {
   color: var(--text-primary);
   background: var(--bg-secondary);
   border-radius: 3px;
+  outline: 2px solid var(--border-primary);
+  outline-offset: 1px;
 }
 
 .block-context-menu {
@@ -1482,6 +1490,25 @@ kbd {
   background-color: var(--hover-bg);
   margin: -2px;
   padding: 2px;
+}
+
+/* Keyboard navigation focus styles */
+.block-content-display:focus {
+  outline: 2px solid var(--border-primary);
+  outline-offset: 1px;
+  background-color: var(--hover-bg-light);
+}
+
+.context-menu-item:focus {
+  outline: 2px solid var(--border-primary);
+  outline-offset: -2px;
+  background: var(--hover-bg);
+}
+
+.page-title-text:focus {
+  outline: 2px solid var(--border-primary);
+  outline-offset: 2px;
+  cursor: text;
 }
 
 /* Responsive */
@@ -3258,11 +3285,14 @@ kbd {
   transition: none;
 }
 
-.context-menu-btn:hover {
+.context-menu-btn:hover,
+.context-menu-btn:focus {
   background: var(--hover-bg);
   border-color: var(--border-primary);
   transform: none;
   box-shadow: none;
+  outline: 2px solid var(--border-primary);
+  outline-offset: 1px;
 }
 
 .context-menu {

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -489,7 +489,6 @@ body {
   max-height: 90vh;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
 }
 
 .settings-modal h2 {
@@ -623,9 +622,11 @@ body {
 
 .help-modal-body {
   overflow-y: auto;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: 1.75rem;
+  outline: none;
 }
 
 .help-section h3 {
@@ -2851,6 +2852,7 @@ kbd {
 .tab-content {
   animation: fadeIn 0.2s ease-in;
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   margin-bottom: 1rem;
 }

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -3828,6 +3828,27 @@ kbd {
   font-weight: 600;
 }
 
+.spotlight-command .spotlight-result-title {
+  font-weight: 500;
+}
+
+.spotlight-command-icon {
+  font-size: 0.85rem;
+  width: 16px;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.spotlight-result-type {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  border: 1px solid var(--border-secondary);
+  padding: 0.1rem 0.4rem;
+  align-self: center;
+  flex-shrink: 0;
+  letter-spacing: 0.03em;
+}
+
 .spotlight-footer {
   border-top: 2px solid var(--border-secondary);
   padding: 0.75rem 1rem;

--- a/packages/django-app/app/knowledge/static/knowledge/js/app.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/app.js
@@ -310,8 +310,8 @@ const KnowledgeApp = createApp({
       this.removeBlockFromContext(blockId);
     },
 
-    async createNewPage() {
-      const title = prompt("Enter page title:");
+    async createNewPage(prefilledTitle = null) {
+      const title = prefilledTitle ?? prompt("Enter page title:");
       if (!title || !title.trim()) return;
 
       try {
@@ -487,7 +487,7 @@ const KnowledgeApp = createApp({
     openSpotlight() {
       this.showSpotlight = true;
       this.spotlightQuery = "";
-      this.spotlightResults = [];
+      this.spotlightResults = this.getCommandResults("");
       this.spotlightSelectedIndex = 0;
 
       // Focus search input after a brief delay to ensure modal is rendered
@@ -506,21 +506,84 @@ const KnowledgeApp = createApp({
       this.spotlightSelectedIndex = 0;
     },
 
+    getCommandResults(query) {
+      const commands = [
+        {
+          id: "new-page",
+          label: "new page",
+          description: "create a new page",
+          icon: "+",
+        },
+        {
+          id: "new-block",
+          label: "new block",
+          description: "add a block to the current page",
+          icon: "+",
+        },
+        {
+          id: "today",
+          label: "today",
+          description: "go to today's daily note",
+          icon: "→",
+        },
+        {
+          id: "settings",
+          label: "settings",
+          description: "open settings",
+          icon: "⚙",
+        },
+        { id: "help", label: "help", description: "open help", icon: "?" },
+      ];
+
+      const q = query.trim().toLowerCase();
+
+      // "new page <title>" — let the user type the title inline
+      if (q.startsWith("new page ")) {
+        const title = query.trim().slice("new page ".length).trim();
+        if (title) {
+          return [
+            {
+              type: "command",
+              commandId: "new-page",
+              commandArg: title,
+              title: `create page "${title}"`,
+              description: "create a new page with this title",
+              icon: "+",
+            },
+          ];
+        }
+      }
+
+      const filtered = q
+        ? commands.filter(
+            (c) => c.label.includes(q) || c.description.includes(q)
+          )
+        : commands;
+
+      return filtered.map((c) => ({
+        type: "command",
+        commandId: c.id,
+        title: c.label,
+        description: c.description,
+        icon: c.icon,
+      }));
+    },
+
     performSpotlightSearchDebounced() {
-      // Clear existing timeout
       if (this.spotlightSearchTimeout) {
         clearTimeout(this.spotlightSearchTimeout);
       }
-
-      // Set new timeout
       this.spotlightSearchTimeout = setTimeout(() => {
         this.performSpotlightSearch();
       }, 300);
     },
 
     async performSpotlightSearch() {
-      if (!this.spotlightQuery.trim()) {
-        this.spotlightResults = [];
+      const query = this.spotlightQuery.trim();
+      const commands = this.getCommandResults(this.spotlightQuery);
+
+      if (!query) {
+        this.spotlightResults = commands;
         this.spotlightLoading = false;
         return;
       }
@@ -529,24 +592,20 @@ const KnowledgeApp = createApp({
       this.spotlightSelectedIndex = 0;
 
       try {
-        // Use the new dedicated search endpoint
-        const result = await window.apiService.searchPages(
-          this.spotlightQuery,
-          10
-        );
-
+        const result = await window.apiService.searchPages(query, 10);
         if (result.success) {
-          this.spotlightResults = result.data.pages.map((page) => ({
+          const pages = result.data.pages.map((page) => ({
             type: "page",
             title: page.title,
             slug: page.slug,
-            snippet: "", // No snippet needed since we only search titles/slugs
+            snippet: "",
             url: `/knowledge/page/${page.slug}/`,
           }));
+          this.spotlightResults = [...commands, ...pages];
         }
       } catch (error) {
         console.error("Search error:", error);
-        this.spotlightResults = [];
+        this.spotlightResults = commands;
       } finally {
         this.spotlightLoading = false;
       }
@@ -580,10 +639,34 @@ const KnowledgeApp = createApp({
     navigateToSpotlightResult(index = null) {
       const targetIndex = index !== null ? index : this.spotlightSelectedIndex;
       const result = this.spotlightResults[targetIndex];
+      if (!result) return;
 
-      if (result) {
-        this.closeSpotlight();
+      this.closeSpotlight();
+
+      if (result.type === "command") {
+        this.executeSpotlightCommand(result.commandId, result.commandArg);
+      } else {
         window.location.href = result.url;
+      }
+    },
+
+    executeSpotlightCommand(commandId, arg) {
+      switch (commandId) {
+        case "new-page":
+          this.createNewPage(arg ?? null);
+          break;
+        case "new-block":
+          document.dispatchEvent(new CustomEvent("spotlight:new-block"));
+          break;
+        case "today":
+          this.redirectToToday();
+          break;
+        case "settings":
+          this.openSettings();
+          break;
+        case "help":
+          this.openHelp();
+          break;
       }
     },
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/app.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/app.js
@@ -348,10 +348,51 @@ const KnowledgeApp = createApp({
     // Menu methods
     toggleMenu() {
       this.showMenu = !this.showMenu;
+      if (this.showMenu) {
+        this.$nextTick(() => {
+          const firstItem = document.querySelector(".menu-popover .menu-item");
+          if (firstItem) firstItem.focus();
+        });
+      }
     },
 
     closeMenu() {
       this.showMenu = false;
+    },
+
+    handleNavMenuKeydown(event) {
+      const items = Array.from(
+        document.querySelectorAll(".menu-popover .menu-item")
+      );
+      if (!items.length) return;
+      const currentIndex = items.indexOf(document.activeElement);
+
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          items[Math.min(currentIndex + 1, items.length - 1)].focus();
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          items[Math.max(currentIndex - 1, 0)].focus();
+          break;
+        case "Escape":
+        case "Tab":
+          event.preventDefault();
+          this.closeMenu();
+          this.$nextTick(() => {
+            if (this.$refs.menuBtn) this.$refs.menuBtn.focus();
+          });
+          break;
+        case "Home":
+          event.preventDefault();
+          items[0].focus();
+          break;
+        case "End":
+          event.preventDefault();
+          items[items.length - 1].focus();
+          break;
+      }
     },
 
     handleDocumentClick(event) {
@@ -430,9 +471,15 @@ const KnowledgeApp = createApp({
         }
       }
 
-      // Handle Escape to close spotlight
-      if (event.key === "Escape" && this.showSpotlight) {
-        this.closeSpotlight();
+      if (event.key === "Escape") {
+        if (this.showSpotlight) {
+          this.closeSpotlight();
+        } else if (this.showMenu) {
+          this.closeMenu();
+          this.$nextTick(() => {
+            if (this.$refs.menuBtn) this.$refs.menuBtn.focus();
+          });
+        }
       }
     },
 
@@ -583,23 +630,23 @@ const KnowledgeApp = createApp({
                         <div class="nav-right">
                             <span class="user-info">hello, {{ user?.email }}</span>
                             <div class="menu-container">
-                                <button @click="toggleMenu" class="menu-btn">
+                                <button @click="toggleMenu" ref="menuBtn" class="menu-btn" :aria-expanded="showMenu" aria-haspopup="menu">
                                     menu
                                 </button>
-                                <div v-if="showMenu" class="menu-popover" @click.stop>
-                                    <button @click="onMenuSearch" class="menu-item">
+                                <div v-if="showMenu" class="menu-popover" @click.stop @keydown="handleNavMenuKeydown" role="menu">
+                                    <button @click="onMenuSearch" class="menu-item" role="menuitem">
                                         search
                                     </button>
-                                    <button @click="onMenuCreatePage" class="menu-item">
+                                    <button @click="onMenuCreatePage" class="menu-item" role="menuitem">
                                         + page
                                     </button>
-                                    <button @click="onMenuSettings" class="menu-item">
+                                    <button @click="onMenuSettings" class="menu-item" role="menuitem">
                                         settings
                                     </button>
-                                    <button @click="onMenuHelp" class="menu-item">
+                                    <button @click="onMenuHelp" class="menu-item" role="menuitem">
                                         help
                                     </button>
-                                    <button @click="onMenuLogout" class="menu-item">
+                                    <button @click="onMenuLogout" class="menu-item" role="menuitem">
                                         logout
                                     </button>
                                 </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -77,6 +77,7 @@ const BlockComponent = {
       isCollapsed: false,
       showContextMenu: false,
       contextMenuPosition: { x: 0, y: 0 },
+      contextMenuFocusedIndex: -1,
       // Touch tracking for distinguishing taps from scrolls
       touchStartX: null,
       touchStartY: null,
@@ -90,6 +91,19 @@ const BlockComponent = {
       return this.block.children?.length > 0;
     },
   },
+  watch: {
+    showContextMenu(val) {
+      if (val) {
+        this.contextMenuFocusedIndex = 0;
+        this.$nextTick(() => {
+          this.focusContextMenuItem(0);
+        });
+      } else {
+        this.contextMenuFocusedIndex = -1;
+      }
+    },
+  },
+
   mounted() {
     // Listen for the custom event to close menus
     document.addEventListener("closeBlockMenus", this.handleCloseBlockMenus);
@@ -211,6 +225,76 @@ const BlockComponent = {
       this.showContextMenu = false;
       document.removeEventListener("click", this.hideContextMenu);
     },
+
+    hideContextMenuAndRestoreFocus() {
+      this.hideContextMenu();
+      this.$nextTick(() => {
+        const menuBtn = this.$el?.querySelector(".block-menu");
+        if (menuBtn) menuBtn.focus();
+      });
+    },
+    getContextMenuItems() {
+      return Array.from(
+        this.$el?.querySelectorAll(".block-context-menu [role='menuitem']") || []
+      );
+    },
+
+    focusContextMenuItem(index) {
+      const items = this.getContextMenuItems();
+      if (items[index]) {
+        items[index].focus();
+        this.contextMenuFocusedIndex = index;
+      }
+    },
+
+    handleContextMenuKeydown(event) {
+      const items = this.getContextMenuItems();
+      if (!items.length) return;
+
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          this.contextMenuFocusedIndex = Math.min(
+            this.contextMenuFocusedIndex + 1,
+            items.length - 1
+          );
+          this.focusContextMenuItem(this.contextMenuFocusedIndex);
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          this.contextMenuFocusedIndex = Math.max(
+            this.contextMenuFocusedIndex - 1,
+            0
+          );
+          this.focusContextMenuItem(this.contextMenuFocusedIndex);
+          break;
+        case "Escape":
+        case "Tab":
+          event.preventDefault();
+          this.hideContextMenu();
+          this.$nextTick(() => {
+            const menuBtn = this.$el?.querySelector(".block-menu");
+            if (menuBtn) menuBtn.focus();
+          });
+          break;
+        case "Home":
+          event.preventDefault();
+          this.focusContextMenuItem(0);
+          break;
+        case "End":
+          event.preventDefault();
+          this.focusContextMenuItem(items.length - 1);
+          break;
+      }
+    },
+
+    handleBlockDisplayKeydown(event) {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        this.startEditing(this.block);
+      }
+    },
+
     handleContextMenuAction(action) {
       this.hideContextMenu();
 
@@ -285,7 +369,11 @@ const BlockComponent = {
           v-if="!block.isEditing"
           class="block-content-display"
           :class="{ 'completed': ['done', 'wontdo'].includes(block.block_type) }"
+          tabindex="0"
+          role="button"
+          :aria-label="'Edit block: ' + (block.content || 'empty block')"
           @click="$event.target.closest('.clickable-tag') || startEditing(block)"
+          @keydown="handleBlockDisplayKeydown"
           @touchstart="handleTouchStart"
           @touchend="handleContentTouchEnd"
           v-html="formatContentWithTags(block.content, block.block_type)"
@@ -311,56 +399,56 @@ const BlockComponent = {
       </div>
       
       <!-- Context Menu -->
-      <div v-if="showContextMenu" class="block-context-menu" :style="{ left: contextMenuPosition.x + 'px', top: contextMenuPosition.y + 'px' }" @click.stop>
-        <div class="context-menu-item" v-if="hasChildren && isCollapsed" @click="handleContextMenuAction('expand')">
+      <div v-if="showContextMenu" class="block-context-menu" :style="{ left: contextMenuPosition.x + 'px', top: contextMenuPosition.y + 'px' }" @click.stop @keydown="handleContextMenuKeydown" role="menu">
+        <button class="context-menu-item" role="menuitem" tabindex="-1" v-if="hasChildren && isCollapsed" @click="handleContextMenuAction('expand')">
           <span class="context-menu-icon">▶</span>
           <span>expand</span>
-        </div>
-        <div class="context-menu-item" v-if="hasChildren && !isCollapsed" @click="handleContextMenuAction('collapse')">
+        </button>
+        <button class="context-menu-item" role="menuitem" tabindex="-1" v-if="hasChildren && !isCollapsed" @click="handleContextMenuAction('collapse')">
           <span class="context-menu-icon">▼</span>
           <span>collapse</span>
-        </div>
+        </button>
         <div class="context-menu-separator" v-if="hasChildren"></div>
-        <div class="context-menu-item" @click="handleContextMenuAction('indent')">
+        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('indent')">
           <span class="context-menu-icon">→</span>
           <span>indent</span>
-        </div>
-        <div class="context-menu-item" @click="handleContextMenuAction('outdent')">
+        </button>
+        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('outdent')">
           <span class="context-menu-icon">←</span>
           <span>outdent</span>
-        </div>
+        </button>
         <div class="context-menu-separator"></div>
-        <div class="context-menu-item" @click="handleContextMenuAction('moveUp')">
+        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('moveUp')">
           <span class="context-menu-icon">↑</span>
           <span>move up</span>
-        </div>
-        <div class="context-menu-item" @click="handleContextMenuAction('moveDown')">
+        </button>
+        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('moveDown')">
           <span class="context-menu-icon">↓</span>
           <span>move down</span>
-        </div>
+        </button>
         <div class="context-menu-separator"></div>
-        <div class="context-menu-item" @click="handleContextMenuAction('newBlockBefore')">
+        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('newBlockBefore')">
           <span class="context-menu-icon">+</span>
           <span>new block before</span>
-        </div>
-        <div class="context-menu-item" @click="handleContextMenuAction('newBlockAfter')">
+        </button>
+        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('newBlockAfter')">
           <span class="context-menu-icon">+</span>
           <span>new block after</span>
-        </div>
+        </button>
         <div class="context-menu-separator"></div>
-        <div class="context-menu-item" v-if="!blockInContext" @click="handleContextMenuAction('addToContext')">
+        <button class="context-menu-item" role="menuitem" tabindex="-1" v-if="!blockInContext" @click="handleContextMenuAction('addToContext')">
           <span class="context-menu-icon">+</span>
           <span>add to ai context</span>
-        </div>
-        <div class="context-menu-item" v-if="blockInContext" @click="handleContextMenuAction('removeFromContext')">
+        </button>
+        <button class="context-menu-item" role="menuitem" tabindex="-1" v-if="blockInContext" @click="handleContextMenuAction('removeFromContext')">
           <span class="context-menu-icon">-</span>
           <span>remove from ai context</span>
-        </div>
+        </button>
         <div class="context-menu-separator"></div>
-        <div class="context-menu-item context-menu-danger" @click="handleContextMenuAction('delete')">
+        <button class="context-menu-item context-menu-danger" role="menuitem" tabindex="-1" @click="handleContextMenuAction('delete')">
           <span class="context-menu-icon">×</span>
           <span>delete</span>
-        </div>
+        </button>
       </div>
       
       <!-- Recursively render children -->

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -235,7 +235,8 @@ const BlockComponent = {
     },
     getContextMenuItems() {
       return Array.from(
-        this.$el?.querySelectorAll(".block-context-menu [role='menuitem']") || []
+        this.$el?.querySelectorAll(".block-context-menu [role='menuitem']") ||
+          []
       );
     },
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -297,16 +297,20 @@ const BlockComponent = {
       }
     },
 
-    handleBlockDisplayKeydown(event) {
+    async handleBlockDisplayKeydown(event) {
       // Alt+Shift+ArrowUp/Down: move block
       if (event.altKey && event.shiftKey && event.key === "ArrowUp") {
         event.preventDefault();
-        this.moveBlockUp(this.block);
+        const uuid = this.block.uuid;
+        await this.moveBlockUp(this.block);
+        this.refocusDisplay(uuid);
         return;
       }
       if (event.altKey && event.shiftKey && event.key === "ArrowDown") {
         event.preventDefault();
-        this.moveBlockDown(this.block);
+        const uuid = this.block.uuid;
+        await this.moveBlockDown(this.block);
+        this.refocusDisplay(uuid);
         return;
       }
       // Cmd/Ctrl+Shift+Backspace: delete block
@@ -381,6 +385,15 @@ const BlockComponent = {
       if (event.detail?.uuid === this.block.uuid) {
         this.openContextMenuAtBlock();
       }
+    },
+
+    refocusDisplay(uuid) {
+      this.$nextTick(() => {
+        const display = document.querySelector(
+          `[data-block-uuid="${uuid}"] .block-content-display`
+        );
+        if (display) display.focus();
+      });
     },
 
     handleContextMenuAction(action) {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -107,10 +107,18 @@ const BlockComponent = {
   mounted() {
     // Listen for the custom event to close menus
     document.addEventListener("closeBlockMenus", this.handleCloseBlockMenus);
+    document.addEventListener(
+      "openBlockContextMenu",
+      this.handleOpenContextMenuEvent
+    );
   },
   beforeUnmount() {
     // Clean up event listener
     document.removeEventListener("closeBlockMenus", this.handleCloseBlockMenus);
+    document.removeEventListener(
+      "openBlockContextMenu",
+      this.handleOpenContextMenuEvent
+    );
   },
   methods: {
     toggleBlockContext() {
@@ -290,9 +298,88 @@ const BlockComponent = {
     },
 
     handleBlockDisplayKeydown(event) {
+      // Alt+Shift+ArrowUp/Down: move block
+      if (event.altKey && event.shiftKey && event.key === "ArrowUp") {
+        event.preventDefault();
+        this.moveBlockUp(this.block);
+        return;
+      }
+      if (event.altKey && event.shiftKey && event.key === "ArrowDown") {
+        event.preventDefault();
+        this.moveBlockDown(this.block);
+        return;
+      }
+      // Cmd/Ctrl+Shift+Backspace: delete block
+      if (
+        (event.metaKey || event.ctrlKey) &&
+        event.shiftKey &&
+        event.key === "Backspace"
+      ) {
+        event.preventDefault();
+        this.deleteBlock(this.block);
+        return;
+      }
+      // Cmd/Ctrl+. or Shift+F10: open context menu
+      if (
+        ((event.metaKey || event.ctrlKey) && event.key === ".") ||
+        (event.shiftKey && event.key === "F10")
+      ) {
+        event.preventDefault();
+        this.openContextMenuAtBlock();
+        return;
+      }
       if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
         this.startEditing(this.block);
+      }
+    },
+
+    openContextMenuAtBlock() {
+      const menuBtn = this.$el?.querySelector(".block-menu");
+      if (!menuBtn) return;
+      const rect = menuBtn.getBoundingClientRect();
+
+      // Reuse the same positioning logic as showContextMenuAt
+      this.closeOtherMenus();
+
+      const menuWidth = 200;
+      const shadowOffset = 4;
+      const viewportWidth = window.innerWidth;
+      const isMobile = window.innerWidth <= 768;
+      const edgePadding = isMobile ? 20 : 10;
+      const bottomPadding = isMobile ? 60 : 10;
+
+      let x = rect.left;
+      let y = rect.bottom;
+
+      if (x + menuWidth + shadowOffset > viewportWidth - edgePadding) {
+        x = viewportWidth - menuWidth - shadowOffset - edgePadding;
+      }
+      x = Math.max(edgePadding, x);
+
+      this.contextMenuPosition = { x, y };
+      this.showContextMenu = true;
+
+      this.$nextTick(() => {
+        const menuEl = this.$el.querySelector(".block-context-menu");
+        if (!menuEl) return;
+        const menuHeight = menuEl.offsetHeight;
+        const viewportHeight = window.innerHeight;
+        if (y + menuHeight + shadowOffset > viewportHeight - bottomPadding) {
+          y = viewportHeight - menuHeight - shadowOffset - bottomPadding;
+        }
+        y = Math.max(edgePadding, y);
+        this.contextMenuPosition = { x, y };
+      });
+
+      setTimeout(() => {
+        document.addEventListener("click", this.hideContextMenu);
+      }, 10);
+    },
+
+    handleOpenContextMenuEvent(event) {
+      if (event.detail?.uuid === this.block.uuid) {
+        this.openContextMenuAtBlock();
       }
     },
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -389,10 +389,12 @@ const BlockComponent = {
 
     refocusDisplay(uuid) {
       this.$nextTick(() => {
-        const display = document.querySelector(
-          `[data-block-uuid="${uuid}"] .block-content-display`
-        );
-        if (display) display.focus();
+        this.$nextTick(() => {
+          const display = document.querySelector(
+            `[data-block-uuid="${uuid}"] .block-content-display`
+          );
+          if (display) display.focus();
+        });
       });
     },
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/HelpModal.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/HelpModal.js
@@ -13,8 +13,8 @@ window.HelpModal = {
     isOpen(newValue) {
       if (newValue) {
         this.$nextTick(() => {
-          const closeBtn = this.$el?.querySelector(".help-close-btn");
-          if (closeBtn) closeBtn.focus();
+          const body = this.$refs.modalBody;
+          if (body) body.focus();
         });
       }
     },
@@ -56,7 +56,7 @@ window.HelpModal = {
           <button @click="$emit('close')" class="help-close-btn" title="Close">×</button>
         </div>
 
-        <div class="help-modal-body">
+        <div class="help-modal-body" ref="modalBody" tabindex="-1">
           <div class="help-section">
             <h3>text formatting</h3>
             <table class="help-table">

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/HelpModal.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/HelpModal.js
@@ -9,8 +9,47 @@ window.HelpModal = {
 
   emits: ["close"],
 
+  watch: {
+    isOpen(newValue) {
+      if (newValue) {
+        this.$nextTick(() => {
+          const closeBtn = this.$el?.querySelector(".help-close-btn");
+          if (closeBtn) closeBtn.focus();
+        });
+      }
+    },
+  },
+
+  methods: {
+    handleModalKeydown(event) {
+      if (event.key === "Escape") {
+        this.$emit("close");
+        return;
+      }
+      if (event.key === "Tab") {
+        const modal = this.$el?.querySelector(".settings-modal-content");
+        if (!modal) return;
+        const focusable = Array.from(
+          modal.querySelectorAll(
+            'button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+          )
+        );
+        if (focusable.length < 2) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    },
+  },
+
   template: `
-    <div v-if="isOpen" class="settings-modal" @click.self="$emit('close')">
+    <div v-if="isOpen" class="settings-modal" @click.self="$emit('close')" @keydown="handleModalKeydown">
       <div class="settings-modal-content help-modal-content">
         <div class="help-modal-header">
           <h2>help</h2>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/HelpModal.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/HelpModal.js
@@ -102,7 +102,32 @@ window.HelpModal = {
           </div>
 
           <div class="help-section">
-            <h3>keyboard shortcuts</h3>
+            <h3>command palette</h3>
+            <table class="help-table">
+              <tbody>
+                <tr>
+                  <td><kbd>⌘</kbd> + <kbd>K</kbd> / <kbd>Ctrl</kbd> + <kbd>K</kbd></td>
+                  <td>open the command palette</td>
+                </tr>
+                <tr>
+                  <td><kbd>↑</kbd> / <kbd>↓</kbd></td>
+                  <td>navigate results</td>
+                </tr>
+                <tr>
+                  <td><kbd>Enter</kbd></td>
+                  <td>select</td>
+                </tr>
+                <tr>
+                  <td><kbd>Esc</kbd></td>
+                  <td>close</td>
+                </tr>
+              </tbody>
+            </table>
+            <p class="help-hint">search pages or run commands (new page, new block, today, settings, help). type <code class="help-syntax">new page &lt;title&gt;</code> to create a page with that title directly.</p>
+          </div>
+
+          <div class="help-section">
+            <h3>block editing</h3>
             <table class="help-table">
               <tbody>
                 <tr>
@@ -126,6 +151,10 @@ window.HelpModal = {
                   <td>navigate between blocks</td>
                 </tr>
                 <tr>
+                  <td><kbd>Esc</kbd></td>
+                  <td>exit editing (keeps focus on block for tabbing)</td>
+                </tr>
+                <tr>
                   <td>double <kbd>space</kbd> at start</td>
                   <td>indent block (mobile)</td>
                 </tr>
@@ -135,7 +164,7 @@ window.HelpModal = {
 
           <div class="help-section">
             <h3>block actions</h3>
-            <p class="help-hint">click the <strong>⋮</strong> button that appears to the right of any block to access block actions: indent, outdent, move up/down, create before/after, add to AI context, and delete.</p>
+            <p class="help-hint">click the <strong>⋮</strong> button (or <kbd>Tab</kbd> to it) on any block to access block actions: indent, outdent, move up/down, create before/after, add to AI context, and delete. inside the menu, use <kbd>↑</kbd><kbd>↓</kbd> to navigate, <kbd>Enter</kbd> to select, <kbd>Esc</kbd> to close.</p>
           </div>
         </div>
       </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/HelpModal.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/HelpModal.js
@@ -151,6 +151,18 @@ window.HelpModal = {
                   <td>navigate between blocks</td>
                 </tr>
                 <tr>
+                  <td><kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>↑</kbd> / <kbd>↓</kbd></td>
+                  <td>move block up / down</td>
+                </tr>
+                <tr>
+                  <td><kbd>⌘</kbd> + <kbd>Shift</kbd> + <kbd>⌫</kbd></td>
+                  <td>delete block</td>
+                </tr>
+                <tr>
+                  <td><kbd>⌘</kbd> + <kbd>.</kbd> or <kbd>Shift</kbd> + <kbd>F10</kbd></td>
+                  <td>open block actions menu</td>
+                </tr>
+                <tr>
                   <td><kbd>Esc</kbd></td>
                   <td>exit editing (keeps focus on block for tabbing)</td>
                 </tr>
@@ -164,7 +176,7 @@ window.HelpModal = {
 
           <div class="help-section">
             <h3>block actions</h3>
-            <p class="help-hint">click the <strong>⋮</strong> button (or <kbd>Tab</kbd> to it) on any block to access block actions: indent, outdent, move up/down, create before/after, add to AI context, and delete. inside the menu, use <kbd>↑</kbd><kbd>↓</kbd> to navigate, <kbd>Enter</kbd> to select, <kbd>Esc</kbd> to close.</p>
+            <p class="help-hint">click the <strong>⋮</strong> button, <kbd>Tab</kbd> to it, or press <kbd>⌘</kbd>+<kbd>.</kbd> while focused on a block to open the actions menu: indent, outdent, move up/down, create before/after, add to AI context, and delete. inside the menu, use <kbd>↑</kbd><kbd>↓</kbd> to navigate, <kbd>Enter</kbd> to select, <kbd>Esc</kbd> to close.</p>
           </div>
         </div>
       </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -493,12 +493,18 @@ const Page = {
       // Alt+Shift+ArrowUp/Down: move block
       if (event.altKey && event.shiftKey && event.key === "ArrowUp") {
         event.preventDefault();
+        const cursorPos = event.target.selectionStart;
+        const wasEditing = block.isEditing;
         await this.moveBlockUp(block);
+        this.restoreBlockFocus(block.uuid, wasEditing, cursorPos);
         return;
       }
       if (event.altKey && event.shiftKey && event.key === "ArrowDown") {
         event.preventDefault();
+        const cursorPos = event.target.selectionStart;
+        const wasEditing = block.isEditing;
         await this.moveBlockDown(block);
+        this.restoreBlockFocus(block.uuid, wasEditing, cursorPos);
         return;
       }
       // Cmd/Ctrl+Shift+Backspace: delete block
@@ -970,6 +976,31 @@ const Page = {
       };
       addBlocks(this.directBlocks);
       return result;
+    },
+
+    restoreBlockFocus(uuid, wasEditing, cursorPos) {
+      this.$nextTick(() => {
+        const newBlock = this.getAllBlocks().find((b) => b.uuid === uuid);
+        if (!newBlock) return;
+        if (wasEditing) {
+          this.startEditing(newBlock);
+          if (typeof cursorPos === "number") {
+            this.$nextTick(() => {
+              const textarea = document.querySelector(
+                `[data-block-uuid="${uuid}"] textarea`
+              );
+              if (textarea) {
+                textarea.setSelectionRange(cursorPos, cursorPos);
+              }
+            });
+          }
+        } else {
+          const display = document.querySelector(
+            `[data-block-uuid="${uuid}"] .block-content-display`
+          );
+          if (display) display.focus();
+        }
+      });
     },
 
     focusNextBlock(currentBlock) {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -980,26 +980,28 @@ const Page = {
 
     restoreBlockFocus(uuid, wasEditing, cursorPos) {
       this.$nextTick(() => {
-        const newBlock = this.getAllBlocks().find((b) => b.uuid === uuid);
-        if (!newBlock) return;
-        if (wasEditing) {
-          this.startEditing(newBlock);
-          if (typeof cursorPos === "number") {
-            this.$nextTick(() => {
-              const textarea = document.querySelector(
-                `[data-block-uuid="${uuid}"] textarea`
-              );
-              if (textarea) {
-                textarea.setSelectionRange(cursorPos, cursorPos);
-              }
-            });
+        this.$nextTick(() => {
+          const newBlock = this.getAllBlocks().find((b) => b.uuid === uuid);
+          if (!newBlock) return;
+          if (wasEditing) {
+            this.startEditing(newBlock);
+            if (typeof cursorPos === "number") {
+              this.$nextTick(() => {
+                const textarea = document.querySelector(
+                  `[data-block-uuid="${uuid}"] textarea`
+                );
+                if (textarea) {
+                  textarea.setSelectionRange(cursorPos, cursorPos);
+                }
+              });
+            }
+          } else {
+            const display = document.querySelector(
+              `[data-block-uuid="${uuid}"] .block-content-display`
+            );
+            if (display) display.focus();
           }
-        } else {
-          const display = document.querySelector(
-            `[data-block-uuid="${uuid}"] .block-content-display`
-          );
-          if (display) display.focus();
-        }
+        });
       });
     },
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -490,6 +490,40 @@ const Page = {
     },
 
     async onBlockKeyDown(event, block) {
+      // Alt+Shift+ArrowUp/Down: move block
+      if (event.altKey && event.shiftKey && event.key === "ArrowUp") {
+        event.preventDefault();
+        await this.moveBlockUp(block);
+        return;
+      }
+      if (event.altKey && event.shiftKey && event.key === "ArrowDown") {
+        event.preventDefault();
+        await this.moveBlockDown(block);
+        return;
+      }
+      // Cmd/Ctrl+Shift+Backspace: delete block
+      if (
+        (event.metaKey || event.ctrlKey) &&
+        event.shiftKey &&
+        event.key === "Backspace"
+      ) {
+        event.preventDefault();
+        await this.deleteBlock(block);
+        return;
+      }
+      // Cmd/Ctrl+. or Shift+F10: open context menu for this block
+      if (
+        ((event.metaKey || event.ctrlKey) && event.key === ".") ||
+        (event.shiftKey && event.key === "F10")
+      ) {
+        event.preventDefault();
+        document.dispatchEvent(
+          new CustomEvent("openBlockContextMenu", {
+            detail: { uuid: block.uuid },
+          })
+        );
+        return;
+      }
       if (event.key === "Escape") {
         event.preventDefault();
         await this.updateBlock(block, block.content, true);

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -110,8 +110,8 @@ const Page = {
       return null;
     },
 
-    async loadPage() {
-      this.loading = true;
+    async loadPage({ silent = false } = {}) {
+      if (!silent) this.loading = true;
       this.error = null;
 
       try {
@@ -439,8 +439,8 @@ const Page = {
         // Update local state - re-sort siblings
         siblings.sort((a, b) => a.order - b.order);
 
-        // Refresh page data to ensure consistency
-        await this.loadPage();
+        // Refresh page data without unmounting blocks (preserves focus)
+        await this.loadPage({ silent: true });
       } catch (error) {
         console.error("failed to move block up:", error);
         this.error = "failed to move block up";
@@ -476,8 +476,8 @@ const Page = {
         // Update local state - re-sort siblings
         siblings.sort((a, b) => a.order - b.order);
 
-        // Refresh page data to ensure consistency
-        await this.loadPage();
+        // Refresh page data without unmounting blocks (preserves focus)
+        await this.loadPage({ silent: true });
       } catch (error) {
         console.error("failed to move block down:", error);
         this.error = "failed to move block down";

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -481,7 +481,19 @@ const Page = {
     },
 
     async onBlockKeyDown(event, block) {
-      if (event.key === "Enter" && !event.shiftKey) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        await this.updateBlock(block, block.content, true);
+        block.isEditing = false;
+        // Return focus to the display element so tab navigation continues
+        this.$nextTick(() => {
+          const display = document.querySelector(
+            `[data-block-uuid="${block.uuid}"] .block-content-display`
+          );
+          if (display) display.focus();
+        });
+        return;
+      } else if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault();
         // Save current block before creating new one
         await this.updateBlock(block, block.content, true);

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -70,6 +70,8 @@ const Page = {
     document.addEventListener("click", this.handleDocumentClick);
     // Restore focus when window/tab regains focus
     window.addEventListener("focus", this.handleWindowFocus);
+    // Global keydown for Escape to close page menus
+    document.addEventListener("keydown", this.handlePageGlobalKeydown);
     // Load page data
     await this.loadPage();
   },
@@ -78,6 +80,7 @@ const Page = {
     // Clean up event listeners
     document.removeEventListener("click", this.handleDocumentClick);
     window.removeEventListener("focus", this.handleWindowFocus);
+    document.removeEventListener("keydown", this.handlePageGlobalKeydown);
   },
 
   methods: {
@@ -943,10 +946,66 @@ const Page = {
     // Page management methods
     togglePageMenu() {
       this.showPageMenu = !this.showPageMenu;
+      if (this.showPageMenu) {
+        this.$nextTick(() => {
+          const firstItem = this.$el?.querySelector(
+            ".context-menu-container .context-menu .context-menu-item"
+          );
+          if (firstItem) firstItem.focus();
+        });
+      }
     },
 
     closePageMenu() {
       this.showPageMenu = false;
+    },
+
+    closePageMenuAndRestoreFocus() {
+      this.closePageMenu();
+      this.$nextTick(() => {
+        const menuBtn = this.$el?.querySelector(".context-menu-btn");
+        if (menuBtn) menuBtn.focus();
+      });
+    },
+
+    handlePageMenuKeydown(event) {
+      const items = Array.from(
+        this.$el?.querySelectorAll(
+          ".context-menu-container .context-menu .context-menu-item"
+        ) || []
+      );
+      if (!items.length) return;
+      const currentIndex = items.indexOf(document.activeElement);
+
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          items[Math.min(currentIndex + 1, items.length - 1)].focus();
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          items[Math.max(currentIndex - 1, 0)].focus();
+          break;
+        case "Escape":
+        case "Tab":
+          event.preventDefault();
+          this.closePageMenuAndRestoreFocus();
+          break;
+        case "Home":
+          event.preventDefault();
+          items[0].focus();
+          break;
+        case "End":
+          event.preventDefault();
+          items[items.length - 1].focus();
+          break;
+      }
+    },
+
+    handlePageGlobalKeydown(event) {
+      if (event.key === "Escape" && this.showPageMenu) {
+        this.closePageMenuAndRestoreFocus();
+      }
     },
 
     handleDocumentClick(event) {
@@ -1134,14 +1193,14 @@ const Page = {
               </div>
               <div class="header-controls">
                 <div class="context-menu-container">
-                  <button @click="togglePageMenu" class="btn btn-outline context-menu-btn" title="Daily note options">
+                  <button @click="togglePageMenu" class="btn btn-outline context-menu-btn" title="Daily note options" :aria-expanded="showPageMenu" aria-haspopup="menu">
                     ⋮
                   </button>
-                  <div v-if="showPageMenu" class="context-menu" @click.stop>
-                    <button @click="moveUndoneTodos" class="context-menu-item" :disabled="loading">
+                  <div v-if="showPageMenu" class="context-menu" @click.stop @keydown="handlePageMenuKeydown" role="menu">
+                    <button @click="moveUndoneTodos" class="context-menu-item" :disabled="loading" role="menuitem">
                       move undone TODOs here
                     </button>
-                    <button @click="deletePage" class="context-menu-item context-menu-danger">
+                    <button @click="deletePage" class="context-menu-item context-menu-danger" role="menuitem">
                        <span class="context-menu-icon">×</span>
                        <span>delete</span>
                     </button>
@@ -1154,7 +1213,7 @@ const Page = {
             <div v-else class="page-title-container page-header-flex">
               <div class="page-header-flex-left">
                 <div v-if="!isEditingTitle" class="page-title-display">
-                  <h1 class="page-title-text" @click="startEditingTitle">{{ page.title || 'Untitled Page' }}</h1>
+                  <h1 class="page-title-text" tabindex="0" role="button" aria-label="Edit page title" @click="startEditingTitle" @keydown.enter.prevent="startEditingTitle" @keydown.space.prevent="startEditingTitle">{{ page.title || 'Untitled Page' }}</h1>
                 </div>
                 <div v-else class="page-title-edit">
                   <input
@@ -1175,14 +1234,14 @@ const Page = {
               </div>
               <div class="page-actions">
                 <div class="context-menu-container">
-                  <button @click="togglePageMenu" class="btn btn-outline context-menu-btn" title="Page options">
+                  <button @click="togglePageMenu" class="btn btn-outline context-menu-btn" title="Page options" :aria-expanded="showPageMenu" aria-haspopup="menu">
                     ⋮
                   </button>
-                  <div v-if="showPageMenu" class="context-menu" @click.stop>
-                    <button @click="startEditingTitle" class="context-menu-item">
+                  <div v-if="showPageMenu" class="context-menu" @click.stop @keydown="handlePageMenuKeydown" role="menu">
+                    <button @click="startEditingTitle" class="context-menu-item" role="menuitem">
                       edit title
                     </button>
-                    <button @click="deletePage" class="context-menu-item context-menu-danger">
+                    <button @click="deletePage" class="context-menu-item context-menu-danger" role="menuitem">
                       delete page
                     </button>
                   </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -957,10 +957,10 @@ const Page = {
         return;
       }
 
-      // Save the block when user stops editing (blur event)
-      // Skip reload to preserve cursor positions of other blocks
       await this.updateBlock(block, block.content, true);
-      block.isEditing = false;
+      // Don't close the editor if startEditing was called while the save
+      // was in flight (e.g. restoreBlockFocus after a move).
+      if (!block.isEditing) block.isEditing = false;
     },
 
     getAllBlocks() {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -72,6 +72,11 @@ const Page = {
     window.addEventListener("focus", this.handleWindowFocus);
     // Global keydown for Escape to close page menus
     document.addEventListener("keydown", this.handlePageGlobalKeydown);
+    // Spotlight command: new block
+    document.addEventListener(
+      "spotlight:new-block",
+      this.handleSpotlightNewBlock
+    );
     // Load page data
     await this.loadPage();
   },
@@ -81,6 +86,10 @@ const Page = {
     document.removeEventListener("click", this.handleDocumentClick);
     window.removeEventListener("focus", this.handleWindowFocus);
     document.removeEventListener("keydown", this.handlePageGlobalKeydown);
+    document.removeEventListener(
+      "spotlight:new-block",
+      this.handleSpotlightNewBlock
+    );
   },
 
   methods: {
@@ -1018,6 +1027,10 @@ const Page = {
       if (event.key === "Escape" && this.showPageMenu) {
         this.closePageMenuAndRestoreFocus();
       }
+    },
+
+    handleSpotlightNewBlock() {
+      this.addNewBlock();
     },
 
     handleDocumentClick(event) {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SettingsModal.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SettingsModal.js
@@ -89,6 +89,12 @@ window.SettingsModal = {
         if (newValue) {
           this.currentTab = this.activeTab || "general";
           await this.loadAISettings();
+          this.$nextTick(() => {
+            const firstFocusable = this.$el?.querySelector(
+              ".settings-modal-content button, .settings-modal-content input, .settings-modal-content select"
+            );
+            if (firstFocusable) firstFocusable.focus();
+          });
         }
       },
     },
@@ -190,6 +196,32 @@ window.SettingsModal = {
     handleBackdropClick(event) {
       if (event.target === event.currentTarget) {
         this.closeModal();
+      }
+    },
+
+    handleModalKeydown(event) {
+      if (event.key === "Escape") {
+        this.closeModal();
+        return;
+      }
+      if (event.key === "Tab") {
+        const modal = this.$el?.querySelector(".settings-modal-content");
+        if (!modal) return;
+        const focusable = Array.from(
+          modal.querySelectorAll(
+            'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+          )
+        );
+        if (focusable.length < 2) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
       }
     },
 
@@ -357,6 +389,7 @@ window.SettingsModal = {
       v-if="isOpen"
       class="settings-modal"
       @click="handleBackdropClick"
+      @keydown="handleModalKeydown"
     >
       <div class="settings-modal-content">
         <h2>settings</h2>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SpotlightSearch.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SpotlightSearch.js
@@ -124,18 +124,21 @@ window.SpotlightSearch = {
           </div>
 
           <div v-else-if="query && results.length === 0" class="spotlight-no-results">
-            <p>no pages found for "<strong>{{ query }}</strong>"</p>
+            <p>no results for "<strong>{{ query }}</strong>"</p>
           </div>
 
           <div v-else-if="results.length > 0" class="spotlight-results">
             <div
               v-for="(result, index) in results"
-              :key="result.slug"
+              :key="result.type === 'command' ? result.commandId : result.slug"
               class="spotlight-result"
-              :class="{ 'selected': index === selectedIndex }"
+              :class="{ 'selected': index === selectedIndex, 'spotlight-command': result.type === 'command' }"
               @click="handleResultClick(index)"
             >
-              <div class="spotlight-result-icon">
+              <div class="spotlight-result-icon spotlight-command-icon" v-if="result.type === 'command'">
+                {{ result.icon }}
+              </div>
+              <div class="spotlight-result-icon" v-else>
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
                   <path d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3z" stroke="currentColor" stroke-width="1.5" fill="none"/>
                   <path d="M5 6h6M5 8h4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
@@ -143,14 +146,12 @@ window.SpotlightSearch = {
               </div>
               <div class="spotlight-result-content">
                 <div class="spotlight-result-title" v-html="highlightQuery(result.title, query)"></div>
-                <div class="spotlight-result-snippet" v-html="highlightQuery(result.snippet, query)"></div>
-                <div class="spotlight-result-path">{{ result.url }}</div>
+                <div class="spotlight-result-snippet" v-if="result.type === 'command'">{{ result.description }}</div>
+                <div class="spotlight-result-snippet" v-else-if="result.snippet" v-html="highlightQuery(result.snippet, query)"></div>
+                <div class="spotlight-result-path" v-if="result.type === 'page'">{{ result.url }}</div>
               </div>
+              <div class="spotlight-result-type" v-if="result.type === 'command'">command</div>
             </div>
-          </div>
-
-          <div v-else-if="!query" class="spotlight-empty">
-            <p>start typing to search your pages...</p>
           </div>
         </div>
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SpotlightSearch.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SpotlightSearch.js
@@ -57,6 +57,25 @@ window.SpotlightSearch = {
     },
 
     handleKeydown(event) {
+      if (event.key === "Tab") {
+        const modal = this.$el?.querySelector(".spotlight-modal");
+        if (!modal) return;
+        const focusable = Array.from(
+          modal.querySelectorAll(
+            'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+          )
+        );
+        if (focusable.length < 2) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
       this.$emit("keydown", event);
     },
 
@@ -76,7 +95,7 @@ window.SpotlightSearch = {
   },
 
   template: `
-    <div v-if="isOpen" class="spotlight-overlay" @click="handleOverlayClick">
+    <div v-if="isOpen" class="spotlight-overlay" @click="handleOverlayClick" @keydown="handleKeydown">
       <div class="spotlight-modal">
         <div class="spotlight-header">
           <div class="spotlight-search-container">

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SpotlightSearch.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SpotlightSearch.js
@@ -65,7 +65,12 @@ window.SpotlightSearch = {
             'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
           )
         );
-        if (focusable.length < 2) return;
+        if (!focusable.length) return;
+        if (focusable.length === 1) {
+          event.preventDefault();
+          focusable[0].focus();
+          return;
+        }
         const first = focusable[0];
         const last = focusable[focusable.length - 1];
         if (event.shiftKey && document.activeElement === first) {
@@ -95,7 +100,7 @@ window.SpotlightSearch = {
   },
 
   template: `
-    <div v-if="isOpen" class="spotlight-overlay" @click="handleOverlayClick" @keydown="handleKeydown">
+    <div v-if="isOpen" class="spotlight-overlay" @click="handleOverlayClick">
       <div class="spotlight-modal">
         <div class="spotlight-header">
           <div class="spotlight-search-container">


### PR DESCRIPTION
Closes #9

## Summary
This PR enhances accessibility and keyboard navigation throughout the application by adding comprehensive keyboard support to context menus, page menus, and interactive elements. Users can now navigate menus using arrow keys, Home/End keys, and close them with Escape/Tab.

## Key Changes

### BlockComponent.js
- Added `contextMenuFocusedIndex` state to track focused menu item
- Implemented `watch` on `showContextMenu` to auto-focus first item when menu opens
- Added keyboard handlers:
  - `handleContextMenuKeydown()`: Arrow Up/Down, Home/End, Escape/Tab navigation
  - `handleBlockDisplayKeydown()`: Enter/Space to edit blocks
  - `focusContextMenuItem()`: Helper to focus menu items by index
  - `hideContextMenuAndRestoreFocus()`: Close menu and restore focus to menu button
- Converted context menu items from `<div>` to `<button>` elements with proper ARIA roles (`role="menuitem"`)
- Added keyboard support to block content display with `tabindex="0"`, `role="button"`, and `aria-label`
- Added `@keydown` handler to block display for keyboard activation

### Page.js
- Added global keydown listener for Escape key to close page menus
- Implemented `handlePageMenuKeydown()`: Arrow navigation, Home/End, Escape/Tab support
- Implemented `handlePageGlobalKeydown()`: Global Escape key handling
- Added `closePageMenuAndRestoreFocus()`: Close menu and restore focus to menu button
- Enhanced menu button with `aria-expanded` and `aria-haspopup="menu"` attributes
- Added `role="menu"` to menu containers and `role="menuitem"` to menu items
- Added keyboard support to page title with Enter/Space activation

### app.js
- Implemented `handleNavMenuKeydown()`: Arrow navigation, Home/End, Escape/Tab support
- Enhanced Escape key handling to close menus and restore focus
- Auto-focus first menu item when menu opens
- Added `aria-expanded` and `aria-haspopup="menu"` to menu button
- Added `role="menu"` and `role="menuitem"` attributes to navigation menu
- Added spotlight command palette (Cmd/Ctrl+K) with commands: new page, new block, today, settings, help

### app.css
- Added focus styles for keyboard navigation:
  - `.block-content-display:focus`: Outline with background highlight
  - `.context-menu-item:focus`: Inset outline with hover background
  - `.page-title-text:focus`: Outline with offset
  - `.block-collapse-toggle:focus`: Visibility and outline
  - `.block-menu:focus`: Visibility and outline
  - `.context-menu-btn:focus`: Outline styling

## Implementation Details
- All menus follow WAI-ARIA menu pattern with proper roles and attributes
- Focus management ensures focus returns to trigger button when menu closes
- Arrow keys navigate menu items with boundary checks (no wrapping)
- Home/End keys jump to first/last menu items
- Escape and Tab keys close menus and restore focus
- Visual focus indicators added for keyboard navigation visibility
- Menu items use `tabindex="-1"` to prevent tab order pollution while allowing programmatic focus
- Block move shortcuts (Alt+Shift+↑/↓), delete (Cmd+Shift+⌫), and context menu (Cmd+.) added
- Focus restored correctly after block moves, including fixing a race condition in `stopEditing`

https://claude.ai/code/session_013CRWmVjUAXFAYNXAaHL1x8