### PR TITLE
Add whiteboard page type (tldraw) for iPad/Apple Pencil brain-dump

### DIFF
--- a/packages/django-app/app/knowledge/commands/create_page_command.py
+++ b/packages/django-app/app/knowledge/commands/create_page_command.py
@@ -25,6 +25,7 @@ class CreatePageCommand(AbstractBaseCommand):
             slug=self.form.cleaned_data.get("slug") or slugify(title),
             content=self.form.cleaned_data.get("content", ""),
             is_published=self.form.cleaned_data.get("is_published", True),
+            page_type=self.form.cleaned_data.get("page_type") or "page",
         )
 
         return page

--- a/packages/django-app/app/knowledge/commands/get_historical_data_command.py
+++ b/packages/django-app/app/knowledge/commands/get_historical_data_command.py
@@ -28,7 +28,7 @@ class GetHistoricalDataCommand(AbstractBaseCommand):
         end_date = timezone.now()
         start_date = end_date - timedelta(days=days_back)
 
-        pages = PageRepository.get_recent_pages_with_blocks(user=user, limit=days_back)
+        pages = PageRepository.get_recent_pages(user=user, limit=days_back)
 
         blocks = BlockRepository.get_blocks_by_date_range(
             user=user, start_date=start_date, end_date=end_date, limit=limit

--- a/packages/django-app/app/knowledge/forms/create_page_form.py
+++ b/packages/django-app/app/knowledge/forms/create_page_form.py
@@ -16,6 +16,10 @@ class CreatePageForm(BaseForm):
     content = forms.CharField(widget=forms.Textarea, required=False)
     slug = forms.SlugField(max_length=200, required=False)
     is_published = forms.BooleanField(required=False, initial=True)
+    page_type = forms.ChoiceField(
+        choices=Page._meta.get_field("page_type").choices,
+        required=False,
+    )
 
     def clean_title(self) -> str:
         title = self.cleaned_data.get("title")

--- a/packages/django-app/app/knowledge/forms/update_page_form.py
+++ b/packages/django-app/app/knowledge/forms/update_page_form.py
@@ -28,6 +28,12 @@ class UpdatePageForm(BaseForm):
         return page
 
     def clean_title(self) -> Optional[str]:
+        # Distinguish "title omitted from payload" from "title explicitly blank".
+        # Django's CharField(required=False) coerces a missing field to "", so
+        # without this guard every partial update (e.g. canvas snapshot saves
+        # that only send `content`) would trip the empty-title check.
+        if "title" not in self.data:
+            return None
         title = self.cleaned_data.get("title")
         if title is not None:
             title = title.strip()

--- a/packages/django-app/app/knowledge/forms/update_page_form.py
+++ b/packages/django-app/app/knowledge/forms/update_page_form.py
@@ -30,7 +30,7 @@ class UpdatePageForm(BaseForm):
     def clean_title(self) -> Optional[str]:
         # Distinguish "title omitted from payload" from "title explicitly blank".
         # Django's CharField(required=False) coerces a missing field to "", so
-        # without this guard every partial update (e.g. canvas snapshot saves
+        # without this guard every partial update (e.g. whiteboard snapshot saves
         # that only send `content`) would trip the empty-title check.
         if "title" not in self.data:
             return None

--- a/packages/django-app/app/knowledge/migrations/0018_alter_page_page_type_add_canvas.py
+++ b/packages/django-app/app/knowledge/migrations/0018_alter_page_page_type_add_canvas.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("knowledge", "0017_alter_block_block_type"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="page",
+            name="page_type",
+            field=models.CharField(
+                choices=[
+                    ("page", "Regular Page"),
+                    ("daily", "Daily Note"),
+                    ("template", "Template"),
+                    ("canvas", "Canvas"),
+                ],
+                default="page",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/packages/django-app/app/knowledge/migrations/0019_rename_canvas_to_whiteboard.py
+++ b/packages/django-app/app/knowledge/migrations/0019_rename_canvas_to_whiteboard.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+
+
+def rename_canvas_to_whiteboard(apps, schema_editor):
+    Page = apps.get_model("knowledge", "Page")
+    Page.objects.filter(page_type="canvas").update(page_type="whiteboard")
+
+
+def rename_whiteboard_to_canvas(apps, schema_editor):
+    Page = apps.get_model("knowledge", "Page")
+    Page.objects.filter(page_type="whiteboard").update(page_type="canvas")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("knowledge", "0018_alter_page_page_type_add_canvas"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            rename_canvas_to_whiteboard, reverse_code=rename_whiteboard_to_canvas
+        ),
+        migrations.AlterField(
+            model_name="page",
+            name="page_type",
+            field=models.CharField(
+                choices=[
+                    ("page", "Regular Page"),
+                    ("daily", "Daily Note"),
+                    ("template", "Template"),
+                    ("whiteboard", "Whiteboard"),
+                ],
+                default="page",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/packages/django-app/app/knowledge/models/page.py
+++ b/packages/django-app/app/knowledge/models/page.py
@@ -30,6 +30,7 @@ class Page(UUIDModelMixin, CRUDTimestampsMixin):
             ("page", "Regular Page"),
             ("daily", "Daily Note"),
             ("template", "Template"),
+            ("canvas", "Canvas"),
         ],
         default="page",
     )

--- a/packages/django-app/app/knowledge/models/page.py
+++ b/packages/django-app/app/knowledge/models/page.py
@@ -30,7 +30,7 @@ class Page(UUIDModelMixin, CRUDTimestampsMixin):
             ("page", "Regular Page"),
             ("daily", "Daily Note"),
             ("template", "Template"),
-            ("canvas", "Canvas"),
+            ("whiteboard", "Whiteboard"),
         ],
         default="page",
     )

--- a/packages/django-app/app/knowledge/repositories/page_repository.py
+++ b/packages/django-app/app/knowledge/repositories/page_repository.py
@@ -1,7 +1,7 @@
 from datetime import date
 from typing import Any, Dict, Optional
 
-from django.db.models import Count, QuerySet
+from django.db.models import Count, Q, QuerySet
 
 from common.repositories.base_repository import BaseRepository
 
@@ -132,16 +132,19 @@ class PageRepository(BaseRepository):
         )
 
     @classmethod
-    def get_recent_pages_with_blocks(cls, user, limit=7) -> QuerySet:
-        """Get the most recently modified pages that have blocks."""
-        pages_with_blocks = (
+    def get_recent_pages(cls, user, limit=7) -> QuerySet:
+        """Get the most recently modified pages that have meaningful content.
+
+        Includes pages that have blocks as well as canvas pages (whose content
+        lives in Page.content as a tldraw snapshot rather than in Block rows).
+        """
+        return (
             cls.get_queryset()
             .filter(user=user)
             .annotate(block_count=Count("blocks"))
-            .filter(block_count__gt=0)
+            .filter(Q(block_count__gt=0) | Q(page_type="canvas"))
             .order_by("-modified_at")[:limit]
         )
-        return pages_with_blocks
 
     @classmethod
     def get_tag_page(cls, tag_name: str, user) -> Optional[Page]:

--- a/packages/django-app/app/knowledge/repositories/page_repository.py
+++ b/packages/django-app/app/knowledge/repositories/page_repository.py
@@ -135,14 +135,15 @@ class PageRepository(BaseRepository):
     def get_recent_pages(cls, user, limit=7) -> QuerySet:
         """Get the most recently modified pages that have meaningful content.
 
-        Includes pages that have blocks as well as canvas pages (whose content
-        lives in Page.content as a tldraw snapshot rather than in Block rows).
+        Includes pages that have blocks as well as whiteboard pages (whose
+        content lives in Page.content as a tldraw snapshot rather than in
+        Block rows).
         """
         return (
             cls.get_queryset()
             .filter(user=user)
             .annotate(block_count=Count("blocks"))
-            .filter(Q(block_count__gt=0) | Q(page_type="canvas"))
+            .filter(Q(block_count__gt=0) | Q(page_type="whiteboard"))
             .order_by("-modified_at")[:limit]
         )
 

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -3948,3 +3948,82 @@ kbd {
   border-radius: 2px;
   padding: 0.05em 0.2em;
 }
+
+/* Canvas page (tldraw whiteboard) */
+.page-content-canvas {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - var(--navbar-height, 60px));
+  padding: 0;
+  margin: 0;
+  max-width: none;
+}
+
+.canvas-page-header {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
+  flex: 0 0 auto;
+}
+
+.canvas-page-header .page-type-badge {
+  display: inline-block;
+  margin-left: 0.75rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-secondary, #888);
+  border: 1px solid var(--border-color, rgba(0, 0, 0, 0.2));
+  border-radius: 10px;
+  padding: 0.05em 0.5em;
+}
+
+.canvas-page {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.canvas-container {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.canvas-container .tl-container {
+  position: absolute;
+  inset: 0;
+}
+
+.canvas-loading,
+.canvas-error {
+  padding: 1rem;
+  color: var(--text-secondary, #888);
+  font-size: 0.9rem;
+}
+
+.canvas-error {
+  color: var(--danger-color, #d33);
+}
+
+.canvas-status {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  z-index: 10;
+  font-size: 0.75rem;
+  color: var(--text-secondary, #888);
+  background: var(--bg-primary, rgba(255, 255, 255, 0.85));
+  padding: 0.15em 0.5em;
+  border-radius: 3px;
+  pointer-events: none;
+}
+
+.canvas-status-error {
+  color: var(--danger-color, #d33);
+}

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -3949,8 +3949,8 @@ kbd {
   padding: 0.05em 0.2em;
 }
 
-/* Canvas page (tldraw whiteboard) */
-.page-content-canvas {
+/* Whiteboard page (tldraw) */
+.page-content-whiteboard {
   display: flex;
   flex-direction: column;
   height: calc(100vh - var(--navbar-height, 60px));
@@ -3959,13 +3959,13 @@ kbd {
   max-width: none;
 }
 
-.canvas-page-header {
+.whiteboard-page-header {
   padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
   flex: 0 0 auto;
 }
 
-.canvas-page-header .page-type-badge {
+.whiteboard-page-header .page-type-badge {
   display: inline-block;
   margin-left: 0.75rem;
   font-size: 0.7rem;
@@ -3977,7 +3977,7 @@ kbd {
   padding: 0.05em 0.5em;
 }
 
-.canvas-page {
+.whiteboard-page {
   position: relative;
   flex: 1 1 auto;
   min-height: 0;
@@ -3985,7 +3985,7 @@ kbd {
   flex-direction: column;
 }
 
-.canvas-container {
+.whiteboard-container {
   position: relative;
   flex: 1 1 auto;
   min-height: 0;
@@ -3995,23 +3995,23 @@ kbd {
   user-select: none;
 }
 
-.canvas-container .tl-container {
+.whiteboard-container .tl-container {
   position: absolute;
   inset: 0;
 }
 
-.canvas-loading,
-.canvas-error {
+.whiteboard-loading,
+.whiteboard-error {
   padding: 1rem;
   color: var(--text-secondary, #888);
   font-size: 0.9rem;
 }
 
-.canvas-error {
+.whiteboard-error {
   color: var(--danger-color, #d33);
 }
 
-.canvas-status {
+.whiteboard-status {
   position: absolute;
   top: 0.5rem;
   right: 0.75rem;
@@ -4024,6 +4024,6 @@ kbd {
   pointer-events: none;
 }
 
-.canvas-status-error {
+.whiteboard-status-error {
   color: var(--danger-color, #d33);
 }

--- a/packages/django-app/app/knowledge/static/knowledge/js/app.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/app.js
@@ -310,8 +310,12 @@ const KnowledgeApp = createApp({
       this.removeBlockFromContext(blockId);
     },
 
-    async createNewPage(prefilledTitle = null) {
-      const title = prefilledTitle ?? prompt("Enter page title:");
+    async createNewPage(prefilledTitle = null, pageType = "page") {
+      const title =
+        prefilledTitle ??
+        prompt(
+          pageType === "canvas" ? "Enter canvas title:" : "Enter page title:"
+        );
       if (!title || !title.trim()) return;
 
       try {
@@ -327,7 +331,8 @@ const KnowledgeApp = createApp({
           title.trim(),
           "",
           slug,
-          true
+          true,
+          pageType
         );
 
         if (result.success) {
@@ -343,6 +348,10 @@ const KnowledgeApp = createApp({
         console.error("Failed to create page:", error);
         alert("Failed to create page. Please try again.");
       }
+    },
+
+    async createNewCanvas(prefilledTitle = null) {
+      return this.createNewPage(prefilledTitle, "canvas");
     },
 
     // Menu methods
@@ -412,6 +421,11 @@ const KnowledgeApp = createApp({
     onMenuCreatePage() {
       this.closeMenu();
       this.createNewPage();
+    },
+
+    onMenuCreateCanvas() {
+      this.closeMenu();
+      this.createNewCanvas();
     },
 
     onMenuSettings() {
@@ -515,6 +529,12 @@ const KnowledgeApp = createApp({
           icon: "+",
         },
         {
+          id: "new-canvas",
+          label: "new canvas",
+          description: "create a new whiteboard canvas",
+          icon: "✎",
+        },
+        {
           id: "new-block",
           label: "new block",
           description: "add a block to the current page",
@@ -549,6 +569,23 @@ const KnowledgeApp = createApp({
               title: `create page "${title}"`,
               description: "create a new page with this title",
               icon: "+",
+            },
+          ];
+        }
+      }
+
+      // "new canvas <title>" — inline canvas title
+      if (q.startsWith("new canvas ")) {
+        const title = query.trim().slice("new canvas ".length).trim();
+        if (title) {
+          return [
+            {
+              type: "command",
+              commandId: "new-canvas",
+              commandArg: title,
+              title: `create canvas "${title}"`,
+              description: "create a new whiteboard canvas with this title",
+              icon: "✎",
             },
           ];
         }
@@ -655,6 +692,9 @@ const KnowledgeApp = createApp({
         case "new-page":
           this.createNewPage(arg ?? null);
           break;
+        case "new-canvas":
+          this.createNewCanvas(arg ?? null);
+          break;
         case "new-block":
           document.dispatchEvent(new CustomEvent("spotlight:new-block"));
           break;
@@ -722,6 +762,9 @@ const KnowledgeApp = createApp({
                                     </button>
                                     <button @click="onMenuCreatePage" class="menu-item" role="menuitem">
                                         + page
+                                    </button>
+                                    <button @click="onMenuCreateCanvas" class="menu-item" role="menuitem">
+                                        + canvas
                                     </button>
                                     <button @click="onMenuSettings" class="menu-item" role="menuitem">
                                         settings

--- a/packages/django-app/app/knowledge/static/knowledge/js/app.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/app.js
@@ -28,6 +28,7 @@ const KnowledgeApp = createApp({
       spotlightLoading: false, // Loading state for search
       spotlightSelectedIndex: 0, // Selected result index for keyboard navigation
       spotlightSearchTimeout: null, // Debounce timeout for search
+      currentPagePageType: null, // page_type of the currently-loaded page
     };
   },
 
@@ -58,6 +59,11 @@ const KnowledgeApp = createApp({
       }
 
       return "page"; // Default fallback for /knowledge/ - redirect to today's date
+    },
+
+    showChatPanel() {
+      // Whiteboards benefit from the full column width; chat is noise on them.
+      return this.currentPagePageType !== "whiteboard";
     },
   },
 
@@ -310,11 +316,17 @@ const KnowledgeApp = createApp({
       this.removeBlockFromContext(blockId);
     },
 
+    onPageLoaded(page) {
+      this.currentPagePageType = page?.page_type || null;
+    },
+
     async createNewPage(prefilledTitle = null, pageType = "page") {
       const title =
         prefilledTitle ??
         prompt(
-          pageType === "canvas" ? "Enter canvas title:" : "Enter page title:"
+          pageType === "whiteboard"
+            ? "Enter whiteboard title:"
+            : "Enter page title:"
         );
       if (!title || !title.trim()) return;
 
@@ -350,8 +362,8 @@ const KnowledgeApp = createApp({
       }
     },
 
-    async createNewCanvas(prefilledTitle = null) {
-      return this.createNewPage(prefilledTitle, "canvas");
+    async createNewWhiteboard(prefilledTitle = null) {
+      return this.createNewPage(prefilledTitle, "whiteboard");
     },
 
     // Menu methods
@@ -423,9 +435,9 @@ const KnowledgeApp = createApp({
       this.createNewPage();
     },
 
-    onMenuCreateCanvas() {
+    onMenuCreateWhiteboard() {
       this.closeMenu();
-      this.createNewCanvas();
+      this.createNewWhiteboard();
     },
 
     onMenuSettings() {
@@ -529,9 +541,9 @@ const KnowledgeApp = createApp({
           icon: "+",
         },
         {
-          id: "new-canvas",
-          label: "new canvas",
-          description: "create a new whiteboard canvas",
+          id: "new-whiteboard",
+          label: "new whiteboard",
+          description: "create a new whiteboard",
           icon: "✎",
         },
         {
@@ -574,17 +586,17 @@ const KnowledgeApp = createApp({
         }
       }
 
-      // "new canvas <title>" — inline canvas title
-      if (q.startsWith("new canvas ")) {
-        const title = query.trim().slice("new canvas ".length).trim();
+      // "new whiteboard <title>" — inline whiteboard title
+      if (q.startsWith("new whiteboard ")) {
+        const title = query.trim().slice("new whiteboard ".length).trim();
         if (title) {
           return [
             {
               type: "command",
-              commandId: "new-canvas",
+              commandId: "new-whiteboard",
               commandArg: title,
-              title: `create canvas "${title}"`,
-              description: "create a new whiteboard canvas with this title",
+              title: `create whiteboard "${title}"`,
+              description: "create a new whiteboard with this title",
               icon: "✎",
             },
           ];
@@ -693,8 +705,8 @@ const KnowledgeApp = createApp({
         case "new-page":
           this.createNewPage(arg ?? null);
           break;
-        case "new-canvas":
-          this.createNewCanvas(arg ?? null);
+        case "new-whiteboard":
+          this.createNewWhiteboard(arg ?? null);
           break;
         case "new-block":
           document.dispatchEvent(new CustomEvent("spotlight:new-block"));
@@ -764,8 +776,8 @@ const KnowledgeApp = createApp({
                                     <button @click="onMenuCreatePage" class="menu-item" role="menuitem">
                                         + page
                                     </button>
-                                    <button @click="onMenuCreateCanvas" class="menu-item" role="menuitem">
-                                        + canvas
+                                    <button @click="onMenuCreateWhiteboard" class="menu-item" role="menuitem">
+                                        + whiteboard
                                     </button>
                                     <button @click="onMenuSettings" class="menu-item" role="menuitem">
                                         settings
@@ -803,9 +815,11 @@ const KnowledgeApp = createApp({
                                 @block-add-to-context="onBlockAddToContext"
                                 @block-remove-from-context="onBlockRemoveFromContext"
                                 @visible-blocks-changed="updateVisibleBlocks"
+                                @page-loaded="onPageLoaded"
                             />
                         </div>
                         <ChatPanel
+                            v-if="showChatPanel"
                             :chat-context-blocks="chatContextBlocks"
                             :visible-blocks="visibleBlocks"
                             @open-settings="onChatPanelOpenSettings"

--- a/packages/django-app/app/knowledge/static/knowledge/js/app.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/app.js
@@ -633,6 +633,7 @@ const KnowledgeApp = createApp({
         if (result.success) {
           const pages = result.data.pages.map((page) => ({
             type: "page",
+            pageType: page.page_type,
             title: page.title,
             slug: page.slug,
             snippet: "",

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Canvas.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Canvas.js
@@ -1,0 +1,162 @@
+// Canvas component — renders a tldraw whiteboard for canvas-type pages.
+// tldraw is a React library; we load React + tldraw via ESM from esm.sh
+// and mount it into a DOM node that Vue manages.
+
+const CANVAS_SAVE_DEBOUNCE_MS = 1500;
+
+const REACT_VERSION = "18.3.1";
+const TLDRAW_VERSION = "3.13.1";
+
+const Canvas = {
+  props: {
+    page: {
+      type: Object,
+      required: true,
+    },
+  },
+  emits: ["page-updated"],
+  data() {
+    return {
+      isLoadingLib: true,
+      saveStatus: "idle",
+      loadError: null,
+      _reactRoot: null,
+      _saveTimer: null,
+      _editor: null,
+      _unsubscribeStore: null,
+    };
+  },
+  async mounted() {
+    try {
+      await this.loadAndMountTldraw();
+    } catch (err) {
+      console.error("Failed to load tldraw:", err);
+      this.loadError = err.message || String(err);
+    } finally {
+      this.isLoadingLib = false;
+    }
+  },
+  beforeUnmount() {
+    if (this._saveTimer) {
+      clearTimeout(this._saveTimer);
+      this.flushSave();
+    }
+    if (this._unsubscribeStore) {
+      this._unsubscribeStore();
+    }
+    if (this._reactRoot) {
+      this._reactRoot.unmount();
+    }
+  },
+  methods: {
+    async loadAndMountTldraw() {
+      const deps = `deps=react@${REACT_VERSION},react-dom@${REACT_VERSION}`;
+      const [reactMod, reactDomClient, tldrawMod] = await Promise.all([
+        import(`https://esm.sh/react@${REACT_VERSION}`),
+        import(
+          `https://esm.sh/react-dom@${REACT_VERSION}/client?deps=react@${REACT_VERSION}`
+        ),
+        import(`https://esm.sh/tldraw@${TLDRAW_VERSION}?${deps}`),
+      ]);
+
+      const React = reactMod.default || reactMod;
+      const { createRoot } = reactDomClient;
+      const { Tldraw, getSnapshot, loadSnapshot } = tldrawMod;
+
+      this._tldrawApi = { getSnapshot, loadSnapshot };
+
+      const container = this.$refs.canvasContainer;
+      if (!container) {
+        throw new Error("Canvas container ref missing");
+      }
+
+      this._reactRoot = createRoot(container);
+      this._reactRoot.render(
+        React.createElement(Tldraw, {
+          onMount: this.onTldrawMount,
+        })
+      );
+    },
+
+    onTldrawMount(editor) {
+      this._editor = editor;
+
+      const snapshot = this.parseStoredSnapshot(this.page.content);
+      if (snapshot) {
+        try {
+          this._tldrawApi.loadSnapshot(editor.store, snapshot);
+        } catch (err) {
+          console.warn("Failed to load canvas snapshot; starting fresh:", err);
+        }
+      }
+
+      this._unsubscribeStore = editor.store.listen(() => this.scheduleSave(), {
+        source: "user",
+        scope: "document",
+      });
+    },
+
+    parseStoredSnapshot(content) {
+      if (!content || !content.trim()) return null;
+      try {
+        return JSON.parse(content);
+      } catch (err) {
+        console.warn("Stored canvas content is not valid JSON:", err);
+        return null;
+      }
+    },
+
+    scheduleSave() {
+      if (this._saveTimer) {
+        clearTimeout(this._saveTimer);
+      }
+      this.saveStatus = "pending";
+      this._saveTimer = setTimeout(() => {
+        this.flushSave();
+      }, CANVAS_SAVE_DEBOUNCE_MS);
+    },
+
+    async flushSave() {
+      this._saveTimer = null;
+      if (!this._editor || !this._tldrawApi) return;
+
+      const snapshot = this._tldrawApi.getSnapshot(this._editor.store);
+      const payload = JSON.stringify(snapshot);
+
+      this.saveStatus = "saving";
+      try {
+        const result = await window.apiService.updatePage(this.page.uuid, {
+          content: payload,
+        });
+        if (result.success) {
+          this.saveStatus = "saved";
+          this.$emit("page-updated", result.data);
+        } else {
+          this.saveStatus = "error";
+          console.error("Canvas save failed:", result.errors);
+        }
+      } catch (err) {
+        this.saveStatus = "error";
+        console.error("Canvas save error:", err);
+      }
+    },
+  },
+
+  template: `
+    <div class="canvas-page">
+      <div v-if="isLoadingLib" class="canvas-loading">loading canvas...</div>
+      <div v-if="loadError" class="canvas-error">
+        failed to load canvas: {{ loadError }}
+      </div>
+      <div class="canvas-status" :class="'canvas-status-' + saveStatus">
+        <span v-if="saveStatus === 'pending'">•</span>
+        <span v-else-if="saveStatus === 'saving'">saving…</span>
+        <span v-else-if="saveStatus === 'saved'">saved</span>
+        <span v-else-if="saveStatus === 'error'">save failed</span>
+      </div>
+      <div ref="canvasContainer" class="canvas-container"></div>
+    </div>
+  `,
+};
+
+window.Canvas = Canvas;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Canvas.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Canvas.js
@@ -1,11 +1,19 @@
 // Canvas component — renders a tldraw whiteboard for canvas-type pages.
 // tldraw is a React library; we load React + tldraw via ESM from esm.sh
 // and mount it into a DOM node that Vue manages.
+//
+// IMPORTANT: the React root, tldraw editor, and store subscription must NOT
+// become Vue reactive proxies — Vue's proxying of tldraw's internal signals
+// causes an infinite render loop (React error #185). We keep them off of
+// `data()` and assign them to the component instance as plain properties,
+// additionally wrapping with Vue.markRaw as a belt-and-suspenders measure.
 
 const CANVAS_SAVE_DEBOUNCE_MS = 1500;
 
-const REACT_VERSION = "18.3.1";
-const TLDRAW_VERSION = "3.13.1";
+const REACT_VERSION = "18";
+const TLDRAW_VERSION = "3";
+
+const markRaw = (val) => (Vue && Vue.markRaw ? Vue.markRaw(val) : val);
 
 const Canvas = {
   props: {
@@ -20,11 +28,17 @@ const Canvas = {
       isLoadingLib: true,
       saveStatus: "idle",
       loadError: null,
-      _reactRoot: null,
-      _saveTimer: null,
-      _editor: null,
-      _unsubscribeStore: null,
     };
+  },
+  created() {
+    // Non-reactive instance state. Declared here (not in data()) so Vue does
+    // NOT wrap them in reactive proxies — tldraw relies on reference identity
+    // of its editor/store/atoms internally.
+    this._reactRoot = null;
+    this._saveTimer = null;
+    this._editor = null;
+    this._unsubscribeStore = null;
+    this._tldrawApi = null;
   },
   async mounted() {
     try {
@@ -42,10 +56,18 @@ const Canvas = {
       this.flushSave();
     }
     if (this._unsubscribeStore) {
-      this._unsubscribeStore();
+      try {
+        this._unsubscribeStore();
+      } catch (err) {
+        console.warn("Failed to unsubscribe tldraw store:", err);
+      }
     }
     if (this._reactRoot) {
-      this._reactRoot.unmount();
+      try {
+        this._reactRoot.unmount();
+      } catch (err) {
+        console.warn("Failed to unmount tldraw react root:", err);
+      }
     }
   },
   methods: {
@@ -63,14 +85,14 @@ const Canvas = {
       const { createRoot } = reactDomClient;
       const { Tldraw, getSnapshot, loadSnapshot } = tldrawMod;
 
-      this._tldrawApi = { getSnapshot, loadSnapshot };
+      this._tldrawApi = markRaw({ getSnapshot, loadSnapshot });
 
       const container = this.$refs.canvasContainer;
       if (!container) {
         throw new Error("Canvas container ref missing");
       }
 
-      this._reactRoot = createRoot(container);
+      this._reactRoot = markRaw(createRoot(container));
       this._reactRoot.render(
         React.createElement(Tldraw, {
           onMount: this.onTldrawMount,
@@ -79,7 +101,7 @@ const Canvas = {
     },
 
     onTldrawMount(editor) {
-      this._editor = editor;
+      this._editor = markRaw(editor);
 
       const snapshot = this.parseStoredSnapshot(this.page.content);
       if (snapshot) {
@@ -90,10 +112,25 @@ const Canvas = {
         }
       }
 
-      this._unsubscribeStore = editor.store.listen(() => this.scheduleSave(), {
-        source: "user",
-        scope: "document",
-      });
+      try {
+        this._unsubscribeStore = editor.store.listen(
+          () => {
+            try {
+              this.scheduleSave();
+            } catch (err) {
+              console.error("Canvas scheduleSave threw:", err);
+            }
+          },
+          { source: "user", scope: "document" }
+        );
+      } catch (err) {
+        // Fallback if the filter signature doesn't match this tldraw version
+        console.warn(
+          "Store filter subscribe failed, falling back to unfiltered:",
+          err
+        );
+        this._unsubscribeStore = editor.store.listen(() => this.scheduleSave());
+      }
     },
 
     parseStoredSnapshot(content) {
@@ -120,8 +157,15 @@ const Canvas = {
       this._saveTimer = null;
       if (!this._editor || !this._tldrawApi) return;
 
-      const snapshot = this._tldrawApi.getSnapshot(this._editor.store);
-      const payload = JSON.stringify(snapshot);
+      let payload;
+      try {
+        const snapshot = this._tldrawApi.getSnapshot(this._editor.store);
+        payload = JSON.stringify(snapshot);
+      } catch (err) {
+        console.error("Failed to snapshot canvas:", err);
+        this.saveStatus = "error";
+        return;
+      }
 
       this.saveStatus = "saving";
       try {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -2,6 +2,7 @@
 const Page = {
   components: {
     BlockComponent: window.BlockComponent || {},
+    Canvas: window.Canvas || {},
   },
   props: {
     chatContextBlocks: {
@@ -46,6 +47,10 @@ const Page = {
   computed: {
     isDaily() {
       return this.page?.page_type === "daily";
+    },
+
+    isCanvas() {
+      return this.page?.page_type === "canvas";
     },
 
     pageTitle() {
@@ -1194,6 +1199,12 @@ const Page = {
       this.newTitle = this.page?.title || "";
     },
 
+    onCanvasPageUpdated(updatedPage) {
+      if (this.page && updatedPage) {
+        this.page.modified_at = updatedPage.modified_at;
+      }
+    },
+
     async updatePageTitle() {
       if (!this.page || !this.newTitle.trim()) {
         this.isEditingTitle = false;
@@ -1265,6 +1276,42 @@ const Page = {
       <!-- Error State -->
       <div v-if="error" class="error">
         {{ error }}
+      </div>
+
+      <!-- Canvas Page (full-screen tldraw) -->
+      <div v-else-if="page && isCanvas" class="page-content page-content-canvas">
+        <div class="page-header canvas-page-header">
+          <div class="page-title-container page-header-flex">
+            <div class="page-header-flex-left">
+              <div v-if="!isEditingTitle" class="page-title-display">
+                <h1 class="page-title-text" tabindex="0" role="button" aria-label="Edit page title" @click="startEditingTitle" @keydown.enter.prevent="startEditingTitle" @keydown.space.prevent="startEditingTitle">{{ page.title || 'Untitled Canvas' }}</h1>
+              </div>
+              <div v-else class="page-title-edit">
+                <input
+                  ref="titleInput"
+                  v-model="newTitle"
+                  @keyup.enter="updatePageTitle"
+                  @keyup.escape="cancelEditingTitle"
+                  class="form-control page-title-input"
+                  placeholder="enter canvas title"
+                />
+                <button @click="updatePageTitle" class="btn btn-success save-title-btn" title="Save title">✓</button>
+                <button @click="cancelEditingTitle" class="btn btn-outline cancel-title-btn" title="Cancel">✗</button>
+              </div>
+              <span class="page-type-badge">canvas</span>
+            </div>
+            <div class="page-actions">
+              <div class="context-menu-container">
+                <button @click="togglePageMenu" class="btn btn-outline context-menu-btn" title="Canvas options" :aria-expanded="showPageMenu" aria-haspopup="menu">⋮</button>
+                <div v-if="showPageMenu" class="context-menu" @click.stop @keydown="handlePageMenuKeydown" role="menu">
+                  <button @click="startEditingTitle" class="context-menu-item" role="menuitem">edit title</button>
+                  <button @click="deletePage" class="context-menu-item context-menu-danger" role="menuitem">delete canvas</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <Canvas :page="page" @page-updated="onCanvasPageUpdated" />
       </div>
 
       <!-- Page Content -->

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -2,7 +2,7 @@
 const Page = {
   components: {
     BlockComponent: window.BlockComponent || {},
-    Canvas: window.Canvas || {},
+    Whiteboard: window.Whiteboard || {},
   },
   props: {
     chatContextBlocks: {
@@ -18,6 +18,7 @@ const Page = {
     "block-add-to-context",
     "block-remove-from-context",
     "visible-blocks-changed",
+    "page-loaded",
   ],
   data() {
     return {
@@ -49,8 +50,8 @@ const Page = {
       return this.page?.page_type === "daily";
     },
 
-    isCanvas() {
-      return this.page?.page_type === "canvas";
+    isWhiteboard() {
+      return this.page?.page_type === "whiteboard";
     },
 
     pageTitle() {
@@ -142,6 +143,7 @@ const Page = {
             result.data.direct_blocks || []
           );
           this.referencedBlocks = result.data.referenced_blocks || [];
+          this.$emit("page-loaded", this.page);
         } else {
           this.error = "failed to load page";
         }
@@ -1199,7 +1201,7 @@ const Page = {
       this.newTitle = this.page?.title || "";
     },
 
-    onCanvasPageUpdated(updatedPage) {
+    onWhiteboardPageUpdated(updatedPage) {
       if (this.page && updatedPage) {
         this.page.modified_at = updatedPage.modified_at;
       }
@@ -1278,13 +1280,13 @@ const Page = {
         {{ error }}
       </div>
 
-      <!-- Canvas Page (full-screen tldraw) -->
-      <div v-else-if="page && isCanvas" class="page-content page-content-canvas">
-        <div class="page-header canvas-page-header">
+      <!-- Whiteboard Page (full-screen tldraw) -->
+      <div v-else-if="page && isWhiteboard" class="page-content page-content-whiteboard">
+        <div class="page-header whiteboard-page-header">
           <div class="page-title-container page-header-flex">
             <div class="page-header-flex-left">
               <div v-if="!isEditingTitle" class="page-title-display">
-                <h1 class="page-title-text" tabindex="0" role="button" aria-label="Edit page title" @click="startEditingTitle" @keydown.enter.prevent="startEditingTitle" @keydown.space.prevent="startEditingTitle">{{ page.title || 'Untitled Canvas' }}</h1>
+                <h1 class="page-title-text" tabindex="0" role="button" aria-label="Edit page title" @click="startEditingTitle" @keydown.enter.prevent="startEditingTitle" @keydown.space.prevent="startEditingTitle">{{ page.title || 'Untitled Whiteboard' }}</h1>
               </div>
               <div v-else class="page-title-edit">
                 <input
@@ -1293,25 +1295,25 @@ const Page = {
                   @keyup.enter="updatePageTitle"
                   @keyup.escape="cancelEditingTitle"
                   class="form-control page-title-input"
-                  placeholder="enter canvas title"
+                  placeholder="enter whiteboard title"
                 />
                 <button @click="updatePageTitle" class="btn btn-success save-title-btn" title="Save title">✓</button>
                 <button @click="cancelEditingTitle" class="btn btn-outline cancel-title-btn" title="Cancel">✗</button>
               </div>
-              <span class="page-type-badge">canvas</span>
+              <span class="page-type-badge">whiteboard</span>
             </div>
             <div class="page-actions">
               <div class="context-menu-container">
-                <button @click="togglePageMenu" class="btn btn-outline context-menu-btn" title="Canvas options" :aria-expanded="showPageMenu" aria-haspopup="menu">⋮</button>
+                <button @click="togglePageMenu" class="btn btn-outline context-menu-btn" title="Whiteboard options" :aria-expanded="showPageMenu" aria-haspopup="menu">⋮</button>
                 <div v-if="showPageMenu" class="context-menu" @click.stop @keydown="handlePageMenuKeydown" role="menu">
                   <button @click="startEditingTitle" class="context-menu-item" role="menuitem">edit title</button>
-                  <button @click="deletePage" class="context-menu-item context-menu-danger" role="menuitem">delete canvas</button>
+                  <button @click="deletePage" class="context-menu-item context-menu-danger" role="menuitem">delete whiteboard</button>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <Canvas :page="page" @page-updated="onCanvasPageUpdated" />
+        <Whiteboard :page="page" @page-updated="onWhiteboardPageUpdated" />
       </div>
 
       <!-- Page Content -->

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SpotlightSearch.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SpotlightSearch.js
@@ -143,7 +143,7 @@ window.SpotlightSearch = {
               <div class="spotlight-result-icon spotlight-command-icon" v-if="result.type === 'command'">
                 {{ result.icon }}
               </div>
-              <div class="spotlight-result-icon" v-else-if="result.pageType === 'canvas'">
+              <div class="spotlight-result-icon" v-else-if="result.pageType === 'whiteboard'">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
                   <path d="M2 3h12v10H2z" stroke="currentColor" stroke-width="1.5" fill="none"/>
                   <path d="M4 10l2-3 2 2 3-4 1 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SpotlightSearch.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SpotlightSearch.js
@@ -143,6 +143,12 @@ window.SpotlightSearch = {
               <div class="spotlight-result-icon spotlight-command-icon" v-if="result.type === 'command'">
                 {{ result.icon }}
               </div>
+              <div class="spotlight-result-icon" v-else-if="result.pageType === 'canvas'">
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                  <path d="M2 3h12v10H2z" stroke="currentColor" stroke-width="1.5" fill="none"/>
+                  <path d="M4 10l2-3 2 2 3-4 1 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                </svg>
+              </div>
               <div class="spotlight-result-icon" v-else>
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
                   <path d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3z" stroke="currentColor" stroke-width="1.5" fill="none"/>
@@ -156,6 +162,7 @@ window.SpotlightSearch = {
                 <div class="spotlight-result-path" v-if="result.type === 'page'">{{ result.url }}</div>
               </div>
               <div class="spotlight-result-type" v-if="result.type === 'command'">command</div>
+              <div class="spotlight-result-type" v-else-if="result.pageType && result.pageType !== 'page'">{{ result.pageType }}</div>
             </div>
           </div>
         </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Whiteboard.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Whiteboard.js
@@ -1,6 +1,6 @@
-// Canvas component — renders a tldraw whiteboard for canvas-type pages.
-// tldraw is a React library; we load React + tldraw via ESM from esm.sh
-// and mount it into a DOM node that Vue manages.
+// Whiteboard component — renders a tldraw whiteboard for whiteboard-type
+// pages. tldraw is a React library; we load React + tldraw via ESM from
+// esm.sh and mount it into a DOM node that Vue manages.
 //
 // IMPORTANT: the React root, tldraw editor, and store subscription must NOT
 // become Vue reactive proxies — Vue's proxying of tldraw's internal signals
@@ -8,14 +8,14 @@
 // `data()` and assign them to the component instance as plain properties,
 // additionally wrapping with Vue.markRaw as a belt-and-suspenders measure.
 
-const CANVAS_SAVE_DEBOUNCE_MS = 1500;
+const WHITEBOARD_SAVE_DEBOUNCE_MS = 1500;
 
 const REACT_VERSION = "18";
 const TLDRAW_VERSION = "3";
 
 const markRaw = (val) => (Vue && Vue.markRaw ? Vue.markRaw(val) : val);
 
-const Canvas = {
+const Whiteboard = {
   props: {
     page: {
       type: Object,
@@ -39,8 +39,15 @@ const Canvas = {
     this._editor = null;
     this._unsubscribeStore = null;
     this._tldrawApi = null;
+    this._lastSavedPayload = null;
+    this._boundVisibilityHandler = this.handleVisibilityChange.bind(this);
+    this._boundBeforeUnloadHandler = this.handleBeforeUnload.bind(this);
+    this._boundThemeObserver = null;
   },
   async mounted() {
+    document.addEventListener("visibilitychange", this._boundVisibilityHandler);
+    window.addEventListener("beforeunload", this._boundBeforeUnloadHandler);
+
     try {
       await this.loadAndMountTldraw();
     } catch (err) {
@@ -51,6 +58,17 @@ const Canvas = {
     }
   },
   beforeUnmount() {
+    document.removeEventListener(
+      "visibilitychange",
+      this._boundVisibilityHandler
+    );
+    window.removeEventListener("beforeunload", this._boundBeforeUnloadHandler);
+
+    if (this._boundThemeObserver) {
+      this._boundThemeObserver.disconnect();
+      this._boundThemeObserver = null;
+    }
+
     if (this._saveTimer) {
       clearTimeout(this._saveTimer);
       this.flushSave();
@@ -87,9 +105,9 @@ const Canvas = {
 
       this._tldrawApi = markRaw({ getSnapshot, loadSnapshot });
 
-      const container = this.$refs.canvasContainer;
+      const container = this.$refs.whiteboardContainer;
       if (!container) {
-        throw new Error("Canvas container ref missing");
+        throw new Error("Whiteboard container ref missing");
       }
 
       this._reactRoot = markRaw(createRoot(container));
@@ -103,12 +121,18 @@ const Canvas = {
     onTldrawMount(editor) {
       this._editor = markRaw(editor);
 
+      this.applyThemeToEditor();
+      this.watchThemeChanges();
+
       const snapshot = this.parseStoredSnapshot(this.page.content);
       if (snapshot) {
         try {
           this._tldrawApi.loadSnapshot(editor.store, snapshot);
         } catch (err) {
-          console.warn("Failed to load canvas snapshot; starting fresh:", err);
+          console.warn(
+            "Failed to load whiteboard snapshot; starting fresh:",
+            err
+          );
         }
       }
 
@@ -118,7 +142,7 @@ const Canvas = {
             try {
               this.scheduleSave();
             } catch (err) {
-              console.error("Canvas scheduleSave threw:", err);
+              console.error("Whiteboard scheduleSave threw:", err);
             }
           },
           { source: "user", scope: "document" }
@@ -133,12 +157,35 @@ const Canvas = {
       }
     },
 
+    applyThemeToEditor() {
+      if (!this._editor) return;
+      const appTheme =
+        document.documentElement.getAttribute("data-theme") || "light";
+      const colorScheme = appTheme === "dark" ? "dark" : "light";
+      try {
+        this._editor.user.updateUserPreferences({ colorScheme });
+      } catch (err) {
+        console.warn("Failed to set tldraw color scheme:", err);
+      }
+    },
+
+    watchThemeChanges() {
+      // Mirror app theme changes into tldraw while the whiteboard is open.
+      if (this._boundThemeObserver) return;
+      const observer = new MutationObserver(() => this.applyThemeToEditor());
+      observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["data-theme"],
+      });
+      this._boundThemeObserver = observer;
+    },
+
     parseStoredSnapshot(content) {
       if (!content || !content.trim()) return null;
       try {
         return JSON.parse(content);
       } catch (err) {
-        console.warn("Stored canvas content is not valid JSON:", err);
+        console.warn("Stored whiteboard content is not valid JSON:", err);
         return null;
       }
     },
@@ -150,20 +197,29 @@ const Canvas = {
       this.saveStatus = "pending";
       this._saveTimer = setTimeout(() => {
         this.flushSave();
-      }, CANVAS_SAVE_DEBOUNCE_MS);
+      }, WHITEBOARD_SAVE_DEBOUNCE_MS);
+    },
+
+    buildPayload() {
+      if (!this._editor || !this._tldrawApi) return null;
+      try {
+        const snapshot = this._tldrawApi.getSnapshot(this._editor.store);
+        return JSON.stringify(snapshot);
+      } catch (err) {
+        console.error("Failed to snapshot whiteboard:", err);
+        return null;
+      }
     },
 
     async flushSave() {
       this._saveTimer = null;
-      if (!this._editor || !this._tldrawApi) return;
-
-      let payload;
-      try {
-        const snapshot = this._tldrawApi.getSnapshot(this._editor.store);
-        payload = JSON.stringify(snapshot);
-      } catch (err) {
-        console.error("Failed to snapshot canvas:", err);
+      const payload = this.buildPayload();
+      if (payload === null) {
         this.saveStatus = "error";
+        return;
+      }
+      if (payload === this._lastSavedPayload) {
+        this.saveStatus = "saved";
         return;
       }
 
@@ -173,34 +229,53 @@ const Canvas = {
           content: payload,
         });
         if (result.success) {
+          this._lastSavedPayload = payload;
           this.saveStatus = "saved";
           this.$emit("page-updated", result.data);
         } else {
           this.saveStatus = "error";
-          console.error("Canvas save failed:", result.errors);
+          console.error("Whiteboard save failed:", result.errors);
         }
       } catch (err) {
         this.saveStatus = "error";
-        console.error("Canvas save error:", err);
+        console.error("Whiteboard save error:", err);
       }
+    },
+
+    handleVisibilityChange() {
+      // Flush pending edits when the tab is backgrounded so a swipe-away on
+      // iPad doesn't drop the last 1.5s of work.
+      if (document.visibilityState === "hidden") {
+        if (this._saveTimer) clearTimeout(this._saveTimer);
+        this.flushSave();
+      }
+    },
+
+    handleBeforeUnload() {
+      // Best-effort flush on navigation/close. Modern browsers may still
+      // cancel the in-flight fetch; a proper sendBeacon upgrade is a
+      // follow-up, but for now this catches the common "tab close with a
+      // second of pending edits" case.
+      if (this._saveTimer) clearTimeout(this._saveTimer);
+      this.flushSave();
     },
   },
 
   template: `
-    <div class="canvas-page">
-      <div v-if="isLoadingLib" class="canvas-loading">loading canvas...</div>
-      <div v-if="loadError" class="canvas-error">
-        failed to load canvas: {{ loadError }}
+    <div class="whiteboard-page">
+      <div v-if="isLoadingLib" class="whiteboard-loading">loading whiteboard...</div>
+      <div v-if="loadError" class="whiteboard-error">
+        failed to load whiteboard: {{ loadError }}
       </div>
-      <div class="canvas-status" :class="'canvas-status-' + saveStatus">
+      <div class="whiteboard-status" :class="'whiteboard-status-' + saveStatus">
         <span v-if="saveStatus === 'pending'">•</span>
         <span v-else-if="saveStatus === 'saving'">saving…</span>
         <span v-else-if="saveStatus === 'saved'">saved</span>
         <span v-else-if="saveStatus === 'error'">save failed</span>
       </div>
-      <div ref="canvasContainer" class="canvas-container"></div>
+      <div ref="whiteboardContainer" class="whiteboard-container"></div>
     </div>
   `,
 };
 
-window.Canvas = Canvas;
+window.Whiteboard = Whiteboard;

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -108,7 +108,13 @@ class ApiService {
     return await this.request("/api/auth/me/");
   }
 
-  async createPage(title, content, slug, isPublished = true) {
+  async createPage(
+    title,
+    content,
+    slug,
+    isPublished = true,
+    pageType = "page"
+  ) {
     return await this.request("/knowledge/api/pages/", {
       method: "POST",
       body: JSON.stringify({
@@ -116,6 +122,7 @@ class ApiService {
         content,
         slug,
         is_published: isPublished,
+        page_type: pageType,
       }),
     });
   }

--- a/packages/django-app/app/knowledge/templates/knowledge/base.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/base.html
@@ -30,7 +30,7 @@
     <!-- Vue Components -->
     <script src="{% static 'knowledge/js/components/BlockComponent.js' %}"></script>
     <script src="{% static 'knowledge/js/components/LoginForm.js' %}"></script>
-    <script src="{% static 'knowledge/js/components/Canvas.js' %}"></script>
+    <script src="{% static 'knowledge/js/components/Whiteboard.js' %}"></script>
     <script src="{% static 'knowledge/js/components/Page.js' %}"></script>
     <script src="{% static 'knowledge/js/components/TaggedBlockDisplay.js' %}"></script>
     <script src="{% static 'knowledge/js/components/HistoricalSidebar.js' %}"></script>

--- a/packages/django-app/app/knowledge/templates/knowledge/base.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/base.html
@@ -6,6 +6,7 @@
     <title>{% block title %}brainspread{% endblock %}</title>
     {% load static %} {% csrf_token %}
     <link rel="stylesheet" href="{% static 'knowledge/css/app.css' %}" />
+    <link rel="stylesheet" href="https://esm.sh/tldraw@3.13.1/tldraw.css" />
     {% block extra_css %}{% endblock %}
   </head>
   <body>
@@ -29,6 +30,7 @@
     <!-- Vue Components -->
     <script src="{% static 'knowledge/js/components/BlockComponent.js' %}"></script>
     <script src="{% static 'knowledge/js/components/LoginForm.js' %}"></script>
+    <script src="{% static 'knowledge/js/components/Canvas.js' %}"></script>
     <script src="{% static 'knowledge/js/components/Page.js' %}"></script>
     <script src="{% static 'knowledge/js/components/TaggedBlockDisplay.js' %}"></script>
     <script src="{% static 'knowledge/js/components/HistoricalSidebar.js' %}"></script>

--- a/packages/django-app/app/knowledge/templates/knowledge/base.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/base.html
@@ -6,7 +6,7 @@
     <title>{% block title %}brainspread{% endblock %}</title>
     {% load static %} {% csrf_token %}
     <link rel="stylesheet" href="{% static 'knowledge/css/app.css' %}" />
-    <link rel="stylesheet" href="https://esm.sh/tldraw@3.13.1/tldraw.css" />
+    <link rel="stylesheet" href="https://esm.sh/tldraw@3/tldraw.css" />
     {% block extra_css %}{% endblock %}
   </head>
   <body>

--- a/packages/django-app/app/knowledge/test/commands/test_create_page_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_create_page_command.py
@@ -1,0 +1,52 @@
+from django.test import TestCase
+
+from knowledge.commands import CreatePageCommand
+from knowledge.forms import CreatePageForm
+
+from ..helpers import UserFactory
+
+
+class TestCreatePageCommand(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
+    def test_should_create_page_with_default_page_type(self):
+        form = CreatePageForm(
+            {
+                "user": self.user.id,
+                "title": "My Page",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        page = CreatePageCommand(form).execute()
+
+        self.assertEqual(page.page_type, "page")
+        self.assertEqual(page.title, "My Page")
+        self.assertEqual(page.slug, "my-page")
+
+    def test_should_create_canvas_page_when_page_type_is_canvas(self):
+        form = CreatePageForm(
+            {
+                "user": self.user.id,
+                "title": "Brain Dump Board",
+                "page_type": "canvas",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        page = CreatePageCommand(form).execute()
+
+        self.assertEqual(page.page_type, "canvas")
+        self.assertEqual(page.title, "Brain Dump Board")
+        self.assertEqual(page.slug, "brain-dump-board")
+
+    def test_should_reject_invalid_page_type(self):
+        form = CreatePageForm(
+            {
+                "user": self.user.id,
+                "title": "Bad Page",
+                "page_type": "not-a-real-type",
+            }
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("page_type", form.errors)

--- a/packages/django-app/app/knowledge/test/commands/test_create_page_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_create_page_command.py
@@ -25,18 +25,18 @@ class TestCreatePageCommand(TestCase):
         self.assertEqual(page.title, "My Page")
         self.assertEqual(page.slug, "my-page")
 
-    def test_should_create_canvas_page_when_page_type_is_canvas(self):
+    def test_should_create_whiteboard_page_when_page_type_is_whiteboard(self):
         form = CreatePageForm(
             {
                 "user": self.user.id,
                 "title": "Brain Dump Board",
-                "page_type": "canvas",
+                "page_type": "whiteboard",
             }
         )
         self.assertTrue(form.is_valid(), form.errors)
         page = CreatePageCommand(form).execute()
 
-        self.assertEqual(page.page_type, "canvas")
+        self.assertEqual(page.page_type, "whiteboard")
         self.assertEqual(page.title, "Brain Dump Board")
         self.assertEqual(page.slug, "brain-dump-board")
 

--- a/packages/django-app/app/knowledge/test/commands/test_update_page_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_update_page_command.py
@@ -1,0 +1,54 @@
+from django.test import TestCase
+
+from knowledge.commands import UpdatePageCommand
+from knowledge.forms import UpdatePageForm
+
+from ..helpers import PageFactory, UserFactory
+
+
+class TestUpdatePageCommand(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.page = PageFactory(user=cls.user, title="Original", content="old")
+
+    def test_should_update_content_without_touching_title_when_title_omitted(self):
+        # Canvas snapshot saves only send `content` in the payload. The form
+        # must not reject this as "Title cannot be empty".
+        form = UpdatePageForm(
+            {
+                "user": self.user.id,
+                "page": self.page.uuid,
+                "content": '{"snapshot": true}',
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        page = UpdatePageCommand(form).execute()
+        self.assertEqual(page.title, "Original")
+        self.assertEqual(page.content, '{"snapshot": true}')
+
+    def test_should_reject_explicitly_empty_title(self):
+        form = UpdatePageForm(
+            {
+                "user": self.user.id,
+                "page": self.page.uuid,
+                "title": "   ",
+            }
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("title", form.errors)
+
+    def test_should_update_title_when_provided(self):
+        form = UpdatePageForm(
+            {
+                "user": self.user.id,
+                "page": self.page.uuid,
+                "title": "New Title",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        page = UpdatePageCommand(form).execute()
+        self.assertEqual(page.title, "New Title")
+        self.assertEqual(page.slug, "new-title")

--- a/packages/django-app/app/knowledge/test/commands/test_update_page_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_update_page_command.py
@@ -13,7 +13,7 @@ class TestUpdatePageCommand(TestCase):
         cls.page = PageFactory(user=cls.user, title="Original", content="old")
 
     def test_should_update_content_without_touching_title_when_title_omitted(self):
-        # Canvas snapshot saves only send `content` in the payload. The form
+        # Whiteboard snapshot saves only send `content` in the payload. The form
         # must not reject this as "Title cannot be empty".
         form = UpdatePageForm(
             {

--- a/packages/django-app/app/knowledge/test/repositories/test_page_repository.py
+++ b/packages/django-app/app/knowledge/test/repositories/test_page_repository.py
@@ -173,13 +173,16 @@ class TestPageRepository(TestCase):
         self.assertEqual(unpublished_pages.count(), 1)
         self.assertFalse(unpublished_pages.first().is_published)
 
-    def test_get_recent_pages_should_include_canvas_pages_without_blocks(self):
-        # Canvas pages have no Block rows — their content lives in Page.content.
-        # They should still show up in history alongside pages that have blocks.
+    def test_get_recent_pages_should_include_whiteboard_pages_without_blocks(self):
+        # Whiteboard pages have no Block rows — their content lives in
+        # Page.content. They should still show up in history alongside pages
+        # that have blocks.
         page_with_blocks = PageFactory(user=self.user, title="Has Blocks")
         BlockFactory(user=self.user, page=page_with_blocks)
 
-        canvas_page = PageFactory(user=self.user, title="My Canvas", page_type="canvas")
+        whiteboard_page = PageFactory(
+            user=self.user, title="My Whiteboard", page_type="whiteboard"
+        )
 
         empty_regular_page = PageFactory(user=self.user, title="No Blocks Here")
 
@@ -187,5 +190,5 @@ class TestPageRepository(TestCase):
         uuids = {str(p.uuid) for p in pages}
 
         self.assertIn(str(page_with_blocks.uuid), uuids)
-        self.assertIn(str(canvas_page.uuid), uuids)
+        self.assertIn(str(whiteboard_page.uuid), uuids)
         self.assertNotIn(str(empty_regular_page.uuid), uuids)

--- a/packages/django-app/app/knowledge/test/repositories/test_page_repository.py
+++ b/packages/django-app/app/knowledge/test/repositories/test_page_repository.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from knowledge.models import Page
 from knowledge.repositories import PageRepository
 
-from ..helpers import PageFactory, UserFactory
+from ..helpers import BlockFactory, PageFactory, UserFactory
 
 
 class TestPageRepository(TestCase):
@@ -172,3 +172,20 @@ class TestPageRepository(TestCase):
 
         self.assertEqual(unpublished_pages.count(), 1)
         self.assertFalse(unpublished_pages.first().is_published)
+
+    def test_get_recent_pages_should_include_canvas_pages_without_blocks(self):
+        # Canvas pages have no Block rows — their content lives in Page.content.
+        # They should still show up in history alongside pages that have blocks.
+        page_with_blocks = PageFactory(user=self.user, title="Has Blocks")
+        BlockFactory(user=self.user, page=page_with_blocks)
+
+        canvas_page = PageFactory(user=self.user, title="My Canvas", page_type="canvas")
+
+        empty_regular_page = PageFactory(user=self.user, title="No Blocks Here")
+
+        pages = list(PageRepository.get_recent_pages(self.user))
+        uuids = {p.uuid for p in pages}
+
+        self.assertIn(page_with_blocks.uuid, uuids)
+        self.assertIn(canvas_page.uuid, uuids)
+        self.assertNotIn(empty_regular_page.uuid, uuids)

--- a/packages/django-app/app/knowledge/test/repositories/test_page_repository.py
+++ b/packages/django-app/app/knowledge/test/repositories/test_page_repository.py
@@ -184,8 +184,8 @@ class TestPageRepository(TestCase):
         empty_regular_page = PageFactory(user=self.user, title="No Blocks Here")
 
         pages = list(PageRepository.get_recent_pages(self.user))
-        uuids = {p.uuid for p in pages}
+        uuids = {str(p.uuid) for p in pages}
 
-        self.assertIn(page_with_blocks.uuid, uuids)
-        self.assertIn(canvas_page.uuid, uuids)
-        self.assertNotIn(empty_regular_page.uuid, uuids)
+        self.assertIn(str(page_with_blocks.uuid), uuids)
+        self.assertIn(str(canvas_page.uuid), uuids)
+        self.assertNotIn(str(empty_regular_page.uuid), uuids)


### PR DESCRIPTION
Closes #31

## Summary
Adds a new `whiteboard` page type backed by [tldraw](https://tldraw.dev), giving brainspread a freestyle infinite canvas aimed at iPad + Apple Pencil brain-dumps. Whiteboards live alongside regular and daily pages, show up in history and spotlight search, and auto-save their state to the existing Page API.

## What's in the box

### Backend
- `Page.page_type` gains `"whiteboard"` (migration `0018` added the choice; `0019` is the rename migration that rewrote any `"canvas"` rows to `"whiteboard"` before altering the choice set — reversible)
- `CreatePageForm` / `CreatePageCommand` accept `page_type` so the frontend can create whiteboards via the existing endpoint
- `UpdatePageForm.clean_title` fix: partial updates that only send `{page, content}` (e.g. whiteboard snapshot saves) no longer get rejected with "Title cannot be empty" because Django's `CharField(required=False)` coerces missing fields to `""`
- `PageRepository.get_recent_pages` (renamed from `get_recent_pages_with_blocks`) now matches `block_count > 0 OR page_type = 'whiteboard'` so whiteboards show up in history
- Tests: `CreatePageCommand` (page/whiteboard/invalid-type), `UpdatePageCommand` (partial update, blank-title reject, title update), `PageRepository.get_recent_pages` (whiteboard inclusion)

### Frontend
- `Whiteboard.js` Vue component dynamically imports React + tldraw from esm.sh (no build step added). Mounts a React root into a Vue-managed div; uses `Vue.markRaw` and keeps editor/root/store-sub off of `data()` to avoid Vue proxying tldraw's internal signals (the root cause of the initial React error #185 infinite render loop)
- Debounced save (1.5s) of `getSnapshot()` JSON into `Page.content` via the existing `updatePage` endpoint; loads back via `loadSnapshot` on mount
- **Flush on `visibilitychange` / `beforeunload`** so swiping away on iPad doesn't drop the last 1.5s of work
- **No-op skip** if the serialized snapshot hasn't changed since the last save
- **Dark-mode pass-through** — mirrors the app's `data-theme` attribute into `editor.user.updateUserPreferences({ colorScheme })`, with a `MutationObserver` so toggling theme while the whiteboard is open follows along
- **Chat panel auto-hides** on whiteboard pages (via a `page-loaded` emit from `Page.js` → `showChatPanel` computed in `app.js`) so the canvas gets the full column width
- Entry points: `Cmd+K → "new whiteboard"` (supports inline title `"new whiteboard My Board"`) and a `+ whiteboard` nav menu item
- Spotlight results now pipe `page_type` through and render a whiteboard-specific icon + type badge in the right gutter

### Template / CSS
- `base.html` loads `tldraw.css` from esm.sh and the `Whiteboard.js` script alongside the existing components
- Full-height whiteboard container with `touch-action: none` and user-select disabled for Apple Pencil / touch

## Snapshot storage

tldraw snapshots are stringified and stored in the existing `Page.content` TextField — no new model, no new endpoint. Fine for the prototype; a dedicated `WhiteboardSnapshot` model (with object-storage for images) is a likely follow-up once we add image upload.

## Known follow-ups (deliberately out of scope)

- Image upload (pasted images currently land as data URLs in the snapshot — will bloat `Page.content` past reasonable sizes)
- Text-extracted full-text search (spotlight currently hits `title`/`slug` only — not text written on the whiteboard)
- `#tag` / `[[page]]` handling inside whiteboard text shapes (so whiteboards show up as backlinks)
- `sendBeacon`-based unload flush (current `beforeunload` flush is best-effort)
- Snapshot versioning / restore

https://claude.ai/code/session_01Q7bfP91Z6N72wHmBWXRzXe