### PR TITLE
Persist empty provider model selection in AI settings

### DIFF
--- a/packages/django-app/app/ai_chat/views.py
+++ b/packages/django-app/app/ai_chat/views.py
@@ -294,12 +294,10 @@ def update_ai_settings(request):
 
                 # Handle enabled_models M2M relationship
                 enabled_model_names = config_data.get("enabled_models", [])
-                if enabled_model_names:
-                    # Get AIModel objects for the given names and provider
-                    ai_models = AIModel.objects.filter(
-                        name__in=enabled_model_names, provider=provider, is_active=True
-                    )
-                    provider_config.enabled_models.set(ai_models)
+                ai_models = AIModel.objects.filter(
+                    name__in=enabled_model_names, provider=provider, is_active=True
+                )
+                provider_config.enabled_models.set(ai_models)
 
             except AIProvider.DoesNotExist:
                 logger.warning(


### PR DESCRIPTION
## Summary
- Fix bug where deselecting every model for a provider (e.g. clearing all Gemini models) was not persisted across page reload
- `update_ai_settings` in `ai_chat/views.py` skipped the `enabled_models.set()` call when the incoming list was empty, so the prior M2M selection stayed attached
- The frontend (`SettingsModal.js`) always sends the full desired state per provider, so always call `.set()` — an empty list correctly clears the M2M

## Test plan
- [ ] Open AI Settings, deselect every model for a provider (e.g. Google / all Gemini models), click Save
- [ ] Reload the page — the cleared selection should persist
- [ ] Re-enable a few models, save, reload — the exact selected set should persist
- [ ] Deselect all models for one provider while leaving another provider's selection untouched — only the targeted provider is cleared

https://claude.ai/code/session_01Q5CT8wfiAWaRxSnun447a7