### PR TITLE
Update Anthropic models to latest versions

### DIFF
--- a/packages/django-app/app/ai_chat/management/commands/populate_ai_providers_and_models.py
+++ b/packages/django-app/app/ai_chat/management/commands/populate_ai_providers_and_models.py
@@ -47,45 +47,27 @@ class Command(BaseCommand):
             # Anthropic models
             (
                 "Anthropic",
-                "claude-opus-4-20250514",
-                "Claude Opus 4",
-                "Most capable Claude 4 model",
+                "claude-opus-4-7",
+                "Claude Opus 4.7",
+                "Most capable Claude model; adaptive thinking, 1M context",
             ),
             (
                 "Anthropic",
-                "claude-sonnet-4-20250514",
-                "Claude Sonnet 4",
-                "Latest Claude 4 model",
+                "claude-opus-4-6",
+                "Claude Opus 4.6",
+                "Previous-generation Opus; adaptive thinking, 1M context",
             ),
             (
                 "Anthropic",
-                "claude-3-5-sonnet-20241022",
-                "Claude 3.5 Sonnet",
-                "Most intelligent Claude 3.5 model",
+                "claude-sonnet-4-6",
+                "Claude Sonnet 4.6",
+                "Best balance of speed and intelligence; 1M context",
             ),
             (
                 "Anthropic",
-                "claude-3-5-haiku-20241022",
-                "Claude 3.5 Haiku",
-                "Fast and lightweight Claude model",
-            ),
-            (
-                "Anthropic",
-                "claude-3-opus-20240229",
-                "Claude 3 Opus",
-                "Most capable Claude 3 model",
-            ),
-            (
-                "Anthropic",
-                "claude-3-sonnet-20240229",
-                "Claude 3 Sonnet",
-                "Balanced Claude 3 model",
-            ),
-            (
-                "Anthropic",
-                "claude-3-haiku-20240307",
-                "Claude 3 Haiku",
-                "Fast Claude 3 model",
+                "claude-haiku-4-5",
+                "Claude Haiku 4.5",
+                "Fastest and most cost-effective Claude model",
             ),
             # Google models
             (

--- a/packages/django-app/app/ai_chat/models/ai_model.py
+++ b/packages/django-app/app/ai_chat/models/ai_model.py
@@ -12,7 +12,7 @@ class AIModel(UUIDModelMixin, CRUDTimestampsMixin):
     name = models.CharField(
         max_length=100,
         unique=True,
-        help_text="Model name (e.g., gpt-4, claude-3-sonnet)",
+        help_text="Model name (e.g., gpt-4, claude-opus-4-7)",
     )
     provider = models.ForeignKey(
         AIProvider, on_delete=models.CASCADE, related_name="models"

--- a/packages/django-app/app/ai_chat/services/anthropic_service.py
+++ b/packages/django-app/app/ai_chat/services/anthropic_service.py
@@ -15,7 +15,7 @@ class AnthropicServiceError(AIServiceError):
 
 
 class AnthropicService(BaseAIService):
-    def __init__(self, api_key: str, model: str = "claude-sonnet-4-20250514") -> None:
+    def __init__(self, api_key: str, model: str = "claude-opus-4-7") -> None:
         super().__init__(api_key, model)
         try:
             self.client = anthropic.Anthropic(api_key=api_key)


### PR DESCRIPTION
## Summary
This PR updates the Anthropic AI model configurations to use the latest model versions, removing deprecated/older models and updating default model references.

## Key Changes
- **Model Population**: Updated `populate_ai_providers_and_models.py` to register the latest Anthropic models:
  - Replaced `claude-opus-4-20250514` with `claude-opus-4-7` (most capable model)
  - Replaced `claude-sonnet-4-20250514` with `claude-sonnet-4-6` (balanced speed/intelligence)
  - Replaced `claude-3-5-sonnet-20241022` with `claude-opus-4-6` (previous-generation Opus)
  - Replaced `claude-3-5-haiku-20241022` with `claude-haiku-4-5` (fastest/most cost-effective)
  - Removed deprecated Claude 3 models (`claude-3-opus-20240229`, `claude-3-sonnet-20240229`, `claude-3-haiku-20240307`)

- **Default Model**: Updated the default model in `AnthropicService` from `claude-sonnet-4-20250514` to `claude-opus-4-7`

- **Documentation**: Updated model name example in `AIModel` help text from `claude-3-sonnet` to `claude-opus-4-7`

## Implementation Details
- All model descriptions have been updated to reflect current capabilities (e.g., "1M context", "adaptive thinking")
- The changes maintain backward compatibility at the service level while updating the available model options
- Removed 3 older Claude 3 model variants in favor of the newer Claude 4 and Haiku 4.5 versions

https://claude.ai/code/session_01Q5CT8wfiAWaRxSnun447a7