### PR TITLE
Add streaming responses and extended thinking support for AI chat

### DIFF
--- a/packages/django-app/app/ai_chat/commands/__init__.py
+++ b/packages/django-app/app/ai_chat/commands/__init__.py
@@ -1,1 +1,2 @@
 from .send_message_command import SendMessageCommand
+from .stream_send_message_command import StreamSendMessageCommand

--- a/packages/django-app/app/ai_chat/commands/send_message_command.py
+++ b/packages/django-app/app/ai_chat/commands/send_message_command.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, List, Optional
 
 from ai_chat.services.ai_service_factory import AIServiceFactory, AIServiceFactoryError
 from ai_chat.services.base_ai_service import AIServiceError
+from ai_chat.tools.notes_tool_executor import NotesToolExecutor
+from ai_chat.tools.notes_tools import anthropic_notes_tools, openai_notes_tools
 from ai_chat.tools.web_search import WebSearchTools
 from common.commands.abstract_base_command import AbstractBaseCommand
 
@@ -68,10 +70,16 @@ class SendMessageCommand(AbstractBaseCommand):
                 api_key=api_key,
                 model=model,
             )
-            tools = SendMessageCommand._get_web_search_tools(provider_name)
+            enable_notes_tools = self.form.cleaned_data.get("enable_notes_tools")
+            tools, tool_executor = SendMessageCommand._build_tools(
+                provider_name, user, enable_notes_tools
+            )
 
             result = service.send_message(
-                messages, tools, system=BRAINSPREAD_SYSTEM_PROMPT
+                messages,
+                tools,
+                system=BRAINSPREAD_SYSTEM_PROMPT,
+                tool_executor=tool_executor,
             )
 
             ai_model = AIModelRepository.get_by_name(model)
@@ -184,3 +192,30 @@ class SendMessageCommand(AbstractBaseCommand):
             return [WebSearchTools.google_search()]
 
         return None
+
+    @staticmethod
+    def _build_tools(provider_name, user, enable_notes_tools):
+        """Combine provider-native web search with optional notes tools.
+
+        Returns the tools payload plus a ToolExecutor if custom tools are
+        active — only Anthropic's service runs the custom tool loop today,
+        so for other providers notes tools are skipped.
+        """
+        tools: List[Dict[str, Any]] = []
+        web_tools = SendMessageCommand._get_web_search_tools(provider_name)
+        if web_tools:
+            tools.extend(web_tools)
+
+        tool_executor = None
+        if enable_notes_tools:
+            if provider_name == "anthropic":
+                tools.extend(anthropic_notes_tools())
+                tool_executor = NotesToolExecutor(user)
+            elif provider_name == "openai":
+                # OpenAI's Responses API is only invoked when tools are present;
+                # mixing function-calling with the Responses web_search path is
+                # brittle, so we only surface notes tools here for Anthropic
+                # until the tool loop is implemented for OpenAI.
+                tools.extend(openai_notes_tools())
+
+        return (tools or None), tool_executor

--- a/packages/django-app/app/ai_chat/commands/send_message_command.py
+++ b/packages/django-app/app/ai_chat/commands/send_message_command.py
@@ -16,6 +16,17 @@ from ..repositories import (
 logger = logging.getLogger(__name__)
 
 
+# A stable system prompt gives providers that support prompt caching something
+# worth caching. Keep it short but concrete.
+BRAINSPREAD_SYSTEM_PROMPT = (
+    "You are the assistant embedded in brainspread, a personal note-taking app"
+    " where users capture thoughts as hierarchical blocks on daily pages."
+    " Be concise, direct, and helpful. Format answers as markdown."
+    " When the user attaches note blocks as context, prefer them over outside"
+    " knowledge and cite specific items when relevant."
+)
+
+
 class SendMessageCommandError(Exception):
     """Custom exception for command errors"""
 
@@ -26,11 +37,10 @@ class SendMessageCommand(AbstractBaseCommand):
     def __init__(self, form: SendMessageForm) -> None:
         self.form = form
 
-    def execute(self) -> Dict[str, str]:
+    def execute(self) -> Dict[str, Any]:
         super().execute()
 
         try:
-            # Get validated data from form
             message = self.form.cleaned_data["message"]
             model = self.form.cleaned_data["model"]
             session = self.form.cleaned_data.get("session_id")
@@ -39,81 +49,64 @@ class SendMessageCommand(AbstractBaseCommand):
             api_key = self.form.cleaned_data["api_key"]
             user = self.form.cleaned_data["user"]
 
-            # Create or get session
             if not session:
                 session = ChatSessionRepository.create_session(user)
 
-            # Prepare the message with context blocks
             formatted_message = self._format_message_with_context(
                 message, context_blocks
             )
 
-            # Add user message to database
             ChatMessageRepository.add_message(session, "user", formatted_message)
 
-            # Get conversation history
             messages: List[Dict[str, str]] = [
                 {"role": msg.role, "content": msg.content}
                 for msg in ChatMessageRepository.get_messages(session)
             ]
 
-            # Create AI service using factory
             service = AIServiceFactory.create_service(
                 provider_name=provider_name,
                 api_key=api_key,
                 model=model,
             )
-            # Configure web search tools if enabled
             tools = self._get_web_search_tools(provider_name)
 
-            response_content = service.send_message(messages, tools)
-
-            # Get the AI model to store with the assistant response
-            ai_model = AIModelRepository.get_by_name(model)
-
-            # Add assistant response to database
-            assistant_message = ChatMessageRepository.add_message(
-                session, "assistant", response_content, ai_model
+            result = service.send_message(
+                messages, tools, system=BRAINSPREAD_SYSTEM_PROMPT
             )
 
-            # Return complete message data including AI model info
+            ai_model = AIModelRepository.get_by_name(model)
+
+            assistant_message = ChatMessageRepository.add_message(
+                session,
+                "assistant",
+                result.content,
+                ai_model=ai_model,
+                thinking=result.thinking or "",
+                usage=result.usage,
+            )
+
             return {
-                "response": response_content,
+                "response": result.content,
                 "session_id": str(session.uuid),
-                "message": {
-                    "role": assistant_message.role,
-                    "content": assistant_message.content,
-                    "created_at": assistant_message.created_at.isoformat(),
-                    "ai_model": (
-                        {
-                            "name": ai_model.name,
-                            "display_name": ai_model.display_name,
-                            "provider": ai_model.provider.name,
-                        }
-                        if ai_model
-                        else None
-                    ),
-                },
+                "message": self._serialize_message(assistant_message, ai_model),
             }
 
         except (AIServiceError, AIServiceFactoryError) as e:
             logger.error(f"AI service error for user {user.id}: {str(e)}")
-            # Still save the user message even if AI fails
             if session:
                 ai_model = AIModelRepository.get_by_name(model)
                 error_message = (
                     f"Sorry, I'm experiencing technical difficulties: {str(e)}"
                 )
-                assistant_message = ChatMessageRepository.add_message(
+                ChatMessageRepository.add_message(
                     session,
                     "assistant",
                     error_message,
-                    ai_model,
+                    ai_model=ai_model,
                 )
             raise SendMessageCommandError(f"AI service error: {str(e)}") from e
 
         except SendMessageCommandError:
-            # Re-raise command errors as-is
             raise
 
         except Exception as e:
@@ -124,6 +117,30 @@ class SendMessageCommand(AbstractBaseCommand):
                 f"An unexpected error occurred: {str(e)}"
             ) from e
 
+    @staticmethod
+    def _serialize_message(message, ai_model) -> Dict[str, Any]:
+        return {
+            "role": message.role,
+            "content": message.content,
+            "thinking": message.thinking or None,
+            "created_at": message.created_at.isoformat(),
+            "usage": {
+                "input_tokens": message.input_tokens,
+                "output_tokens": message.output_tokens,
+                "cache_creation_input_tokens": message.cache_creation_input_tokens,
+                "cache_read_input_tokens": message.cache_read_input_tokens,
+            },
+            "ai_model": (
+                {
+                    "name": ai_model.name,
+                    "display_name": ai_model.display_name,
+                    "provider": ai_model.provider.name,
+                }
+                if ai_model
+                else None
+            ),
+        }
+
     def _format_message_with_context(
         self, message: str, context_blocks: List[Dict]
     ) -> str:
@@ -131,7 +148,6 @@ class SendMessageCommand(AbstractBaseCommand):
         if not context_blocks:
             return message
 
-        # Format context blocks
         context_text_parts = []
         for block in context_blocks:
             content = block.get("content", "").strip()
@@ -147,21 +163,17 @@ class SendMessageCommand(AbstractBaseCommand):
         if not context_text_parts:
             return message
 
-        # Combine context and message
         context_section = "\n".join(context_text_parts)
-        formatted_message = f"""**Context from my notes:**
+        return f"""**Context from my notes:**
 {context_section}
 
 **My question:**
 {message}"""
 
-        return formatted_message
-
     def _get_web_search_tools(
         self, provider_name: str
     ) -> Optional[List[Dict[str, Any]]]:
         """Get web search tools configuration for the specified provider."""
-        # Enable web search for all providers
         if provider_name == "anthropic":
             return [WebSearchTools.anthropic_web_search()]
         elif provider_name == "openai":

--- a/packages/django-app/app/ai_chat/commands/send_message_command.py
+++ b/packages/django-app/app/ai_chat/commands/send_message_command.py
@@ -52,7 +52,7 @@ class SendMessageCommand(AbstractBaseCommand):
             if not session:
                 session = ChatSessionRepository.create_session(user)
 
-            formatted_message = self._format_message_with_context(
+            formatted_message = SendMessageCommand._format_message_with_context(
                 message, context_blocks
             )
 
@@ -68,7 +68,7 @@ class SendMessageCommand(AbstractBaseCommand):
                 api_key=api_key,
                 model=model,
             )
-            tools = self._get_web_search_tools(provider_name)
+            tools = SendMessageCommand._get_web_search_tools(provider_name)
 
             result = service.send_message(
                 messages, tools, system=BRAINSPREAD_SYSTEM_PROMPT
@@ -141,8 +141,9 @@ class SendMessageCommand(AbstractBaseCommand):
             ),
         }
 
+    @staticmethod
     def _format_message_with_context(
-        self, message: str, context_blocks: List[Dict]
+        message: str, context_blocks: List[Dict]
     ) -> str:
         """Format the user message with context blocks if any are provided."""
         if not context_blocks:
@@ -170,8 +171,9 @@ class SendMessageCommand(AbstractBaseCommand):
 **My question:**
 {message}"""
 
+    @staticmethod
     def _get_web_search_tools(
-        self, provider_name: str
+        provider_name: str,
     ) -> Optional[List[Dict[str, Any]]]:
         """Get web search tools configuration for the specified provider."""
         if provider_name == "anthropic":

--- a/packages/django-app/app/ai_chat/commands/send_message_command.py
+++ b/packages/django-app/app/ai_chat/commands/send_message_command.py
@@ -150,9 +150,7 @@ class SendMessageCommand(AbstractBaseCommand):
         }
 
     @staticmethod
-    def _format_message_with_context(
-        message: str, context_blocks: List[Dict]
-    ) -> str:
+    def _format_message_with_context(message: str, context_blocks: List[Dict]) -> str:
         """Format the user message with context blocks if any are provided."""
         if not context_blocks:
             return message

--- a/packages/django-app/app/ai_chat/commands/stream_send_message_command.py
+++ b/packages/django-app/app/ai_chat/commands/stream_send_message_command.py
@@ -63,7 +63,10 @@ class StreamSendMessageCommand(AbstractBaseCommand):
                 api_key=api_key,
                 model=model,
             )
-            tools = SendMessageCommand._get_web_search_tools(provider_name)
+            enable_notes_tools = self.form.cleaned_data.get("enable_notes_tools")
+            tools, tool_executor = SendMessageCommand._build_tools(
+                provider_name, user, enable_notes_tools
+            )
 
             yield {
                 "type": "session",
@@ -75,7 +78,10 @@ class StreamSendMessageCommand(AbstractBaseCommand):
             final_usage = AIUsage()
 
             for event in service.stream_message(
-                messages, tools, system=BRAINSPREAD_SYSTEM_PROMPT
+                messages,
+                tools,
+                system=BRAINSPREAD_SYSTEM_PROMPT,
+                tool_executor=tool_executor,
             ):
                 etype = event.get("type")
                 if etype == "text":

--- a/packages/django-app/app/ai_chat/commands/stream_send_message_command.py
+++ b/packages/django-app/app/ai_chat/commands/stream_send_message_command.py
@@ -1,0 +1,134 @@
+import logging
+from typing import Any, Dict, Iterator, List
+
+from ai_chat.services.ai_service_factory import AIServiceFactory, AIServiceFactoryError
+from ai_chat.services.base_ai_service import AIServiceError, AIUsage
+from common.commands.abstract_base_command import AbstractBaseCommand
+
+from ..forms import SendMessageForm
+from ..repositories import (
+    AIModelRepository,
+    ChatMessageRepository,
+    ChatSessionRepository,
+)
+from .send_message_command import (
+    BRAINSPREAD_SYSTEM_PROMPT,
+    SendMessageCommand,
+    SendMessageCommandError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class StreamSendMessageCommand(AbstractBaseCommand):
+    """Send a chat message and yield incremental SSE-shaped events.
+
+    Mirrors SendMessageCommand's persistence but streams text/thinking deltas
+    back to the caller as they arrive and persists the assistant record once
+    the stream completes.
+    """
+
+    def __init__(self, form: SendMessageForm) -> None:
+        self.form = form
+
+    def execute(self) -> Iterator[Dict[str, Any]]:
+        super().execute()
+
+        session = None
+        user = self.form.cleaned_data["user"]
+        model = self.form.cleaned_data["model"]
+        provider_name = self.form.cleaned_data["provider_name"]
+
+        try:
+            message = self.form.cleaned_data["message"]
+            api_key = self.form.cleaned_data["api_key"]
+            session = self.form.cleaned_data.get("session_id")
+            context_blocks = self.form.cleaned_data.get("context_blocks", [])
+
+            if not session:
+                session = ChatSessionRepository.create_session(user)
+
+            formatted_message = SendMessageCommand._format_message_with_context(
+                message, context_blocks
+            )
+            ChatMessageRepository.add_message(session, "user", formatted_message)
+
+            messages: List[Dict[str, str]] = [
+                {"role": msg.role, "content": msg.content}
+                for msg in ChatMessageRepository.get_messages(session)
+            ]
+
+            service = AIServiceFactory.create_service(
+                provider_name=provider_name,
+                api_key=api_key,
+                model=model,
+            )
+            tools = SendMessageCommand._get_web_search_tools(provider_name)
+
+            yield {
+                "type": "session",
+                "session_id": str(session.uuid),
+            }
+
+            final_content = ""
+            final_thinking = ""
+            final_usage = AIUsage()
+
+            for event in service.stream_message(
+                messages, tools, system=BRAINSPREAD_SYSTEM_PROMPT
+            ):
+                etype = event.get("type")
+                if etype == "text":
+                    yield {"type": "text", "delta": event.get("delta", "")}
+                elif etype == "thinking":
+                    yield {"type": "thinking", "delta": event.get("delta", "")}
+                elif etype == "done":
+                    final_content = event.get("content", "") or ""
+                    final_thinking = event.get("thinking") or ""
+                    final_usage = event.get("usage") or AIUsage()
+
+            ai_model = AIModelRepository.get_by_name(model)
+            assistant_message = ChatMessageRepository.add_message(
+                session,
+                "assistant",
+                final_content,
+                ai_model=ai_model,
+                thinking=final_thinking,
+                usage=final_usage,
+            )
+
+            yield {
+                "type": "done",
+                "session_id": str(session.uuid),
+                "message": SendMessageCommand._serialize_message(
+                    assistant_message, ai_model
+                ),
+            }
+
+        except (AIServiceError, AIServiceFactoryError) as e:
+            logger.error(f"AI service error for user {user.id}: {str(e)}")
+            if session:
+                ai_model = AIModelRepository.get_by_name(model)
+                error_message = (
+                    f"Sorry, I'm experiencing technical difficulties: {str(e)}"
+                )
+                ChatMessageRepository.add_message(
+                    session,
+                    "assistant",
+                    error_message,
+                    ai_model=ai_model,
+                )
+            yield {"type": "error", "error": f"AI service error: {str(e)}"}
+            raise SendMessageCommandError(f"AI service error: {str(e)}") from e
+
+        except SendMessageCommandError:
+            raise
+
+        except Exception as e:
+            logger.error(
+                f"Unexpected error in StreamSendMessageCommand for user {user.id}: {str(e)}"
+            )
+            yield {"type": "error", "error": "An unexpected error occurred."}
+            raise SendMessageCommandError(
+                f"An unexpected error occurred: {str(e)}"
+            ) from e

--- a/packages/django-app/app/ai_chat/forms.py
+++ b/packages/django-app/app/ai_chat/forms.py
@@ -19,6 +19,7 @@ class SendMessageForm(BaseForm):
     model = forms.CharField(required=True)  # Model selection per request
     session_id = forms.CharField(required=False)
     context_blocks = forms.JSONField(required=False)
+    enable_notes_tools = forms.BooleanField(required=False)
 
     def clean_user(self) -> User:
         user = self.cleaned_data.get("user")

--- a/packages/django-app/app/ai_chat/migrations/0011_chatmessage_thinking_and_usage.py
+++ b/packages/django-app/app/ai_chat/migrations/0011_chatmessage_thinking_and_usage.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ai_chat", "0010_alter_useraisettings_options"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="chatmessage",
+            name="thinking",
+            field=models.TextField(blank=True, default=""),
+        ),
+        migrations.AddField(
+            model_name="chatmessage",
+            name="input_tokens",
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="chatmessage",
+            name="output_tokens",
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="chatmessage",
+            name="cache_creation_input_tokens",
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="chatmessage",
+            name="cache_read_input_tokens",
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+    ]

--- a/packages/django-app/app/ai_chat/models/chat_session.py
+++ b/packages/django-app/app/ai_chat/models/chat_session.py
@@ -20,9 +20,14 @@ class ChatMessage(UUIDModelMixin, CRUDTimestampsMixin):
     )
     role = models.CharField(max_length=20)  # 'user' or 'assistant'
     content = models.TextField()
+    thinking = models.TextField(blank=True, default="")
     ai_model = models.ForeignKey(
         "ai_chat.AIModel", on_delete=models.SET_NULL, null=True, blank=True
     )
+    input_tokens = models.PositiveIntegerField(null=True, blank=True)
+    output_tokens = models.PositiveIntegerField(null=True, blank=True)
+    cache_creation_input_tokens = models.PositiveIntegerField(null=True, blank=True)
+    cache_read_input_tokens = models.PositiveIntegerField(null=True, blank=True)
 
     class Meta:
         db_table = "ai_chat_messages"

--- a/packages/django-app/app/ai_chat/repositories/chat_message_repository.py
+++ b/packages/django-app/app/ai_chat/repositories/chat_message_repository.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 from common.repositories.base_repository import BaseRepository
 
 from ..models import AIModel, ChatMessage, ChatSession
+from ..services.base_ai_service import AIUsage
 
 
 class ChatMessageRepository(BaseRepository):
@@ -15,10 +16,26 @@ class ChatMessageRepository(BaseRepository):
         role: str,
         content: str,
         ai_model: Optional[AIModel] = None,
+        thinking: str = "",
+        usage: Optional[AIUsage] = None,
     ) -> ChatMessage:
-        return cls.model.objects.create(
-            session=session, role=role, content=content, ai_model=ai_model
-        )
+        fields = {
+            "session": session,
+            "role": role,
+            "content": content,
+            "ai_model": ai_model,
+            "thinking": thinking or "",
+        }
+        if usage is not None:
+            fields.update(
+                {
+                    "input_tokens": usage.input_tokens,
+                    "output_tokens": usage.output_tokens,
+                    "cache_creation_input_tokens": usage.cache_creation_input_tokens,
+                    "cache_read_input_tokens": usage.cache_read_input_tokens,
+                }
+            )
+        return cls.model.objects.create(**fields)
 
     @classmethod
     def get_messages(cls, session: ChatSession) -> List[ChatMessage]:

--- a/packages/django-app/app/ai_chat/services/anthropic_service.py
+++ b/packages/django-app/app/ai_chat/services/anthropic_service.py
@@ -3,9 +3,24 @@ from typing import Any, Dict, List, Optional
 
 import anthropic
 
-from .base_ai_service import AIServiceError, BaseAIService
+from .base_ai_service import AIServiceError, AIServiceResult, AIUsage, BaseAIService
 
 logger = logging.getLogger(__name__)
+
+
+# Claude models that support extended thinking. Keep this list conservative —
+# enabling `thinking` on a model that doesn't support it raises at the API.
+THINKING_CAPABLE_MODEL_PREFIXES = (
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+)
+
+# With thinking enabled Anthropic requires max_tokens > budget_tokens.
+THINKING_BUDGET_TOKENS = 4000
+DEFAULT_MAX_TOKENS = 2000
+THINKING_MAX_TOKENS = 8000
 
 
 class AnthropicServiceError(AIServiceError):
@@ -25,108 +40,124 @@ class AnthropicService(BaseAIService):
                 f"Failed to initialize Anthropic client: {e}"
             ) from e
 
+    def _supports_thinking(self) -> bool:
+        return self.model.startswith(THINKING_CAPABLE_MODEL_PREFIXES)
+
     def send_message(
         self,
         messages: List[Dict[str, str]],
         tools: Optional[List[Dict[str, Any]]] = None,
-    ) -> str:
-        """
-        Send messages to Anthropic API and return the response content.
-
-        Args:
-            messages: List of message dictionaries with 'role' and 'content' keys
-            tools: Optional list of tools to make available to the model
-
-        Returns:
-            str: The assistant's response content
-
-        Raises:
-            AnthropicServiceError: If the API call fails
-        """
+        system: Optional[str] = None,
+    ) -> AIServiceResult:
         try:
-            # Validate messages format using base class method
             self.validate_messages(messages)
 
-            # Convert messages format for Anthropic API
             anthropic_messages = []
-            system_message = None
-
+            # If a system prompt is embedded in messages (legacy callers), pull it out.
+            embedded_system = None
             for msg in messages:
                 if msg["role"] == "system":
-                    system_message = msg["content"]
+                    embedded_system = msg["content"]
                 else:
                     anthropic_messages.append(
                         {"role": msg["role"], "content": msg["content"]}
                     )
 
-            # Prepare API call parameters
-            kwargs = {
+            effective_system = system if system is not None else embedded_system
+
+            thinking_enabled = self._supports_thinking()
+
+            kwargs: Dict[str, Any] = {
                 "model": self.model,
-                "max_tokens": 2000,
+                "max_tokens": (
+                    THINKING_MAX_TOKENS if thinking_enabled else DEFAULT_MAX_TOKENS
+                ),
                 "messages": anthropic_messages,
             }
 
-            # Add system message if present
-            if system_message:
-                kwargs["system"] = system_message
+            if effective_system:
+                # Mark the system prompt as cacheable so repeated requests with
+                # the same prompt pay the discounted cache-read rate.
+                kwargs["system"] = [
+                    {
+                        "type": "text",
+                        "text": effective_system,
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ]
 
-            # Add tools if provided
             if tools:
                 kwargs["tools"] = tools
 
-            # Make the API call
+            if thinking_enabled:
+                kwargs["thinking"] = {
+                    "type": "enabled",
+                    "budget_tokens": THINKING_BUDGET_TOKENS,
+                }
+
             response = self.client.messages.create(**kwargs)
 
-            # Extract the content from the response
-            if response.content and len(response.content) > 0:
-                # Handle different content block types
-                content_parts = []
-                for block in response.content:
-                    # Handle text blocks
-                    if hasattr(block, "text") and block.text:
-                        content_parts.append(block.text)
-                    # Handle tool use blocks (should be skipped)
-                    elif hasattr(block, "type") and block.type == "tool_use":
-                        continue
-                    # Handle any other block types by trying to access text
-                    elif hasattr(block, "__dict__"):
-                        # Log the block structure for debugging
-                        logger.debug(
-                            f"Unknown block type: {type(block)}, attributes: {block.__dict__}"
-                        )
-                        # Try to extract text content if available
-                        if hasattr(block, "text"):
-                            content_parts.append(str(block.text))
+            text_parts: List[str] = []
+            thinking_parts: List[str] = []
 
-                if content_parts:
-                    return "\n".join(content_parts)
+            for block in response.content or []:
+                block_type = getattr(block, "type", None)
+                if block_type == "thinking":
+                    thinking_text = getattr(block, "thinking", None)
+                    if thinking_text:
+                        thinking_parts.append(thinking_text)
+                elif block_type == "tool_use":
+                    continue
+                elif getattr(block, "text", None):
+                    text_parts.append(block.text)
                 else:
-                    # If no text content found, return a fallback message
-                    logger.warning(
-                        f"No text content found in Anthropic response with {len(response.content)} blocks"
+                    logger.debug(
+                        f"Unknown Anthropic block type: {block_type} attrs: {getattr(block, '__dict__', block)}"
                     )
-                    return "I apologize, but I encountered an issue processing the response. Please try again."
+
+            if not text_parts:
+                logger.warning(
+                    "No text content found in Anthropic response (%s blocks)",
+                    len(response.content or []),
+                )
+                content = (
+                    "I apologize, but I encountered an issue processing the response."
+                    " Please try again."
+                )
             else:
-                raise AnthropicServiceError("No content blocks in Anthropic response")
+                content = "\n".join(text_parts)
+
+            usage = self._extract_usage(response)
+            thinking = "\n\n".join(thinking_parts) if thinking_parts else None
+
+            return AIServiceResult(content=content, thinking=thinking, usage=usage)
 
         except Exception as e:
             logger.error(f"Anthropic API error: {str(e)}")
             if isinstance(e, AnthropicServiceError):
                 raise
-            else:
-                raise AnthropicServiceError(
-                    f"Anthropic API call failed: {str(e)}"
-                ) from e
+            raise AnthropicServiceError(
+                f"Anthropic API call failed: {str(e)}"
+            ) from e
+
+    @staticmethod
+    def _extract_usage(response: Any) -> AIUsage:
+        usage_obj = getattr(response, "usage", None)
+        if usage_obj is None:
+            return AIUsage()
+        return AIUsage(
+            input_tokens=getattr(usage_obj, "input_tokens", 0) or 0,
+            output_tokens=getattr(usage_obj, "output_tokens", 0) or 0,
+            cache_creation_input_tokens=(
+                getattr(usage_obj, "cache_creation_input_tokens", 0) or 0
+            ),
+            cache_read_input_tokens=(
+                getattr(usage_obj, "cache_read_input_tokens", 0) or 0
+            ),
+        )
 
     def validate_api_key(self) -> bool:
-        """
-        Validate the Anthropic API key by making a test call.
-
-        Returns:
-            bool: True if API key is valid, False otherwise
-        """
         try:
-            # Make a minimal test call to validate the API key
             test_messages = [{"role": "user", "content": "Hi"}]
             response = self.client.messages.create(
                 model=self.model, max_tokens=1, messages=test_messages

--- a/packages/django-app/app/ai_chat/services/anthropic_service.py
+++ b/packages/django-app/app/ai_chat/services/anthropic_service.py
@@ -1,9 +1,16 @@
+import json
 import logging
 from typing import Any, Dict, Iterator, List, Optional
 
 import anthropic
 
-from .base_ai_service import AIServiceError, AIServiceResult, AIUsage, BaseAIService
+from .base_ai_service import (
+    AIServiceError,
+    AIServiceResult,
+    AIUsage,
+    BaseAIService,
+    ToolExecutor,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +28,10 @@ THINKING_CAPABLE_MODEL_PREFIXES = (
 THINKING_BUDGET_TOKENS = 4000
 DEFAULT_MAX_TOKENS = 2000
 THINKING_MAX_TOKENS = 8000
+
+# Safety net for custom tool loops: the model shouldn't be able to spin
+# us indefinitely even if it keeps requesting tool calls.
+MAX_TOOL_ITERATIONS = 5
 
 
 class AnthropicServiceError(AIServiceError):
@@ -48,34 +59,75 @@ class AnthropicService(BaseAIService):
         messages: List[Dict[str, str]],
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
+        tool_executor: Optional[ToolExecutor] = None,
     ) -> AIServiceResult:
         try:
             self.validate_messages(messages)
             kwargs = self._build_kwargs(messages, tools, system)
-            response = self.client.messages.create(**kwargs)
 
             text_parts: List[str] = []
             thinking_parts: List[str] = []
+            total_usage = AIUsage()
 
-            for block in response.content or []:
-                block_type = getattr(block, "type", None)
-                if block_type == "thinking":
-                    thinking_text = getattr(block, "thinking", None)
-                    if thinking_text:
-                        thinking_parts.append(thinking_text)
-                elif block_type == "tool_use":
-                    continue
-                elif getattr(block, "text", None):
-                    text_parts.append(block.text)
-                else:
-                    logger.debug(
-                        f"Unknown Anthropic block type: {block_type} attrs: {getattr(block, '__dict__', block)}"
+            for _ in range(MAX_TOOL_ITERATIONS + 1):
+                response = self.client.messages.create(**kwargs)
+                self._accumulate_usage(total_usage, response)
+
+                for block in response.content or []:
+                    block_type = getattr(block, "type", None)
+                    if block_type == "thinking":
+                        thinking_text = getattr(block, "thinking", None)
+                        if thinking_text:
+                            thinking_parts.append(thinking_text)
+                    elif block_type == "tool_use":
+                        continue
+                    elif getattr(block, "text", None):
+                        text_parts.append(block.text)
+                    else:
+                        logger.debug(
+                            f"Unknown Anthropic block type: {block_type} attrs: {getattr(block, '__dict__', block)}"
+                        )
+
+                if (
+                    tool_executor is None
+                    or getattr(response, "stop_reason", None) != "tool_use"
+                ):
+                    break
+
+                custom_tool_uses = [
+                    block
+                    for block in response.content or []
+                    if getattr(block, "type", None) == "tool_use"
+                    and tool_executor.is_known(getattr(block, "name", ""))
+                ]
+                if not custom_tool_uses:
+                    break
+
+                kwargs["messages"].append(
+                    {
+                        "role": "assistant",
+                        "content": [
+                            self._serialize_block(b) for b in response.content or []
+                        ],
+                    }
+                )
+                tool_results: List[Dict[str, Any]] = []
+                for tu in custom_tool_uses:
+                    result = tool_executor.execute(
+                        getattr(tu, "name", ""), getattr(tu, "input", {}) or {}
                     )
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": getattr(tu, "id", ""),
+                            "content": json.dumps(result),
+                        }
+                    )
+                kwargs["messages"].append({"role": "user", "content": tool_results})
 
             if not text_parts:
                 logger.warning(
-                    "No text content found in Anthropic response (%s blocks)",
-                    len(response.content or []),
+                    "No text content found in Anthropic response after tool loop"
                 )
                 content = (
                     "I apologize, but I encountered an issue processing the response."
@@ -84,10 +136,11 @@ class AnthropicService(BaseAIService):
             else:
                 content = "\n".join(text_parts)
 
-            usage = self._extract_usage(response)
             thinking = "\n\n".join(thinking_parts) if thinking_parts else None
 
-            return AIServiceResult(content=content, thinking=thinking, usage=usage)
+            return AIServiceResult(
+                content=content, thinking=thinking, usage=total_usage
+            )
 
         except Exception as e:
             logger.error(f"Anthropic API error: {str(e)}")
@@ -97,12 +150,56 @@ class AnthropicService(BaseAIService):
                 f"Anthropic API call failed: {str(e)}"
             ) from e
 
+    @staticmethod
+    def _serialize_block(block: Any) -> Dict[str, Any]:
+        """Serialize a response content block back to the dict shape the API accepts."""
+        block_type = getattr(block, "type", None)
+        if block_type == "text":
+            return {"type": "text", "text": getattr(block, "text", "") or ""}
+        if block_type == "thinking":
+            return {
+                "type": "thinking",
+                "thinking": getattr(block, "thinking", "") or "",
+                "signature": getattr(block, "signature", "") or "",
+            }
+        if block_type == "tool_use":
+            return {
+                "type": "tool_use",
+                "id": getattr(block, "id", ""),
+                "name": getattr(block, "name", ""),
+                "input": getattr(block, "input", {}) or {},
+            }
+        return {"type": block_type or "text", "text": str(block)}
+
+    @staticmethod
+    def _accumulate_usage(total: AIUsage, response: Any) -> None:
+        usage = getattr(response, "usage", None)
+        if usage is None:
+            return
+        total.input_tokens += getattr(usage, "input_tokens", 0) or 0
+        total.output_tokens += getattr(usage, "output_tokens", 0) or 0
+        total.cache_creation_input_tokens += (
+            getattr(usage, "cache_creation_input_tokens", 0) or 0
+        )
+        total.cache_read_input_tokens += (
+            getattr(usage, "cache_read_input_tokens", 0) or 0
+        )
+
     def stream_message(
         self,
         messages: List[Dict[str, str]],
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
+        tool_executor: Optional[ToolExecutor] = None,
     ) -> Iterator[Dict[str, Any]]:
+        # Custom-tool loops require multiple round-trips, which don't fit
+        # the single-stream contract. Fall back to buffered send_message so
+        # the UI still gets a `done` event.
+        if tool_executor is not None:
+            yield from super().stream_message(
+                messages, tools, system=system, tool_executor=tool_executor
+            )
+            return
         try:
             self.validate_messages(messages)
             kwargs = self._build_kwargs(messages, tools, system)

--- a/packages/django-app/app/ai_chat/services/anthropic_service.py
+++ b/packages/django-app/app/ai_chat/services/anthropic_service.py
@@ -146,9 +146,7 @@ class AnthropicService(BaseAIService):
             logger.error(f"Anthropic API error: {str(e)}")
             if isinstance(e, AnthropicServiceError):
                 raise
-            raise AnthropicServiceError(
-                f"Anthropic API call failed: {str(e)}"
-            ) from e
+            raise AnthropicServiceError(f"Anthropic API call failed: {str(e)}") from e
 
     @staticmethod
     def _serialize_block(block: Any) -> Dict[str, Any]:
@@ -220,18 +218,13 @@ class AnthropicService(BaseAIService):
                             getattr(event, "message", None), "usage", None
                         )
                         if start_usage is not None:
-                            input_tokens = (
-                                getattr(start_usage, "input_tokens", 0) or 0
-                            )
+                            input_tokens = getattr(start_usage, "input_tokens", 0) or 0
                             cache_creation = (
-                                getattr(
-                                    start_usage, "cache_creation_input_tokens", 0
-                                )
+                                getattr(start_usage, "cache_creation_input_tokens", 0)
                                 or 0
                             )
                             cache_read = (
-                                getattr(start_usage, "cache_read_input_tokens", 0)
-                                or 0
+                                getattr(start_usage, "cache_read_input_tokens", 0) or 0
                             )
 
                     elif event_type == "content_block_delta":
@@ -274,9 +267,7 @@ class AnthropicService(BaseAIService):
             logger.error(f"Anthropic streaming error: {e}")
             if isinstance(e, AnthropicServiceError):
                 raise
-            raise AnthropicServiceError(
-                f"Anthropic streaming call failed: {e}"
-            ) from e
+            raise AnthropicServiceError(f"Anthropic streaming call failed: {e}") from e
 
     def _build_kwargs(
         self,

--- a/packages/django-app/app/ai_chat/services/anthropic_service.py
+++ b/packages/django-app/app/ai_chat/services/anthropic_service.py
@@ -24,10 +24,15 @@ THINKING_CAPABLE_MODEL_PREFIXES = (
     "claude-haiku-4-5",
 )
 
-# With thinking enabled Anthropic requires max_tokens > budget_tokens.
-THINKING_BUDGET_TOKENS = 4000
-DEFAULT_MAX_TOKENS = 2000
-THINKING_MAX_TOKENS = 8000
+# Models that accept `output_config.effort`. Sending it to Haiku 4.5 (or older
+# non-4.6 models) returns a 400.
+EFFORT_CAPABLE_MODEL_PREFIXES = (
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+)
+
+DEFAULT_MAX_TOKENS = 8192
 
 # Safety net for custom tool loops: the model shouldn't be able to spin
 # us indefinitely even if it keeps requesting tool calls.
@@ -53,6 +58,9 @@ class AnthropicService(BaseAIService):
 
     def _supports_thinking(self) -> bool:
         return self.model.startswith(THINKING_CAPABLE_MODEL_PREFIXES)
+
+    def _supports_effort(self) -> bool:
+        return self.model.startswith(EFFORT_CAPABLE_MODEL_PREFIXES)
 
     def send_message(
         self,
@@ -290,9 +298,7 @@ class AnthropicService(BaseAIService):
 
         kwargs: Dict[str, Any] = {
             "model": self.model,
-            "max_tokens": (
-                THINKING_MAX_TOKENS if thinking_enabled else DEFAULT_MAX_TOKENS
-            ),
+            "max_tokens": DEFAULT_MAX_TOKENS,
             "messages": anthropic_messages,
         }
 
@@ -307,10 +313,12 @@ class AnthropicService(BaseAIService):
         if tools:
             kwargs["tools"] = tools
         if thinking_enabled:
-            kwargs["thinking"] = {
-                "type": "enabled",
-                "budget_tokens": THINKING_BUDGET_TOKENS,
-            }
+            # Adaptive thinking — Claude decides when and how much to reason.
+            # `display: "summarized"` surfaces the reasoning trace; the 4.7
+            # default is "omitted" which would make thinking blocks empty.
+            kwargs["thinking"] = {"type": "adaptive", "display": "summarized"}
+        if self._supports_effort():
+            kwargs["output_config"] = {"effort": "high"}
         return kwargs
 
     @staticmethod

--- a/packages/django-app/app/ai_chat/services/anthropic_service.py
+++ b/packages/django-app/app/ai_chat/services/anthropic_service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 import anthropic
 
@@ -51,50 +51,7 @@ class AnthropicService(BaseAIService):
     ) -> AIServiceResult:
         try:
             self.validate_messages(messages)
-
-            anthropic_messages = []
-            # If a system prompt is embedded in messages (legacy callers), pull it out.
-            embedded_system = None
-            for msg in messages:
-                if msg["role"] == "system":
-                    embedded_system = msg["content"]
-                else:
-                    anthropic_messages.append(
-                        {"role": msg["role"], "content": msg["content"]}
-                    )
-
-            effective_system = system if system is not None else embedded_system
-
-            thinking_enabled = self._supports_thinking()
-
-            kwargs: Dict[str, Any] = {
-                "model": self.model,
-                "max_tokens": (
-                    THINKING_MAX_TOKENS if thinking_enabled else DEFAULT_MAX_TOKENS
-                ),
-                "messages": anthropic_messages,
-            }
-
-            if effective_system:
-                # Mark the system prompt as cacheable so repeated requests with
-                # the same prompt pay the discounted cache-read rate.
-                kwargs["system"] = [
-                    {
-                        "type": "text",
-                        "text": effective_system,
-                        "cache_control": {"type": "ephemeral"},
-                    }
-                ]
-
-            if tools:
-                kwargs["tools"] = tools
-
-            if thinking_enabled:
-                kwargs["thinking"] = {
-                    "type": "enabled",
-                    "budget_tokens": THINKING_BUDGET_TOKENS,
-                }
-
+            kwargs = self._build_kwargs(messages, tools, system)
             response = self.client.messages.create(**kwargs)
 
             text_parts: List[str] = []
@@ -139,6 +96,134 @@ class AnthropicService(BaseAIService):
             raise AnthropicServiceError(
                 f"Anthropic API call failed: {str(e)}"
             ) from e
+
+    def stream_message(
+        self,
+        messages: List[Dict[str, str]],
+        tools: Optional[List[Dict[str, Any]]] = None,
+        system: Optional[str] = None,
+    ) -> Iterator[Dict[str, Any]]:
+        try:
+            self.validate_messages(messages)
+            kwargs = self._build_kwargs(messages, tools, system)
+
+            content_parts: List[str] = []
+            thinking_parts: List[str] = []
+            input_tokens = 0
+            output_tokens = 0
+            cache_creation = 0
+            cache_read = 0
+
+            with self.client.messages.stream(**kwargs) as stream:
+                for event in stream:
+                    event_type = getattr(event, "type", None)
+
+                    if event_type == "message_start":
+                        start_usage = getattr(
+                            getattr(event, "message", None), "usage", None
+                        )
+                        if start_usage is not None:
+                            input_tokens = (
+                                getattr(start_usage, "input_tokens", 0) or 0
+                            )
+                            cache_creation = (
+                                getattr(
+                                    start_usage, "cache_creation_input_tokens", 0
+                                )
+                                or 0
+                            )
+                            cache_read = (
+                                getattr(start_usage, "cache_read_input_tokens", 0)
+                                or 0
+                            )
+
+                    elif event_type == "content_block_delta":
+                        delta = getattr(event, "delta", None)
+                        delta_type = getattr(delta, "type", None)
+                        if delta_type == "text_delta":
+                            text = getattr(delta, "text", "") or ""
+                            if text:
+                                content_parts.append(text)
+                                yield {"type": "text", "delta": text}
+                        elif delta_type == "thinking_delta":
+                            thinking = getattr(delta, "thinking", "") or ""
+                            if thinking:
+                                thinking_parts.append(thinking)
+                                yield {"type": "thinking", "delta": thinking}
+
+                    elif event_type == "message_delta":
+                        delta_usage = getattr(event, "usage", None)
+                        if delta_usage is not None:
+                            output_tokens = (
+                                getattr(delta_usage, "output_tokens", 0) or 0
+                            )
+
+            usage = AIUsage(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_creation_input_tokens=cache_creation,
+                cache_read_input_tokens=cache_read,
+            )
+            content = "".join(content_parts)
+            thinking = "\n\n".join(thinking_parts) if thinking_parts else None
+
+            yield {
+                "type": "done",
+                "content": content,
+                "thinking": thinking,
+                "usage": usage,
+            }
+        except Exception as e:
+            logger.error(f"Anthropic streaming error: {e}")
+            if isinstance(e, AnthropicServiceError):
+                raise
+            raise AnthropicServiceError(
+                f"Anthropic streaming call failed: {e}"
+            ) from e
+
+    def _build_kwargs(
+        self,
+        messages: List[Dict[str, str]],
+        tools: Optional[List[Dict[str, Any]]],
+        system: Optional[str],
+    ) -> Dict[str, Any]:
+        anthropic_messages: List[Dict[str, str]] = []
+        embedded_system: Optional[str] = None
+        for msg in messages:
+            if msg["role"] == "system":
+                embedded_system = msg["content"]
+            else:
+                anthropic_messages.append(
+                    {"role": msg["role"], "content": msg["content"]}
+                )
+
+        effective_system = system if system is not None else embedded_system
+        thinking_enabled = self._supports_thinking()
+
+        kwargs: Dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": (
+                THINKING_MAX_TOKENS if thinking_enabled else DEFAULT_MAX_TOKENS
+            ),
+            "messages": anthropic_messages,
+        }
+
+        if effective_system:
+            kwargs["system"] = [
+                {
+                    "type": "text",
+                    "text": effective_system,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ]
+        if tools:
+            kwargs["tools"] = tools
+        if thinking_enabled:
+            kwargs["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": THINKING_BUDGET_TOKENS,
+            }
+        return kwargs
 
     @staticmethod
     def _extract_usage(response: Any) -> AIUsage:

--- a/packages/django-app/app/ai_chat/services/base_ai_service.py
+++ b/packages/django-app/app/ai_chat/services/base_ai_service.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 
 class AIServiceError(Exception):
@@ -65,6 +65,37 @@ class BaseAIService(ABC):
             AIServiceError: If the API call fails
         """
         pass
+
+    def stream_message(
+        self,
+        messages: List[Dict[str, str]],
+        tools: Optional[List[Dict[str, Any]]] = None,
+        system: Optional[str] = None,
+    ) -> Iterator[Dict[str, Any]]:
+        """
+        Stream the assistant response as incremental events.
+
+        Each yielded dict has a `type` field and type-specific payload:
+          - {"type": "text", "delta": "..."}
+          - {"type": "thinking", "delta": "..."}
+          - {"type": "done", "content": str, "thinking": Optional[str],
+             "usage": AIUsage}
+
+        The default implementation buffers `send_message` into a single
+        `done` event so providers without native streaming still work.
+        Subclasses should override for true streaming.
+        """
+        result = self.send_message(messages, tools, system=system)
+        if result.content:
+            yield {"type": "text", "delta": result.content}
+        if result.thinking:
+            yield {"type": "thinking", "delta": result.thinking}
+        yield {
+            "type": "done",
+            "content": result.content,
+            "thinking": result.thinking,
+            "usage": result.usage,
+        }
 
     @abstractmethod
     def validate_api_key(self) -> bool:

--- a/packages/django-app/app/ai_chat/services/base_ai_service.py
+++ b/packages/django-app/app/ai_chat/services/base_ai_service.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 
@@ -6,6 +7,31 @@ class AIServiceError(Exception):
     """Base exception for AI service errors"""
 
     pass
+
+
+@dataclass
+class AIUsage:
+    """Token usage for a single AI service call.
+
+    All fields default to 0 so services that don't surface a given counter
+    still produce a valid record.
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    # Anthropic-only: tokens written to the prompt cache on this request.
+    cache_creation_input_tokens: int = 0
+    # Anthropic + OpenAI: tokens served from cache rather than the live prompt.
+    cache_read_input_tokens: int = 0
+
+
+@dataclass
+class AIServiceResult:
+    """Structured response from an AI provider."""
+
+    content: str
+    thinking: Optional[str] = None
+    usage: AIUsage = field(default_factory=AIUsage)
 
 
 class BaseAIService(ABC):
@@ -20,16 +46,20 @@ class BaseAIService(ABC):
         self,
         messages: List[Dict[str, str]],
         tools: Optional[List[Dict[str, Any]]] = None,
-    ) -> str:
+        system: Optional[str] = None,
+    ) -> AIServiceResult:
         """
-        Send messages to AI service and return the response content.
+        Send messages to AI service and return the response.
 
         Args:
             messages: List of message dictionaries with 'role' and 'content' keys
             tools: Optional list of tools/functions to make available to the model
+            system: Optional system prompt. Providers that support a dedicated
+                system slot should mark it with cache_control where possible.
 
         Returns:
-            str: The assistant's response content
+            AIServiceResult: Structured result containing the assistant text,
+                optional thinking trace, and token usage.
 
         Raises:
             AIServiceError: If the API call fails

--- a/packages/django-app/app/ai_chat/services/base_ai_service.py
+++ b/packages/django-app/app/ai_chat/services/base_ai_service.py
@@ -1,12 +1,22 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Protocol
 
 
 class AIServiceError(Exception):
     """Base exception for AI service errors"""
 
     pass
+
+
+class ToolExecutor(Protocol):
+    """Callable that runs a custom (client-side) tool and returns a JSON-
+    serialisable result dict. Services use this to complete a tool-use loop
+    when the model asks for a tool that isn't provider-native."""
+
+    def is_known(self, name: str) -> bool: ...
+
+    def execute(self, name: str, args: Dict[str, Any]) -> Dict[str, Any]: ...
 
 
 @dataclass
@@ -47,6 +57,7 @@ class BaseAIService(ABC):
         messages: List[Dict[str, str]],
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
+        tool_executor: Optional[ToolExecutor] = None,
     ) -> AIServiceResult:
         """
         Send messages to AI service and return the response.
@@ -56,6 +67,8 @@ class BaseAIService(ABC):
             tools: Optional list of tools/functions to make available to the model
             system: Optional system prompt. Providers that support a dedicated
                 system slot should mark it with cache_control where possible.
+            tool_executor: Optional callback that runs client-side tools and
+                returns results so the service can complete the tool-use loop.
 
         Returns:
             AIServiceResult: Structured result containing the assistant text,
@@ -71,6 +84,7 @@ class BaseAIService(ABC):
         messages: List[Dict[str, str]],
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
+        tool_executor: Optional[ToolExecutor] = None,
     ) -> Iterator[Dict[str, Any]]:
         """
         Stream the assistant response as incremental events.
@@ -85,7 +99,9 @@ class BaseAIService(ABC):
         `done` event so providers without native streaming still work.
         Subclasses should override for true streaming.
         """
-        result = self.send_message(messages, tools, system=system)
+        result = self.send_message(
+            messages, tools, system=system, tool_executor=tool_executor
+        )
         if result.content:
             yield {"type": "text", "delta": result.content}
         if result.thinking:

--- a/packages/django-app/app/ai_chat/services/google_service.py
+++ b/packages/django-app/app/ai_chat/services/google_service.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 import google.generativeai as genai
 from google.api_core import exceptions as google_exceptions
 
-from .base_ai_service import AIServiceError, BaseAIService
+from .base_ai_service import AIServiceError, AIServiceResult, AIUsage, BaseAIService
 
 logger = logging.getLogger(__name__)
 
@@ -27,38 +27,26 @@ class GoogleService(BaseAIService):
         self,
         messages: List[Dict[str, str]],
         tools: Optional[List[Dict[str, Any]]] = None,
-    ) -> str:
-        """
-        Send messages to Google AI service and return the response content.
-
-        Args:
-            messages: List of message dictionaries with 'role' and 'content' keys
-            tools: Optional list of tools to make available to the model
-
-        Returns:
-            str: The assistant's response content
-
-        Raises:
-            GoogleServiceError: If the API call fails
-        """
+        system: Optional[str] = None,
+    ) -> AIServiceResult:
         try:
             self.validate_messages(messages)
 
-            # Configure generation with tools if provided
+            # Prepend the caller-supplied system prompt if one isn't already present.
+            working_messages = list(messages)
+            if system and not any(m["role"] == "system" for m in working_messages):
+                working_messages = [
+                    {"role": "system", "content": system}
+                ] + working_messages
+
             tool_config = None
-
             if tools:
-                # Convert tools to Google AI format
-                google_tools = self._convert_tools_to_google_format(tools)
-                tool_config = google_tools
+                tool_config = self._convert_tools_to_google_format(tools)
 
-            # Convert messages to Google AI format
-            formatted_messages = self._format_messages_for_google(messages)
+            formatted_messages = self._format_messages_for_google(working_messages)
 
-            # Generate response
             if tool_config:
                 try:
-                    # Try direct tools parameter first
                     response = self.client.generate_content(
                         formatted_messages, tools=tool_config
                     )
@@ -70,7 +58,6 @@ class GoogleService(BaseAIService):
                         logger.warning(
                             f"Google Search Grounding not supported, falling back to regular generation: {e}"
                         )
-                        # Fallback to regular generation without tools
                         response = self.client.generate_content(formatted_messages)
                     else:
                         raise e
@@ -85,7 +72,10 @@ class GoogleService(BaseAIService):
             if not response.text:
                 raise GoogleServiceError("Empty response from Google AI")
 
-            return response.text
+            return AIServiceResult(
+                content=response.text,
+                usage=self._extract_usage(response),
+            )
 
         except google_exceptions.GoogleAPIError as e:
             logger.error(f"Google AI API error: {e}")
@@ -95,16 +85,9 @@ class GoogleService(BaseAIService):
             raise GoogleServiceError(f"Unexpected error: {e}")
 
     def validate_api_key(self) -> bool:
-        """
-        Validate the API key by making a test call.
-
-        Returns:
-            bool: True if API key is valid, False otherwise
-        """
         try:
-            # Use a reliable model for validation
             test_model = genai.GenerativeModel("gemini-1.5-flash")
-            response = test_model.generate_content("Hi")  # Minimal test prompt
+            response = test_model.generate_content("Hi")
             return response.text is not None
         except google_exceptions.GoogleAPIError:
             return False
@@ -112,64 +95,34 @@ class GoogleService(BaseAIService):
             return False
 
     def _format_messages_for_google(self, messages: List[Dict[str, str]]) -> str:
-        """
-        Format messages for Google AI API.
-
-        Google AI expects a single text prompt, so we'll concatenate messages
-        with role indicators.
-
-        Args:
-            messages: List of message dictionaries
-
-        Returns:
-            str: Formatted prompt for Google AI
-        """
         formatted_parts = []
-
         for msg in messages:
             role = msg["role"]
             content = msg["content"]
-
             if role == "system":
                 formatted_parts.append(f"System: {content}")
             elif role == "user":
                 formatted_parts.append(f"User: {content}")
             elif role == "assistant":
                 formatted_parts.append(f"Assistant: {content}")
-
         return "\n\n".join(formatted_parts)
 
     def _convert_tools_to_google_format(
         self, tools: List[Dict[str, Any]]
     ) -> Optional[List[Dict[str, Any]]]:
-        """
-        Convert tools to Google AI format.
-
-        Args:
-            tools: List of tool configurations
-
-        Returns:
-            Optional[List[Dict[str, Any]]]: Tools in Google AI format, or None if not supported
-        """
         try:
             google_tools = []
-
             for tool in tools:
                 if "google_search" in tool:
-                    # Try different formats for Google Search grounding
                     try:
-                        # Method 1: Try the direct dictionary format
-                        google_search_tool = {"google_search_retrieval": {}}
-                        google_tools.append(google_search_tool)
+                        google_tools.append({"google_search_retrieval": {}})
                         logger.info(
                             "Google Search grounding tool added (dictionary format)"
                         )
                     except Exception as e:
                         logger.warning(f"Google Search grounding method 1 failed: {e}")
                         try:
-                            # Method 2: Try alternative format
-                            google_search_tool = {"google_search": {}}
-                            google_tools.append(google_search_tool)
+                            google_tools.append({"google_search": {}})
                             logger.info(
                                 "Google Search grounding tool added (alternative format)"
                             )
@@ -179,7 +132,6 @@ class GoogleService(BaseAIService):
                             )
                             continue
                 elif "url_context" in tool:
-                    # Handle URL context if needed
                     logger.info("URL context tool not implemented yet")
                     continue
 
@@ -188,3 +140,16 @@ class GoogleService(BaseAIService):
         except Exception as e:
             logger.warning(f"Google tools conversion failed: {e}")
             return None
+
+    @staticmethod
+    def _extract_usage(response: Any) -> AIUsage:
+        metadata = getattr(response, "usage_metadata", None)
+        if metadata is None:
+            return AIUsage()
+        return AIUsage(
+            input_tokens=getattr(metadata, "prompt_token_count", 0) or 0,
+            output_tokens=getattr(metadata, "candidates_token_count", 0) or 0,
+            cache_read_input_tokens=(
+                getattr(metadata, "cached_content_token_count", 0) or 0
+            ),
+        )

--- a/packages/django-app/app/ai_chat/services/google_service.py
+++ b/packages/django-app/app/ai_chat/services/google_service.py
@@ -4,7 +4,13 @@ from typing import Any, Dict, Iterator, List, Optional
 import google.generativeai as genai
 from google.api_core import exceptions as google_exceptions
 
-from .base_ai_service import AIServiceError, AIServiceResult, AIUsage, BaseAIService
+from .base_ai_service import (
+    AIServiceError,
+    AIServiceResult,
+    AIUsage,
+    BaseAIService,
+    ToolExecutor,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +34,7 @@ class GoogleService(BaseAIService):
         messages: List[Dict[str, str]],
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
+        tool_executor: Optional[ToolExecutor] = None,
     ) -> AIServiceResult:
         try:
             self.validate_messages(messages)
@@ -89,6 +96,7 @@ class GoogleService(BaseAIService):
         messages: List[Dict[str, str]],
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
+        tool_executor: Optional[ToolExecutor] = None,
     ) -> Iterator[Dict[str, Any]]:
         try:
             self.validate_messages(messages)
@@ -100,9 +108,12 @@ class GoogleService(BaseAIService):
                 ] + working_messages
 
             # Streaming with Google's Search Grounding is not consistently
-            # supported across SDK versions, so only stream plain generations.
-            if tools:
-                yield from super().stream_message(messages, tools, system=system)
+            # supported across SDK versions, and custom tool loops need
+            # multiple round-trips, so fall back in either case.
+            if tools or tool_executor is not None:
+                yield from super().stream_message(
+                    messages, tools, system=system, tool_executor=tool_executor
+                )
                 return
 
             formatted_messages = self._format_messages_for_google(working_messages)

--- a/packages/django-app/app/ai_chat/services/google_service.py
+++ b/packages/django-app/app/ai_chat/services/google_service.py
@@ -129,7 +129,9 @@ class GoogleService(BaseAIService):
                     content_parts.append(text)
                     yield {"type": "text", "delta": text}
 
-            usage = self._extract_usage(last_chunk) if last_chunk is not None else AIUsage()
+            usage = (
+                self._extract_usage(last_chunk) if last_chunk is not None else AIUsage()
+            )
             yield {
                 "type": "done",
                 "content": "".join(content_parts),

--- a/packages/django-app/app/ai_chat/services/google_service.py
+++ b/packages/django-app/app/ai_chat/services/google_service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 import google.generativeai as genai
 from google.api_core import exceptions as google_exceptions
@@ -83,6 +83,56 @@ class GoogleService(BaseAIService):
         except Exception as e:
             logger.error(f"Unexpected error in Google AI service: {e}")
             raise GoogleServiceError(f"Unexpected error: {e}")
+
+    def stream_message(
+        self,
+        messages: List[Dict[str, str]],
+        tools: Optional[List[Dict[str, Any]]] = None,
+        system: Optional[str] = None,
+    ) -> Iterator[Dict[str, Any]]:
+        try:
+            self.validate_messages(messages)
+
+            working_messages = list(messages)
+            if system and not any(m["role"] == "system" for m in working_messages):
+                working_messages = [
+                    {"role": "system", "content": system}
+                ] + working_messages
+
+            # Streaming with Google's Search Grounding is not consistently
+            # supported across SDK versions, so only stream plain generations.
+            if tools:
+                yield from super().stream_message(messages, tools, system=system)
+                return
+
+            formatted_messages = self._format_messages_for_google(working_messages)
+
+            content_parts: List[str] = []
+            last_chunk: Any = None
+
+            stream = self.client.generate_content(formatted_messages, stream=True)
+            for chunk in stream:
+                last_chunk = chunk
+                text = getattr(chunk, "text", None)
+                if text:
+                    content_parts.append(text)
+                    yield {"type": "text", "delta": text}
+
+            usage = self._extract_usage(last_chunk) if last_chunk is not None else AIUsage()
+            yield {
+                "type": "done",
+                "content": "".join(content_parts),
+                "thinking": None,
+                "usage": usage,
+            }
+        except google_exceptions.GoogleAPIError as e:
+            logger.error(f"Google streaming error: {e}")
+            raise GoogleServiceError(f"Google AI streaming error: {e}")
+        except Exception as e:
+            logger.error(f"Google streaming error: {e}")
+            if isinstance(e, GoogleServiceError):
+                raise
+            raise GoogleServiceError(f"Google streaming call failed: {e}")
 
     def validate_api_key(self) -> bool:
         try:

--- a/packages/django-app/app/ai_chat/services/openai_service.py
+++ b/packages/django-app/app/ai_chat/services/openai_service.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 from openai import OpenAI
 from openai.types.chat import ChatCompletion
 
-from .base_ai_service import AIServiceError, BaseAIService
+from .base_ai_service import AIServiceError, AIServiceResult, AIUsage, BaseAIService
 
 logger = logging.getLogger(__name__)
 
@@ -17,11 +17,8 @@ class OpenAIServiceError(AIServiceError):
 
 class OpenAIService(BaseAIService):
     def __init__(self, api_key: str, model: str = "gpt-4o") -> None:
-        self.api_key = api_key
-        self.model = model
-        # Initialize OpenAI client with minimal parameters to avoid proxy issues
+        super().__init__(api_key, model)
         try:
-            # Try with just the API key first
             self.client = OpenAI(api_key=api_key)
         except Exception as e:
             logger.error(f"Failed to initialize OpenAI client: {e}")
@@ -31,65 +28,48 @@ class OpenAIService(BaseAIService):
         self,
         messages: List[Dict[str, str]],
         tools: Optional[List[Dict[str, Any]]] = None,
-    ) -> str:
-        """
-        Send messages to OpenAI API and return the response content.
-
-        Args:
-            messages: List of message dictionaries with 'role' and 'content' keys
-            tools: Optional list of tools to make available to the model
-
-        Returns:
-            str: The assistant's response content
-
-        Raises:
-            OpenAIServiceError: If the API call fails
-        """
+        system: Optional[str] = None,
+    ) -> AIServiceResult:
         try:
-            # Validate messages format using base class method
             self.validate_messages(messages)
 
-            # Prepare API call parameters
+            # OpenAI takes the system prompt as a message; prepend it if provided
+            # and not already embedded. Keeping the system message stable across
+            # requests lets OpenAI's automatic prompt caching (>1024 tokens) kick in.
+            chat_messages = list(messages)
+            if system and not any(m["role"] == "system" for m in chat_messages):
+                chat_messages = [{"role": "system", "content": system}] + chat_messages
+
+            if tools:
+                return self._send_message_with_responses_api(chat_messages, tools)
+
             kwargs = {
                 "model": self.model,
-                "messages": messages,
+                "messages": chat_messages,
                 "max_tokens": 2000,
                 "temperature": 0.7,
             }
-
-            # Check if tools are provided - if so, use Responses API
-            if tools:
-                return self._send_message_with_responses_api(messages, tools)
-
-            # Use regular Chat Completions API
             response: ChatCompletion = self.client.chat.completions.create(**kwargs)
 
-            # Extract the content from the response
-            if response.choices and len(response.choices) > 0:
-                content = response.choices[0].message.content
-                if content:
-                    return content
-                else:
-                    raise OpenAIServiceError("No content in OpenAI response")
-            else:
+            if not response.choices:
                 raise OpenAIServiceError("No choices in OpenAI response")
+            content = response.choices[0].message.content
+            if not content:
+                raise OpenAIServiceError("No content in OpenAI response")
+
+            return AIServiceResult(
+                content=content,
+                usage=self._extract_usage(getattr(response, "usage", None)),
+            )
 
         except Exception as e:
             logger.error(f"OpenAI API error: {str(e)}")
             if isinstance(e, OpenAIServiceError):
                 raise
-            else:
-                raise OpenAIServiceError(f"OpenAI API call failed: {str(e)}") from e
+            raise OpenAIServiceError(f"OpenAI API call failed: {str(e)}") from e
 
     def validate_api_key(self) -> bool:
-        """
-        Validate the OpenAI API key by making a test call.
-
-        Returns:
-            bool: True if API key is valid, False otherwise
-        """
         try:
-            # Make a minimal test call to validate the API key
             test_messages = [{"role": "user", "content": "Hi"}]
             response = self.client.chat.completions.create(
                 model=self.model, messages=test_messages, max_tokens=1
@@ -101,44 +81,42 @@ class OpenAIService(BaseAIService):
 
     def _send_message_with_responses_api(
         self, messages: List[Dict[str, str]], tools: List[Dict[str, Any]]
-    ) -> str:
-        """
-        Send message using OpenAI's Responses API for native web search
-
-        Args:
-            messages: List of message dictionaries
-            tools: List of tools to use
-
-        Returns:
-            str: The assistant's response content
-        """
+    ) -> AIServiceResult:
+        """Send message using OpenAI's Responses API for native web search."""
         try:
-            # Convert messages to a single input string for Responses API
-            # Take the last user message as the input
             user_messages = [msg for msg in messages if msg["role"] == "user"]
             if not user_messages:
                 raise OpenAIServiceError("No user messages found for Responses API")
 
             input_text = user_messages[-1]["content"]
 
-            # Make the Responses API call with native web search
             response = self.client.responses.create(
                 model=self.model, tools=tools, input=input_text
             )
 
-            # Extract the text from the response
-            if hasattr(response, "output_text") and response.output_text:
-                return response.output_text
-            elif hasattr(response, "output") and response.output:
-                # Handle different response formats
+            content: Optional[str] = None
+            if getattr(response, "output_text", None):
+                content = response.output_text
+            elif getattr(response, "output", None):
                 for item in response.output:
-                    if hasattr(item, "type") and item.type == "message":
-                        if hasattr(item, "content") and item.content:
-                            for content_item in item.content:
-                                if hasattr(content_item, "text"):
-                                    return content_item.text
+                    if getattr(item, "type", None) == "message":
+                        for content_item in getattr(item, "content", []) or []:
+                            text = getattr(content_item, "text", None)
+                            if text:
+                                content = text
+                                break
+                    if content:
+                        break
 
-            raise OpenAIServiceError("No text content found in Responses API response")
+            if not content:
+                raise OpenAIServiceError(
+                    "No text content found in Responses API response"
+                )
+
+            return AIServiceResult(
+                content=content,
+                usage=self._extract_usage(getattr(response, "usage", None)),
+            )
 
         except AttributeError as e:
             if "'OpenAI' object has no attribute 'responses'" in str(e):
@@ -146,11 +124,9 @@ class OpenAIService(BaseAIService):
                     "OpenAI SDK version doesn't support Responses API, falling back to Chat Completions without web search"
                 )
                 return self._send_message_without_tools(messages)
-            else:
-                raise OpenAIServiceError(f"OpenAI Responses API error: {str(e)}") from e
+            raise OpenAIServiceError(f"OpenAI Responses API error: {str(e)}") from e
         except Exception as e:
             logger.error(f"OpenAI Responses API error: {str(e)}")
-            # Try to determine if it's a Responses API availability issue
             if any(
                 keyword in str(e).lower()
                 for keyword in ["responses", "not found", "unsupported"]
@@ -159,35 +135,59 @@ class OpenAIService(BaseAIService):
                     "Responses API not available, falling back to Chat Completions without web search"
                 )
                 return self._send_message_without_tools(messages)
-            else:
-                raise OpenAIServiceError(
-                    f"OpenAI Responses API call failed: {str(e)}"
-                ) from e
+            raise OpenAIServiceError(
+                f"OpenAI Responses API call failed: {str(e)}"
+            ) from e
 
-    def _send_message_without_tools(self, messages: List[Dict[str, str]]) -> str:
-        """
-        Send message using regular Chat Completions API without tools
-
-        Args:
-            messages: List of message dictionaries
-
-        Returns:
-            str: The assistant's response content
-        """
+    def _send_message_without_tools(
+        self, messages: List[Dict[str, str]]
+    ) -> AIServiceResult:
         kwargs = {
             "model": self.model,
             "messages": messages,
             "max_tokens": 2000,
             "temperature": 0.7,
         }
-
         response: ChatCompletion = self.client.chat.completions.create(**kwargs)
 
-        if response.choices and len(response.choices) > 0:
-            content = response.choices[0].message.content
-            if content:
-                return content
-            else:
-                raise OpenAIServiceError("No content in OpenAI response")
-        else:
+        if not response.choices:
             raise OpenAIServiceError("No choices in OpenAI response")
+        content = response.choices[0].message.content
+        if not content:
+            raise OpenAIServiceError("No content in OpenAI response")
+
+        return AIServiceResult(
+            content=content,
+            usage=self._extract_usage(getattr(response, "usage", None)),
+        )
+
+    @staticmethod
+    def _extract_usage(usage_obj: Any) -> AIUsage:
+        if usage_obj is None:
+            return AIUsage()
+
+        # Chat Completions uses prompt_tokens/completion_tokens;
+        # Responses API uses input_tokens/output_tokens.
+        input_tokens = (
+            getattr(usage_obj, "input_tokens", None)
+            if getattr(usage_obj, "input_tokens", None) is not None
+            else getattr(usage_obj, "prompt_tokens", 0)
+        ) or 0
+        output_tokens = (
+            getattr(usage_obj, "output_tokens", None)
+            if getattr(usage_obj, "output_tokens", None) is not None
+            else getattr(usage_obj, "completion_tokens", 0)
+        ) or 0
+
+        cached = 0
+        details = getattr(usage_obj, "prompt_tokens_details", None) or getattr(
+            usage_obj, "input_tokens_details", None
+        )
+        if details is not None:
+            cached = getattr(details, "cached_tokens", 0) or 0
+
+        return AIUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=cached,
+        )

--- a/packages/django-app/app/ai_chat/services/openai_service.py
+++ b/packages/django-app/app/ai_chat/services/openai_service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from openai import OpenAI
 from openai.types.chat import ChatCompletion
@@ -67,6 +67,66 @@ class OpenAIService(BaseAIService):
             if isinstance(e, OpenAIServiceError):
                 raise
             raise OpenAIServiceError(f"OpenAI API call failed: {str(e)}") from e
+
+    def stream_message(
+        self,
+        messages: List[Dict[str, str]],
+        tools: Optional[List[Dict[str, Any]]] = None,
+        system: Optional[str] = None,
+    ) -> Iterator[Dict[str, Any]]:
+        try:
+            self.validate_messages(messages)
+
+            chat_messages = list(messages)
+            if system and not any(m["role"] == "system" for m in chat_messages):
+                chat_messages = [{"role": "system", "content": system}] + chat_messages
+
+            # The Responses API (used for native web search) does not yet share
+            # the same streaming contract as Chat Completions. Fall back to the
+            # default buffered stream when tools are requested.
+            if tools:
+                yield from super().stream_message(messages, tools, system=system)
+                return
+
+            kwargs = {
+                "model": self.model,
+                "messages": chat_messages,
+                "max_tokens": 2000,
+                "temperature": 0.7,
+                "stream": True,
+                "stream_options": {"include_usage": True},
+            }
+
+            content_parts: List[str] = []
+            usage = AIUsage()
+
+            stream = self.client.chat.completions.create(**kwargs)
+            for chunk in stream:
+                chunk_usage = getattr(chunk, "usage", None)
+                if chunk_usage is not None:
+                    usage = self._extract_usage(chunk_usage)
+
+                choices = getattr(chunk, "choices", None) or []
+                if not choices:
+                    continue
+                delta = getattr(choices[0], "delta", None)
+                text = getattr(delta, "content", None) if delta else None
+                if text:
+                    content_parts.append(text)
+                    yield {"type": "text", "delta": text}
+
+            content = "".join(content_parts)
+            yield {
+                "type": "done",
+                "content": content,
+                "thinking": None,
+                "usage": usage,
+            }
+        except Exception as e:
+            logger.error(f"OpenAI streaming error: {str(e)}")
+            if isinstance(e, OpenAIServiceError):
+                raise
+            raise OpenAIServiceError(f"OpenAI streaming call failed: {str(e)}") from e
 
     def validate_api_key(self) -> bool:
         try:

--- a/packages/django-app/app/ai_chat/services/openai_service.py
+++ b/packages/django-app/app/ai_chat/services/openai_service.py
@@ -4,7 +4,13 @@ from typing import Any, Dict, Iterator, List, Optional
 from openai import OpenAI
 from openai.types.chat import ChatCompletion
 
-from .base_ai_service import AIServiceError, AIServiceResult, AIUsage, BaseAIService
+from .base_ai_service import (
+    AIServiceError,
+    AIServiceResult,
+    AIUsage,
+    BaseAIService,
+    ToolExecutor,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +35,7 @@ class OpenAIService(BaseAIService):
         messages: List[Dict[str, str]],
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
+        tool_executor: Optional[ToolExecutor] = None,
     ) -> AIServiceResult:
         try:
             self.validate_messages(messages)
@@ -73,6 +80,7 @@ class OpenAIService(BaseAIService):
         messages: List[Dict[str, str]],
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
+        tool_executor: Optional[ToolExecutor] = None,
     ) -> Iterator[Dict[str, Any]]:
         try:
             self.validate_messages(messages)
@@ -82,10 +90,13 @@ class OpenAIService(BaseAIService):
                 chat_messages = [{"role": "system", "content": system}] + chat_messages
 
             # The Responses API (used for native web search) does not yet share
-            # the same streaming contract as Chat Completions. Fall back to the
-            # default buffered stream when tools are requested.
-            if tools:
-                yield from super().stream_message(messages, tools, system=system)
+            # the same streaming contract as Chat Completions, and custom tool
+            # loops require multiple round-trips. Fall back to the buffered
+            # stream in either case.
+            if tools or tool_executor is not None:
+                yield from super().stream_message(
+                    messages, tools, system=system, tool_executor=tool_executor
+                )
                 return
 
             kwargs = {

--- a/packages/django-app/app/ai_chat/test/test_api.py
+++ b/packages/django-app/app/ai_chat/test/test_api.py
@@ -12,7 +12,7 @@ from ai_chat.models import (
     UserAISettings,
     UserProviderConfig,
 )
-from ai_chat.services.base_ai_service import AIServiceError
+from ai_chat.services.base_ai_service import AIServiceError, AIServiceResult
 from ai_chat.test.helpers import (
     AnthropicProviderFactory,
     ChatMessageFactory,
@@ -92,7 +92,9 @@ class AIChatAPITestCase(TestCase):
         """Test successful message sending through API"""
         # Mock AI service response
         mock_service = Mock()
-        mock_service.send_message.return_value = "Hello! How can I help you today?"
+        mock_service.send_message.return_value = AIServiceResult(
+            content="Hello! How can I help you today?"
+        )
         mock_create_service.return_value = mock_service
 
         data = {"message": "Hello, AI!", "model": "gpt-4"}
@@ -122,8 +124,8 @@ class AIChatAPITestCase(TestCase):
     def test_send_message_with_context_blocks(self, mock_create_service):
         """Test sending message with context blocks"""
         mock_service = Mock()
-        mock_service.send_message.return_value = (
-            "Based on your notes, here's my advice..."
+        mock_service.send_message.return_value = AIServiceResult(
+            content="Based on your notes, here's my advice..."
         )
         mock_create_service.return_value = mock_service
 
@@ -154,7 +156,9 @@ class AIChatAPITestCase(TestCase):
     def test_send_message_with_existing_session(self, mock_create_service):
         """Test sending message to existing session"""
         mock_service = Mock()
-        mock_service.send_message.return_value = "Continuing our conversation..."
+        mock_service.send_message.return_value = AIServiceResult(
+            content="Continuing our conversation..."
+        )
         mock_create_service.return_value = mock_service
 
         # Create existing session with messages
@@ -419,7 +423,7 @@ class AIChatAPITestCase(TestCase):
     def test_send_message_invalid_session_id(self, mock_create_service):
         """Test sending message with invalid session ID creates new session"""
         mock_service = Mock()
-        mock_service.send_message.return_value = "Response"
+        mock_service.send_message.return_value = AIServiceResult(content="Response")
         mock_create_service.return_value = mock_service
 
         # Use a properly formatted UUID that doesn't exist instead of "invalid-uuid"

--- a/packages/django-app/app/ai_chat/test/test_send_message_command.py
+++ b/packages/django-app/app/ai_chat/test/test_send_message_command.py
@@ -129,6 +129,7 @@ class SendMessageCommandTestCase(TestCase):
             [{"role": "user", "content": "Hello, AI!"}],
             [{"type": "web_search_preview", "search_context_size": "medium"}],
             system=BRAINSPREAD_SYSTEM_PROMPT,
+            tool_executor=None,
         )
 
     @patch("ai_chat.services.ai_service_factory.AIServiceFactory.create_service")

--- a/packages/django-app/app/ai_chat/test/test_send_message_command.py
+++ b/packages/django-app/app/ai_chat/test/test_send_message_command.py
@@ -4,13 +4,14 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from ai_chat.commands.send_message_command import (
+    BRAINSPREAD_SYSTEM_PROMPT,
     SendMessageCommand,
     SendMessageCommandError,
 )
 from ai_chat.forms import SendMessageForm
 from ai_chat.models import AIModel
 from ai_chat.services.ai_service_factory import AIServiceFactoryError
-from ai_chat.services.base_ai_service import AIServiceError
+from ai_chat.services.base_ai_service import AIServiceError, AIServiceResult, AIUsage
 from ai_chat.test.helpers import (
     ChatSessionFactory,
     OpenAIProviderFactory,
@@ -101,7 +102,10 @@ class SendMessageCommandTestCase(TestCase):
         mock_get_messages.return_value = [mock_message]
 
         mock_service = Mock()
-        mock_service.send_message.return_value = "Hello! How can I help you?"
+        mock_service.send_message.return_value = AIServiceResult(
+            content="Hello! How can I help you?",
+            usage=AIUsage(input_tokens=3, output_tokens=5),
+        )
         mock_create_service.return_value = mock_service
 
         # Execute command
@@ -124,6 +128,7 @@ class SendMessageCommandTestCase(TestCase):
         mock_service.send_message.assert_called_once_with(
             [{"role": "user", "content": "Hello, AI!"}],
             [{"type": "web_search_preview", "search_context_size": "medium"}],
+            system=BRAINSPREAD_SYSTEM_PROMPT,
         )
 
     @patch("ai_chat.services.ai_service_factory.AIServiceFactory.create_service")
@@ -149,7 +154,9 @@ class SendMessageCommandTestCase(TestCase):
         mock_get_messages.return_value = mock_messages
 
         mock_service = Mock()
-        mock_service.send_message.return_value = "Follow-up response"
+        mock_service.send_message.return_value = AIServiceResult(
+            content="Follow-up response"
+        )
         mock_create_service.return_value = mock_service
 
         # Execute command
@@ -233,7 +240,6 @@ class SendMessageCommandTestCase(TestCase):
         self.assertIn("AI service error", str(context.exception))
 
         # Verify error message was added to session
-        # The last call should include the AI model parameter
         calls = mock_add_message.call_args_list
         last_call = calls[-1]
         self.assertEqual(last_call[0][0], session)
@@ -242,7 +248,7 @@ class SendMessageCommandTestCase(TestCase):
             last_call[0][2],
             "Sorry, I'm experiencing technical difficulties: API rate limit exceeded",
         )
-        self.assertEqual(last_call[0][3], self.gpt4_model)
+        self.assertEqual(last_call.kwargs["ai_model"], self.gpt4_model)
 
     @patch("ai_chat.services.ai_service_factory.AIServiceFactory.create_service")
     @patch(
@@ -365,8 +371,8 @@ class SendMessageCommandTestCase(TestCase):
         mock_get_messages.return_value = [mock_message]
 
         mock_service = Mock()
-        mock_service.send_message.return_value = (
-            "Based on your notes, here's what I suggest..."
+        mock_service.send_message.return_value = AIServiceResult(
+            content="Based on your notes, here's what I suggest..."
         )
         mock_create_service.return_value = mock_service
 

--- a/packages/django-app/app/ai_chat/test/test_stream_send_message_command.py
+++ b/packages/django-app/app/ai_chat/test/test_stream_send_message_command.py
@@ -1,0 +1,86 @@
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+from ai_chat.commands.stream_send_message_command import StreamSendMessageCommand
+from ai_chat.forms import SendMessageForm
+from ai_chat.models import AIModel
+from ai_chat.services.base_ai_service import AIUsage
+from ai_chat.test.helpers import (
+    OpenAIProviderFactory,
+    UserProviderConfigFactory,
+)
+from core.test.helpers import UserFactory
+
+
+class StreamSendMessageCommandTestCase(TestCase):
+    """Test StreamSendMessageCommand with mocked streaming services."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(email="stream@example.com")
+        cls.openai_provider = OpenAIProviderFactory()
+
+    def setUp(self):
+        self.model = AIModel.objects.create(
+            name="gpt-4",
+            provider=self.openai_provider,
+            display_name="GPT-4",
+            is_active=True,
+        )
+        UserProviderConfigFactory(
+            user=self.user,
+            provider=self.openai_provider,
+            api_key="stream-api-key",
+            enabled_models=[self.model],
+        )
+
+    def _create_form(self):
+        return SendMessageForm(
+            {
+                "user": self.user.id,
+                "message": "Hello",
+                "model": "gpt-4",
+                "context_blocks": [],
+            }
+        )
+
+    @patch("ai_chat.services.ai_service_factory.AIServiceFactory.create_service")
+    @patch(
+        "ai_chat.repositories.chat_message_repository.ChatMessageRepository.get_messages"
+    )
+    def test_emits_session_text_and_done_events(
+        self, mock_get_messages, mock_create_service
+    ):
+        mock_get_messages.return_value = [Mock(role="user", content="Hello")]
+
+        def fake_stream(messages, tools, system=None):
+            yield {"type": "text", "delta": "Hi "}
+            yield {"type": "text", "delta": "there"}
+            yield {
+                "type": "done",
+                "content": "Hi there",
+                "thinking": None,
+                "usage": AIUsage(input_tokens=2, output_tokens=3),
+            }
+
+        mock_service = Mock()
+        mock_service.stream_message.side_effect = fake_stream
+        mock_create_service.return_value = mock_service
+
+        form = self._create_form()
+        command = StreamSendMessageCommand(form)
+        events = list(command.execute())
+
+        types = [e["type"] for e in events]
+        self.assertEqual(types[0], "session")
+        self.assertIn("text", types)
+        self.assertEqual(types[-1], "done")
+
+        text_deltas = [e["delta"] for e in events if e["type"] == "text"]
+        self.assertEqual("".join(text_deltas), "Hi there")
+
+        done = events[-1]
+        self.assertEqual(done["message"]["content"], "Hi there")
+        self.assertEqual(done["message"]["usage"]["input_tokens"], 2)
+        self.assertEqual(done["message"]["usage"]["output_tokens"], 3)

--- a/packages/django-app/app/ai_chat/test/test_stream_send_message_command.py
+++ b/packages/django-app/app/ai_chat/test/test_stream_send_message_command.py
@@ -54,7 +54,7 @@ class StreamSendMessageCommandTestCase(TestCase):
     ):
         mock_get_messages.return_value = [Mock(role="user", content="Hello")]
 
-        def fake_stream(messages, tools, system=None):
+        def fake_stream(messages, tools, system=None, tool_executor=None):
             yield {"type": "text", "delta": "Hi "}
             yield {"type": "text", "delta": "there"}
             yield {

--- a/packages/django-app/app/ai_chat/tests/test_anthropic_service.py
+++ b/packages/django-app/app/ai_chat/tests/test_anthropic_service.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from ai_chat.services.anthropic_service import (
+    AnthropicService,
+    AnthropicServiceError,
+    THINKING_BUDGET_TOKENS,
+)
+from ai_chat.services.base_ai_service import AIServiceResult
+
+
+def _build_response(
+    *,
+    text: str = "hi there",
+    thinking: str = "",
+    input_tokens: int = 5,
+    output_tokens: int = 7,
+    cache_creation: int = 0,
+    cache_read: int = 0,
+):
+    blocks = []
+    if thinking:
+        blocks.append(SimpleNamespace(type="thinking", thinking=thinking))
+    blocks.append(SimpleNamespace(type="text", text=text))
+    usage = SimpleNamespace(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_creation_input_tokens=cache_creation,
+        cache_read_input_tokens=cache_read,
+    )
+    return SimpleNamespace(content=blocks, usage=usage)
+
+
+class TestAnthropicServiceThinking:
+    @patch("anthropic.Anthropic")
+    def test_enables_thinking_on_supported_model(self, mock_anthropic_cls):
+        mock_client = Mock()
+        mock_client.messages.create.return_value = _build_response(
+            text="answer", thinking="reasoning trace"
+        )
+        mock_anthropic_cls.return_value = mock_client
+
+        service = AnthropicService(api_key="k", model="claude-opus-4-7")
+        result = service.send_message(
+            [{"role": "user", "content": "Hello"}],
+            system="brainspread system prompt",
+        )
+
+        assert isinstance(result, AIServiceResult)
+        assert result.content == "answer"
+        assert result.thinking == "reasoning trace"
+        assert result.usage.input_tokens == 5
+        assert result.usage.output_tokens == 7
+
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert kwargs["thinking"] == {
+            "type": "enabled",
+            "budget_tokens": THINKING_BUDGET_TOKENS,
+        }
+        # System prompt is rendered as a cacheable block
+        assert kwargs["system"] == [
+            {
+                "type": "text",
+                "text": "brainspread system prompt",
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+
+    @patch("anthropic.Anthropic")
+    def test_skips_thinking_on_non_4x_model(self, mock_anthropic_cls):
+        mock_client = Mock()
+        mock_client.messages.create.return_value = _build_response()
+        mock_anthropic_cls.return_value = mock_client
+
+        service = AnthropicService(api_key="k", model="claude-3-5-sonnet-legacy")
+        service.send_message([{"role": "user", "content": "Hi"}])
+
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert "thinking" not in kwargs
+
+    @patch("anthropic.Anthropic")
+    def test_extracts_cache_usage_counts(self, mock_anthropic_cls):
+        mock_client = Mock()
+        mock_client.messages.create.return_value = _build_response(
+            cache_creation=100, cache_read=500
+        )
+        mock_anthropic_cls.return_value = mock_client
+
+        service = AnthropicService(api_key="k", model="claude-haiku-4-5")
+        result = service.send_message([{"role": "user", "content": "Hi"}])
+
+        assert result.usage.cache_creation_input_tokens == 100
+        assert result.usage.cache_read_input_tokens == 500
+
+    @patch("anthropic.Anthropic")
+    def test_validates_message_format(self, mock_anthropic_cls):
+        mock_anthropic_cls.return_value = Mock()
+        service = AnthropicService(api_key="k", model="claude-opus-4-7")
+
+        with pytest.raises(AnthropicServiceError):
+            service.send_message([{"role": "user"}])

--- a/packages/django-app/app/ai_chat/tests/test_anthropic_service.py
+++ b/packages/django-app/app/ai_chat/tests/test_anthropic_service.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock, patch
 import pytest
 
 from ai_chat.services.anthropic_service import (
-    THINKING_BUDGET_TOKENS,
     AnthropicService,
     AnthropicServiceError,
 )
@@ -56,9 +55,10 @@ class TestAnthropicServiceThinking:
 
         kwargs = mock_client.messages.create.call_args.kwargs
         assert kwargs["thinking"] == {
-            "type": "enabled",
-            "budget_tokens": THINKING_BUDGET_TOKENS,
+            "type": "adaptive",
+            "display": "summarized",
         }
+        assert kwargs["output_config"] == {"effort": "high"}
         # System prompt is rendered as a cacheable block
         assert kwargs["system"] == [
             {
@@ -93,6 +93,20 @@ class TestAnthropicServiceThinking:
 
         assert result.usage.cache_creation_input_tokens == 100
         assert result.usage.cache_read_input_tokens == 500
+
+    @patch("anthropic.Anthropic")
+    def test_haiku_gets_thinking_but_no_effort(self, mock_anthropic_cls):
+        mock_client = Mock()
+        mock_client.messages.create.return_value = _build_response()
+        mock_anthropic_cls.return_value = mock_client
+
+        service = AnthropicService(api_key="k", model="claude-haiku-4-5")
+        service.send_message([{"role": "user", "content": "Hi"}])
+
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
+        # effort would 400 on Haiku — make sure we don't send it.
+        assert "output_config" not in kwargs
 
     @patch("anthropic.Anthropic")
     def test_validates_message_format(self, mock_anthropic_cls):

--- a/packages/django-app/app/ai_chat/tests/test_anthropic_service.py
+++ b/packages/django-app/app/ai_chat/tests/test_anthropic_service.py
@@ -4,9 +4,9 @@ from unittest.mock import Mock, patch
 import pytest
 
 from ai_chat.services.anthropic_service import (
+    THINKING_BUDGET_TOKENS,
     AnthropicService,
     AnthropicServiceError,
-    THINKING_BUDGET_TOKENS,
 )
 from ai_chat.services.base_ai_service import AIServiceResult
 

--- a/packages/django-app/app/ai_chat/tests/test_google_service.py
+++ b/packages/django-app/app/ai_chat/tests/test_google_service.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 import pytest
 from google.api_core import exceptions as google_exceptions
 
+from ai_chat.services.base_ai_service import AIServiceResult
 from ai_chat.services.google_service import GoogleService, GoogleServiceError
 
 
@@ -15,12 +16,15 @@ class TestGoogleService:
 
     @patch("google.generativeai.GenerativeModel")
     def test_send_message_success(self, mock_model_class):
-        """Test successful message sending"""
-        # Mock the response
+        """Test successful message sending returns AIServiceResult with usage"""
         mock_response = Mock()
         mock_response.text = "Hello! How can I help you?"
+        mock_response.usage_metadata = Mock(
+            prompt_token_count=10,
+            candidates_token_count=20,
+            cached_content_token_count=0,
+        )
 
-        # Mock the model instance
         mock_model = Mock()
         mock_model.generate_content.return_value = mock_response
         mock_model_class.return_value = mock_model
@@ -31,10 +35,12 @@ class TestGoogleService:
 
         result = service.send_message(messages)
 
-        assert result == "Hello! How can I help you?"
+        assert isinstance(result, AIServiceResult)
+        assert result.content == "Hello! How can I help you?"
+        assert result.usage.input_tokens == 10
+        assert result.usage.output_tokens == 20
         mock_model.generate_content.assert_called_once()
 
-        # Check the formatted message
         call_args = mock_model.generate_content.call_args[0][0]
         assert "User: Hello" in call_args
 
@@ -43,6 +49,7 @@ class TestGoogleService:
         """Test message sending with system message"""
         mock_response = Mock()
         mock_response.text = "Response"
+        mock_response.usage_metadata = None
 
         mock_model = Mock()
         mock_model.generate_content.return_value = mock_response
@@ -55,17 +62,37 @@ class TestGoogleService:
             {"role": "user", "content": "Hello"},
         ]
 
-        result = service.send_message(messages)
+        service.send_message(messages)
 
         call_args = mock_model.generate_content.call_args[0][0]
         assert "System: You are a helpful assistant" in call_args
         assert "User: Hello" in call_args
 
     @patch("google.generativeai.GenerativeModel")
+    def test_send_message_injects_caller_system_prompt(self, mock_model_class):
+        """Caller-provided system= should be injected if no system msg is embedded."""
+        mock_response = Mock()
+        mock_response.text = "Response"
+        mock_response.usage_metadata = None
+
+        mock_model = Mock()
+        mock_model.generate_content.return_value = mock_response
+        mock_model_class.return_value = mock_model
+
+        service = GoogleService(api_key="test-key", model="gemini-1.5-pro")
+        service.send_message(
+            [{"role": "user", "content": "Hi"}], system="You are brainspread."
+        )
+
+        call_args = mock_model.generate_content.call_args[0][0]
+        assert "System: You are brainspread." in call_args
+
+    @patch("google.generativeai.GenerativeModel")
     def test_send_message_empty_response(self, mock_model_class):
         """Test handling of empty response"""
         mock_response = Mock()
         mock_response.text = None
+        mock_response.usage_metadata = None
 
         mock_model = Mock()
         mock_model.generate_content.return_value = mock_response

--- a/packages/django-app/app/ai_chat/tests/test_notes_tool_executor.py
+++ b/packages/django-app/app/ai_chat/tests/test_notes_tool_executor.py
@@ -1,0 +1,74 @@
+from django.test import TestCase
+
+from ai_chat.tools.notes_tool_executor import NotesToolExecutor
+from core.test.helpers import UserFactory
+from knowledge.test.helpers import BlockFactory, PageFactory
+
+
+class NotesToolExecutorTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(email="notes-tools@example.com")
+        cls.other_user = UserFactory(email="other@example.com")
+
+        cls.page = PageFactory(user=cls.user, title="Project Alpha", slug="project-alpha")
+        cls.block = BlockFactory(
+            user=cls.user,
+            page=cls.page,
+            content="Follow up with design team",
+            block_type="todo",
+        )
+        cls.child = BlockFactory(
+            user=cls.user,
+            page=cls.page,
+            parent=cls.block,
+            content="Confirm launch date",
+        )
+        # Noise that must not leak across users.
+        BlockFactory(
+            user=cls.other_user,
+            page=PageFactory(user=cls.other_user, title="Other"),
+            content="Follow up on launch",
+        )
+
+    def test_search_notes_scopes_to_user(self):
+        executor = NotesToolExecutor(self.user)
+
+        result = executor.execute("search_notes", {"query": "follow up"})
+
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["results"][0]["page_title"], "Project Alpha")
+        self.assertEqual(result["results"][0]["block_type"], "todo")
+
+    def test_get_page_by_title_returns_root_blocks(self):
+        executor = NotesToolExecutor(self.user)
+
+        result = executor.execute("get_page_by_title", {"title": "project alpha"})
+
+        self.assertEqual(result["page"]["slug"], "project-alpha")
+        self.assertEqual(len(result["blocks"]), 1)
+        self.assertEqual(result["blocks"][0]["content"], "Follow up with design team")
+
+    def test_get_block_by_id_returns_children(self):
+        executor = NotesToolExecutor(self.user)
+
+        result = executor.execute("get_block_by_id", {"block_uuid": str(self.block.uuid)})
+
+        self.assertEqual(result["block"]["content"], "Follow up with design team")
+        self.assertEqual(len(result["children"]), 1)
+        self.assertEqual(result["children"][0]["content"], "Confirm launch date")
+
+    def test_unknown_tool_returns_error(self):
+        executor = NotesToolExecutor(self.user)
+
+        result = executor.execute("delete_all_notes", {})
+
+        self.assertIn("error", result)
+
+    def test_is_known(self):
+        executor = NotesToolExecutor(self.user)
+
+        self.assertTrue(executor.is_known("search_notes"))
+        self.assertTrue(executor.is_known("get_page_by_title"))
+        self.assertTrue(executor.is_known("get_block_by_id"))
+        self.assertFalse(executor.is_known("write_block"))

--- a/packages/django-app/app/ai_chat/tests/test_notes_tool_executor.py
+++ b/packages/django-app/app/ai_chat/tests/test_notes_tool_executor.py
@@ -11,7 +11,9 @@ class NotesToolExecutorTestCase(TestCase):
         cls.user = UserFactory(email="notes-tools@example.com")
         cls.other_user = UserFactory(email="other@example.com")
 
-        cls.page = PageFactory(user=cls.user, title="Project Alpha", slug="project-alpha")
+        cls.page = PageFactory(
+            user=cls.user, title="Project Alpha", slug="project-alpha"
+        )
         cls.block = BlockFactory(
             user=cls.user,
             page=cls.page,
@@ -52,7 +54,9 @@ class NotesToolExecutorTestCase(TestCase):
     def test_get_block_by_id_returns_children(self):
         executor = NotesToolExecutor(self.user)
 
-        result = executor.execute("get_block_by_id", {"block_uuid": str(self.block.uuid)})
+        result = executor.execute(
+            "get_block_by_id", {"block_uuid": str(self.block.uuid)}
+        )
 
         self.assertEqual(result["block"]["content"], "Follow up with design team")
         self.assertEqual(len(result["children"]), 1)

--- a/packages/django-app/app/ai_chat/tests/test_openai_service.py
+++ b/packages/django-app/app/ai_chat/tests/test_openai_service.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from ai_chat.services.base_ai_service import AIServiceResult
+from ai_chat.services.openai_service import OpenAIService
+
+
+def _build_chat_response(
+    *,
+    text: str = "hi",
+    prompt_tokens: int = 42,
+    completion_tokens: int = 13,
+    cached_tokens: int = 0,
+):
+    message = SimpleNamespace(content=text)
+    choice = SimpleNamespace(message=message)
+    details = SimpleNamespace(cached_tokens=cached_tokens)
+    usage = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        prompt_tokens_details=details,
+    )
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+class TestOpenAIServiceUsage:
+    @patch("ai_chat.services.openai_service.OpenAI")
+    def test_extracts_usage_and_cached_tokens(self, mock_openai_cls):
+        mock_client = Mock()
+        mock_client.chat.completions.create.return_value = _build_chat_response(
+            cached_tokens=20
+        )
+        mock_openai_cls.return_value = mock_client
+
+        service = OpenAIService(api_key="k", model="gpt-4o")
+        result = service.send_message([{"role": "user", "content": "hi"}])
+
+        assert isinstance(result, AIServiceResult)
+        assert result.content == "hi"
+        assert result.usage.input_tokens == 42
+        assert result.usage.output_tokens == 13
+        assert result.usage.cache_read_input_tokens == 20
+
+    @patch("ai_chat.services.openai_service.OpenAI")
+    def test_injects_caller_system_prompt(self, mock_openai_cls):
+        mock_client = Mock()
+        mock_client.chat.completions.create.return_value = _build_chat_response()
+        mock_openai_cls.return_value = mock_client
+
+        service = OpenAIService(api_key="k", model="gpt-4o")
+        service.send_message(
+            [{"role": "user", "content": "hi"}], system="brainspread system"
+        )
+
+        kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert kwargs["messages"][0] == {
+            "role": "system",
+            "content": "brainspread system",
+        }
+
+    @patch("ai_chat.services.openai_service.OpenAI")
+    def test_does_not_duplicate_system_prompt(self, mock_openai_cls):
+        mock_client = Mock()
+        mock_client.chat.completions.create.return_value = _build_chat_response()
+        mock_openai_cls.return_value = mock_client
+
+        service = OpenAIService(api_key="k", model="gpt-4o")
+        service.send_message(
+            [
+                {"role": "system", "content": "embedded"},
+                {"role": "user", "content": "hi"},
+            ],
+            system="outer system",
+        )
+
+        kwargs = mock_client.chat.completions.create.call_args.kwargs
+        system_messages = [m for m in kwargs["messages"] if m["role"] == "system"]
+        assert len(system_messages) == 1
+        assert system_messages[0]["content"] == "embedded"

--- a/packages/django-app/app/ai_chat/tools/notes_tool_executor.py
+++ b/packages/django-app/app/ai_chat/tools/notes_tool_executor.py
@@ -1,0 +1,133 @@
+"""Execute assistant-requested notes tool calls.
+
+Keeps the `get_tool_result` surface small and JSON-serialisable so the
+provider service can feed it straight back as a `tool_result` block.
+"""
+
+import logging
+from typing import Any, Dict, List
+
+from core.models import User
+from knowledge.repositories.block_repository import BlockRepository
+from knowledge.repositories.page_repository import PageRepository
+
+from .notes_tools import NOTES_TOOL_NAMES
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SEARCH_LIMIT = 10
+MAX_SEARCH_LIMIT = 25
+
+
+class NotesToolExecutor:
+    """Dispatches a custom tool call to a read-only knowledge query."""
+
+    def __init__(self, user: User) -> None:
+        self.user = user
+
+    def is_known(self, name: str) -> bool:
+        return name in NOTES_TOOL_NAMES
+
+    def execute(self, name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            if name == "search_notes":
+                return self._search_notes(args)
+            if name == "get_page_by_title":
+                return self._get_page_by_title(args)
+            if name == "get_block_by_id":
+                return self._get_block_by_id(args)
+            return {"error": f"Unknown tool: {name}"}
+        except Exception as e:
+            logger.exception("Notes tool %s failed", name)
+            return {"error": f"Tool {name} failed: {e}"}
+
+    def _search_notes(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        query = (args.get("query") or "").strip()
+        if not query:
+            return {"error": "query is required"}
+
+        raw_limit = args.get("limit") or DEFAULT_SEARCH_LIMIT
+        try:
+            limit = int(raw_limit)
+        except (TypeError, ValueError):
+            limit = DEFAULT_SEARCH_LIMIT
+        limit = max(1, min(limit, MAX_SEARCH_LIMIT))
+
+        blocks = (
+            BlockRepository.search_by_content(self.user, query)
+            .select_related("page")
+            .order_by("-modified_at")[:limit]
+        )
+        results: List[Dict[str, Any]] = []
+        for block in blocks:
+            results.append(
+                {
+                    "block_uuid": str(block.uuid),
+                    "page_title": block.page.title if block.page else None,
+                    "page_slug": block.page.slug if block.page else None,
+                    "block_type": block.block_type,
+                    "content": block.content,
+                }
+            )
+        return {"query": query, "count": len(results), "results": results}
+
+    def _get_page_by_title(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        title = (args.get("title") or "").strip()
+        if not title:
+            return {"error": "title is required"}
+
+        page = (
+            PageRepository.get_queryset()
+            .filter(user=self.user, title__iexact=title)
+            .first()
+        )
+        if not page:
+            return {"error": f"No page found with title '{title}'"}
+
+        root_blocks = BlockRepository.get_root_blocks(page)
+        return {
+            "page": {
+                "uuid": str(page.uuid),
+                "title": page.title,
+                "slug": page.slug,
+                "page_type": page.page_type,
+            },
+            "blocks": [
+                {
+                    "block_uuid": str(block.uuid),
+                    "block_type": block.block_type,
+                    "content": block.content,
+                    "order": block.order,
+                }
+                for block in root_blocks
+            ],
+        }
+
+    def _get_block_by_id(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        block_uuid = (args.get("block_uuid") or "").strip()
+        if not block_uuid:
+            return {"error": "block_uuid is required"}
+
+        block = BlockRepository.get_by_uuid(block_uuid, user=self.user)
+        if not block:
+            return {"error": f"No block found with uuid {block_uuid}"}
+
+        children = BlockRepository.get_child_blocks(block)
+        return {
+            "block": {
+                "block_uuid": str(block.uuid),
+                "block_type": block.block_type,
+                "content": block.content,
+                "page_title": block.page.title if block.page else None,
+                "page_slug": block.page.slug if block.page else None,
+            },
+            "children": [
+                {
+                    "block_uuid": str(child.uuid),
+                    "block_type": child.block_type,
+                    "content": child.content,
+                    "order": child.order,
+                }
+                for child in children
+            ],
+        }

--- a/packages/django-app/app/ai_chat/tools/notes_tools.py
+++ b/packages/django-app/app/ai_chat/tools/notes_tools.py
@@ -1,0 +1,106 @@
+"""Read-only notes tools exposed to the assistant.
+
+These are custom (client-executed) tools: the model emits a tool_use block,
+we run the Django query, and return the result as a tool_result. They let
+the assistant pull specific pages/blocks on demand instead of requiring
+all context upfront.
+
+Only read operations are exposed intentionally — write operations need a
+richer permission and confirmation flow before we let the model act.
+"""
+
+from typing import Any, Dict, List
+
+# Anthropic expects: {name, description, input_schema: JSONSchema}.
+# OpenAI's function-calling expects: {type: "function", function: {name, ...}}.
+# We store the common shape here and adapt per provider at the call site.
+NOTES_TOOLS: List[Dict[str, Any]] = [
+    {
+        "name": "search_notes",
+        "description": (
+            "Full-text search over the user's note blocks. Returns up to `limit`"
+            " matching blocks with their page title, block content, and block uuid."
+            " Use this when the user refers to notes whose exact location is unknown."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Substring to search for in block content (case-insensitive).",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of matching blocks to return (default 10, max 25).",
+                    "minimum": 1,
+                    "maximum": 25,
+                },
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "get_page_by_title",
+        "description": (
+            "Fetch a single page by its title (case-insensitive, exact match)"
+            " along with its root blocks. Prefer this when the user names a page."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "Page title to look up.",
+                },
+            },
+            "required": ["title"],
+        },
+    },
+    {
+        "name": "get_block_by_id",
+        "description": (
+            "Fetch a single block by uuid and its direct children. Use after"
+            " search_notes to expand a promising hit into more detail."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "block_uuid": {
+                    "type": "string",
+                    "description": "UUID of the block to fetch.",
+                },
+            },
+            "required": ["block_uuid"],
+        },
+    },
+]
+
+
+NOTES_TOOL_NAMES = frozenset(tool["name"] for tool in NOTES_TOOLS)
+
+
+def anthropic_notes_tools() -> List[Dict[str, Any]]:
+    """Notes tools in Anthropic's tool schema."""
+    return [
+        {
+            "name": tool["name"],
+            "description": tool["description"],
+            "input_schema": tool["input_schema"],
+        }
+        for tool in NOTES_TOOLS
+    ]
+
+
+def openai_notes_tools() -> List[Dict[str, Any]]:
+    """Notes tools in OpenAI's function-calling schema."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": tool["name"],
+                "description": tool["description"],
+                "parameters": tool["input_schema"],
+            },
+        }
+        for tool in NOTES_TOOLS
+    ]

--- a/packages/django-app/app/ai_chat/urls.py
+++ b/packages/django-app/app/ai_chat/urls.py
@@ -6,6 +6,11 @@ app_name = "ai_chat"
 
 urlpatterns = [
     path("send/", views.send_message, name="send_message"),
+    path(
+        "stream/",
+        views.StreamSendMessageView.as_view(),
+        name="stream_send_message",
+    ),
     path("sessions/", views.chat_sessions, name="chat_sessions"),
     path(
         "sessions/<str:session_id>/",

--- a/packages/django-app/app/ai_chat/views.py
+++ b/packages/django-app/app/ai_chat/views.py
@@ -142,7 +142,14 @@ def chat_session_detail(request, session_id):
             {
                 "role": msg.role,
                 "content": msg.content,
+                "thinking": msg.thinking or None,
                 "created_at": msg.created_at.isoformat(),
+                "usage": {
+                    "input_tokens": msg.input_tokens,
+                    "output_tokens": msg.output_tokens,
+                    "cache_creation_input_tokens": msg.cache_creation_input_tokens,
+                    "cache_read_input_tokens": msg.cache_read_input_tokens,
+                },
                 "ai_model": (
                     {
                         "name": msg.ai_model.name,

--- a/packages/django-app/app/ai_chat/views.py
+++ b/packages/django-app/app/ai_chat/views.py
@@ -1,12 +1,15 @@
+import json
 import logging
 from typing import TypedDict
 
+from django.http import StreamingHttpResponse
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
-from .commands import SendMessageCommand
+from .commands import SendMessageCommand, StreamSendMessageCommand
 from .commands.send_message_command import SendMessageCommandError
 from .forms import SendMessageForm
 from .models import (
@@ -82,6 +85,62 @@ def send_message(request):
             },
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
+
+
+def _sse_event(payload: dict) -> bytes:
+    """Encode a dict as a single `data:` SSE frame."""
+    return f"data: {json.dumps(payload)}\n\n".encode("utf-8")
+
+
+class StreamSendMessageView(APIView):
+    """SSE endpoint for streaming assistant responses."""
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        data = request.data.copy()
+        data["user"] = request.user.id
+        form = SendMessageForm(data)
+        if not form.is_valid():
+            error_message = (
+                str(list(form.errors.values())[0][0])
+                if form.errors
+                else "Invalid form data"
+            )
+            return Response(
+                {
+                    "success": False,
+                    "error": error_message,
+                    "error_type": "configuration_error",
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        command = StreamSendMessageCommand(form)
+
+        def event_stream():
+            try:
+                for event in command.execute():
+                    yield _sse_event(event)
+            except SendMessageCommandError as e:
+                logger.warning(
+                    f"Stream command error for user {request.user.id}: {str(e)}"
+                )
+                yield _sse_event({"type": "error", "error": str(e)})
+            except Exception as e:
+                logger.error(
+                    f"Unexpected error in stream_send_message for user {request.user.id}: {str(e)}"
+                )
+                yield _sse_event(
+                    {"type": "error", "error": "An unexpected error occurred."}
+                )
+
+        response = StreamingHttpResponse(
+            event_stream(), content_type="text/event-stream"
+        )
+        response["Cache-Control"] = "no-cache"
+        response["X-Accel-Buffering"] = "no"
+        return response
 
 
 @api_view(["GET"])

--- a/packages/django-app/app/ai_chat/views.py
+++ b/packages/django-app/app/ai_chat/views.py
@@ -6,6 +6,7 @@ from django.http import StreamingHttpResponse
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.renderers import BaseRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -92,10 +93,25 @@ def _sse_event(payload: dict) -> bytes:
     return f"data: {json.dumps(payload)}\n\n".encode("utf-8")
 
 
+class ServerSentEventRenderer(BaseRenderer):
+    """Allow DRF content negotiation to accept `text/event-stream` clients.
+
+    The view returns a StreamingHttpResponse directly, so this renderer is
+    never invoked — it only exists to make negotiation match.
+    """
+
+    media_type = "text/event-stream"
+    format = "sse"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        return data
+
+
 class StreamSendMessageView(APIView):
     """SSE endpoint for streaming assistant responses."""
 
     permission_classes = [IsAuthenticated]
+    renderer_classes = [ServerSentEventRenderer]
 
     def post(self, request):
         data = request.data.copy()

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -476,26 +476,19 @@ body {
   opacity: 0.85;
 }
 
-/* Tools chip: border change signals the popover is open; a small ✓ glyph
-   next to the label signals "at least one tool is on". We don't invert
-   fg/bg like ctx because the popover itself carries the detailed state. */
-.chat-controls .tools-btn.open {
+/* Tools chip inverts fg/bg when any tool is on — matches the ctx chip
+   treatment so "chip inverted = feature on" is a single consistent rule. */
+.chat-controls .tools-btn.active {
+  background: var(--text-primary) !important;
+  color: var(--bg-primary) !important;
   border-color: var(--text-primary) !important;
 }
 
-/* Always reserved to keep the button width constant whether or not any
-   tool is active — avoids layout jitter when toggling. */
-.tools-btn-check {
-  font-weight: bold;
-  color: var(--text-primary);
-  display: inline-block;
-  width: 0.7rem;
-  text-align: center;
-  visibility: hidden;
-}
-
-.tools-btn-check.active {
-  visibility: visible;
+.chat-controls .tools-btn.active:hover {
+  background: var(--text-primary) !important;
+  color: var(--bg-primary) !important;
+  border-color: var(--text-primary) !important;
+  opacity: 0.85;
 }
 
 /* Tools popover — anchored above the trigger since controls sit at the bottom */

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -435,7 +435,7 @@ body {
 /* Chat controls buttons - FORCE same height as model selector */
 .chat-controls .settings-btn,
 .chat-controls .context-btn,
-.chat-controls .notes-tools-btn {
+.chat-controls .tools-btn {
   background: var(--bg-primary) !important;
   border: 1px solid var(--border-secondary) !important;
   color: var(--text-primary) !important;
@@ -446,7 +446,7 @@ body {
   display: flex !important;
   align-items: center !important;
   justify-content: center !important;
-  gap: 0.25rem !important;
+  gap: 0.3rem !important;
   min-width: 35px !important;
   height: 36px !important;
   box-sizing: border-box !important;
@@ -454,32 +454,94 @@ body {
   letter-spacing: 0.5px !important;
 }
 
-.chat-controls .settings-btn:hover {
-  color: var(--text-primary) !important;
-  border-color: var(--border-primary) !important;
-  background: var(--hover-bg) !important;
-}
-
+.chat-controls .settings-btn:hover,
 .chat-controls .context-btn:hover,
-.chat-controls .notes-tools-btn:hover {
+.chat-controls .tools-btn:hover {
   color: var(--text-primary) !important;
   border-color: var(--border-primary) !important;
   background: var(--hover-bg) !important;
 }
 
-/* Active capability chips invert fg/bg so the on-state is obvious at a glance */
-.chat-controls .context-btn.active,
-.chat-controls .notes-tools-btn.active {
+/* Context chip inverts when active so users can see attach-mode on at a glance */
+.chat-controls .context-btn.active {
   background: var(--text-primary) !important;
   color: var(--bg-primary) !important;
   border-color: var(--text-primary) !important;
 }
 
-.chat-controls .context-btn.active:hover,
-.chat-controls .notes-tools-btn.active:hover {
+.chat-controls .context-btn.active:hover {
   background: var(--text-primary) !important;
   color: var(--bg-primary) !important;
   border-color: var(--text-primary) !important;
+  opacity: 0.85;
+}
+
+/* Tools chip: low-key border + small indicator dot when any tool is on.
+   We don't invert fg/bg like ctx because the indicator + popover carry the
+   state and full inversion would compete with the context chip visually. */
+.chat-controls .tools-btn.active,
+.chat-controls .tools-btn.open {
+  border-color: var(--text-primary) !important;
+}
+
+.tools-btn-indicator {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-primary);
+  display: inline-block;
+}
+
+/* Tools popover — anchored above the trigger since controls sit at the bottom */
+.tools-container {
+  position: relative;
+}
+
+.tools-menu {
+  position: absolute;
+  bottom: calc(100% + 0.25rem);
+  right: 0;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  box-shadow: 0 -4px 6px rgba(0, 0, 0, 0.1);
+  min-width: 260px;
+  z-index: 1000;
+  padding: 0.25rem;
+}
+
+.tools-menu-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.tools-menu-item:hover {
+  background: var(--hover-bg);
+}
+
+.tools-menu-item input[type="checkbox"] {
+  margin-top: 0.15rem;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.tools-menu-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.tools-menu-name {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.tools-menu-hint {
+  color: var(--text-secondary);
+  font-size: 0.7rem;
   opacity: 0.85;
 }
 

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -434,7 +434,8 @@ body {
 
 /* Chat controls buttons - FORCE same height as model selector */
 .chat-controls .settings-btn,
-.chat-controls .context-btn {
+.chat-controls .context-btn,
+.chat-controls .notes-tools-btn {
   background: var(--bg-primary) !important;
   border: 1px solid var(--border-secondary) !important;
   color: var(--text-primary) !important;
@@ -461,6 +462,13 @@ body {
 
 .chat-controls .context-btn:hover,
 .chat-controls .context-btn.active {
+  color: var(--text-primary) !important;
+  border-color: var(--context-color) !important;
+  background: var(--hover-bg) !important;
+}
+
+.chat-controls .notes-tools-btn:hover,
+.chat-controls .notes-tools-btn.active {
   color: var(--text-primary) !important;
   border-color: var(--context-color) !important;
   background: var(--hover-bg) !important;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -3463,6 +3463,43 @@ kbd {
   margin-left: 0.25rem;
 }
 
+.message-timestamp .usage-info {
+  color: var(--text-secondary);
+  font-size: 0.7rem;
+  font-weight: 400;
+  margin-left: 0.25rem;
+  opacity: 0.75;
+}
+
+.thinking-block {
+  margin-bottom: 0.5rem;
+  border-left: 2px solid var(--text-secondary);
+  padding-left: 0.5rem;
+  opacity: 0.8;
+}
+
+.thinking-toggle {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0;
+  font-family: inherit;
+}
+
+.thinking-toggle:hover {
+  color: var(--text-primary);
+}
+
+.thinking-content {
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  font-style: italic;
+  white-space: pre-wrap;
+}
+
 /* Page Components */
 .page-page {
   width: 100%;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -476,20 +476,16 @@ body {
   opacity: 0.85;
 }
 
-/* Tools chip: low-key border + small indicator dot when any tool is on.
-   We don't invert fg/bg like ctx because the indicator + popover carry the
-   state and full inversion would compete with the context chip visually. */
-.chat-controls .tools-btn.active,
+/* Tools chip: border change signals the popover is open; a small ✓ glyph
+   next to the label signals "at least one tool is on". We don't invert
+   fg/bg like ctx because the popover itself carries the detailed state. */
 .chat-controls .tools-btn.open {
   border-color: var(--text-primary) !important;
 }
 
-.tools-btn-indicator {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--text-primary);
-  display: inline-block;
+.tools-btn-check {
+  font-weight: bold;
+  color: var(--text-primary);
 }
 
 /* Tools popover — anchored above the trigger since controls sit at the bottom */
@@ -512,20 +508,51 @@ body {
 .tools-menu-item {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
+  gap: 0.6rem;
   padding: 0.5rem;
   cursor: pointer;
   font-size: 0.8rem;
+  user-select: none;
 }
 
 .tools-menu-item:hover {
   background: var(--hover-bg);
 }
 
+/* Mirror the SettingsModal .model-checkbox styling so tool toggles use the
+   same custom checkmark glyph as the rest of the app. */
 .tools-menu-item input[type="checkbox"] {
-  margin-top: 0.15rem;
+  appearance: none;
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 2px solid var(--border-primary);
+  background: var(--bg-primary);
   cursor: pointer;
+  position: relative;
   flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+
+.tools-menu-item input[type="checkbox"]:hover,
+.tools-menu-item input[type="checkbox"]:focus {
+  border-color: var(--text-primary);
+  outline: none;
+}
+
+.tools-menu-item input[type="checkbox"]:checked {
+  background: var(--text-primary);
+  border-color: var(--text-primary);
+}
+
+.tools-menu-item input[type="checkbox"]:checked::after {
+  content: "✓";
+  position: absolute;
+  top: -3px;
+  left: 1px;
+  font-size: 0.85rem;
+  color: var(--bg-primary);
+  font-weight: bold;
+  line-height: 1;
 }
 
 .tools-menu-label {

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -461,17 +461,26 @@ body {
 }
 
 .chat-controls .context-btn:hover,
-.chat-controls .context-btn.active {
+.chat-controls .notes-tools-btn:hover {
   color: var(--text-primary) !important;
-  border-color: var(--context-color) !important;
+  border-color: var(--border-primary) !important;
   background: var(--hover-bg) !important;
 }
 
-.chat-controls .notes-tools-btn:hover,
+/* Active capability chips invert fg/bg so the on-state is obvious at a glance */
+.chat-controls .context-btn.active,
 .chat-controls .notes-tools-btn.active {
-  color: var(--text-primary) !important;
-  border-color: var(--context-color) !important;
-  background: var(--hover-bg) !important;
+  background: var(--text-primary) !important;
+  color: var(--bg-primary) !important;
+  border-color: var(--text-primary) !important;
+}
+
+.chat-controls .context-btn.active:hover,
+.chat-controls .notes-tools-btn.active:hover {
+  background: var(--text-primary) !important;
+  color: var(--bg-primary) !important;
+  border-color: var(--text-primary) !important;
+  opacity: 0.85;
 }
 
 /* Settings Modal */
@@ -3047,6 +3056,25 @@ kbd {
   background: var(--accent-bg);
   order: 1;
   min-height: 40px;
+}
+
+/* Session stats strip — sits above .chat-controls in the input area */
+.session-stats {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  padding: 0.3rem 0.6rem;
+  background: var(--accent-bg);
+  border-top: 1px solid var(--border-secondary);
+  color: var(--text-secondary);
+  font-size: 0.7rem;
+  order: 0;
+  opacity: 0.85;
+}
+
+.session-stats-sep {
+  opacity: 0.5;
 }
 
 /* Message Input Row */

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -483,9 +483,19 @@ body {
   border-color: var(--text-primary) !important;
 }
 
+/* Always reserved to keep the button width constant whether or not any
+   tool is active — avoids layout jitter when toggling. */
 .tools-btn-check {
   font-weight: bold;
   color: var(--text-primary);
+  display: inline-block;
+  width: 0.7rem;
+  text-align: center;
+  visibility: hidden;
+}
+
+.tools-btn-check.active {
+  visibility: visible;
 }
 
 /* Tools popover — anchored above the trigger since controls sit at the bottom */
@@ -547,9 +557,10 @@ body {
 .tools-menu-item input[type="checkbox"]:checked::after {
   content: "✓";
   position: absolute;
-  top: -3px;
-  left: 1px;
-  font-size: 0.85rem;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 0.8rem;
   color: var(--bg-primary);
   font-weight: bold;
   line-height: 1;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
@@ -869,7 +869,7 @@ const ChatPanel = {
                 :title="hasActiveTools ? 'Tools (some active)' : 'Tools'"
               >
                 tools
-                <span v-if="hasActiveTools" class="tools-btn-check" aria-label="tool active">✓</span>
+                <span class="tools-btn-check" :class="{ active: hasActiveTools }" aria-hidden="true">✓</span>
               </button>
               <div v-if="showToolsMenu" class="tools-menu">
                 <label class="tools-menu-item">

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
@@ -57,6 +57,37 @@ const ChatPanel = {
       deep: true,
     },
   },
+  computed: {
+    sessionStats() {
+      let inputTokens = 0;
+      let outputTokens = 0;
+      let cacheRead = 0;
+      let cacheCreation = 0;
+      let turns = 0;
+      for (const msg of this.messages) {
+        if (msg.role !== "assistant" || !msg.usage) continue;
+        turns += 1;
+        inputTokens += msg.usage.input_tokens || 0;
+        outputTokens += msg.usage.output_tokens || 0;
+        cacheRead += msg.usage.cache_read_input_tokens || 0;
+        cacheCreation += msg.usage.cache_creation_input_tokens || 0;
+      }
+      const totalInput = inputTokens + cacheRead + cacheCreation;
+      const cacheRatio = totalInput > 0 ? cacheRead / totalInput : 0;
+      return {
+        turns,
+        inputTokens,
+        outputTokens,
+        cacheRead,
+        cacheCreation,
+        totalInput,
+        cacheRatio,
+      };
+    },
+    hasSessionStats() {
+      return this.sessionStats.turns > 0;
+    },
+  },
   methods: {
     loadOpenState() {
       const saved = localStorage.getItem("chatPanel.isOpen");
@@ -553,13 +584,27 @@ const ChatPanel = {
       };
     },
 
+    formatTokens(n) {
+      if (n == null) return "0";
+      if (n >= 1000) return (n / 1000).toFixed(1) + "k";
+      return String(n);
+    },
+
     formatUsage(usage) {
       if (!usage) return "";
-      const parts = [];
-      if (usage.input_tokens != null) parts.push(`in ${usage.input_tokens}`);
-      if (usage.output_tokens != null) parts.push(`out ${usage.output_tokens}`);
-      const cached = usage.cache_read_input_tokens || 0;
-      if (cached > 0) parts.push(`cached ${cached}`);
+      const input = usage.input_tokens || 0;
+      const output = usage.output_tokens || 0;
+      const cacheRead = usage.cache_read_input_tokens || 0;
+      const cacheCreation = usage.cache_creation_input_tokens || 0;
+      const parts = [
+        `in ${this.formatTokens(input + cacheRead + cacheCreation)}`,
+        `out ${this.formatTokens(output)}`,
+      ];
+      const totalInput = input + cacheRead + cacheCreation;
+      if (totalInput > 0 && cacheRead > 0) {
+        const pct = Math.round((cacheRead / totalInput) * 100);
+        parts.push(`${pct}% cached`);
+      }
       return parts.join(" · ");
     },
 
@@ -567,7 +612,9 @@ const ChatPanel = {
       if (!usage) return false;
       return (
         (usage.input_tokens != null && usage.input_tokens > 0) ||
-        (usage.output_tokens != null && usage.output_tokens > 0)
+        (usage.output_tokens != null && usage.output_tokens > 0) ||
+        (usage.cache_read_input_tokens != null &&
+          usage.cache_read_input_tokens > 0)
       );
     },
 
@@ -755,6 +802,17 @@ const ChatPanel = {
         </div>
         
         <div class="input-area">
+          <div v-if="hasSessionStats" class="session-stats" title="Session token usage">
+            <span>{{ sessionStats.turns }} turn{{ sessionStats.turns === 1 ? '' : 's' }}</span>
+            <span class="session-stats-sep">·</span>
+            <span>in {{ formatTokens(sessionStats.totalInput) }}</span>
+            <span class="session-stats-sep">·</span>
+            <span>out {{ formatTokens(sessionStats.outputTokens) }}</span>
+            <template v-if="sessionStats.cacheRead > 0">
+              <span class="session-stats-sep">·</span>
+              <span>{{ Math.round(sessionStats.cacheRatio * 100) }}% cached</span>
+            </template>
+          </div>
           <div class="chat-controls">
             <div class="model-selector" v-if="aiSettings">
               <button 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
@@ -150,7 +150,8 @@ const ChatPanel = {
             this.messages[assistantIndex].content += event.delta || "";
           } else if (event.type === "thinking") {
             this.messages[assistantIndex].thinking =
-              (this.messages[assistantIndex].thinking || "") + (event.delta || "");
+              (this.messages[assistantIndex].thinking || "") +
+              (event.delta || "");
           } else if (event.type === "done") {
             if (event.message) {
               this.messages.splice(assistantIndex, 1, {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
@@ -111,41 +111,60 @@ const ChatPanel = {
       };
       this.message = "";
       this.loading = true;
+
+      const assistantMsg = {
+        role: "assistant",
+        content: "",
+        thinking: "",
+        created_at: new Date().toISOString(),
+        usage: null,
+        ai_model: null,
+        streaming: true,
+      };
+      this.messages.push(assistantMsg);
+      const assistantIndex = this.messages.length - 1;
+
       try {
-        const result = await window.apiService.sendAIMessage(payload);
-        if (result.success) {
-          // Use the complete message data from the API response
-          if (result.data.message) {
-            this.messages.push(result.data.message);
-          } else {
-            // Fallback for backward compatibility
-            this.messages.push({
-              role: "assistant",
-              content: result.data.response,
-              created_at: new Date().toISOString(),
-            });
+        let streamed = false;
+        for await (const event of window.apiService.streamAIMessage(payload)) {
+          streamed = true;
+          if (event.type === "session") {
+            if (event.session_id && !this.currentSessionId) {
+              this.currentSessionId = event.session_id;
+              this.saveLastSessionId(event.session_id);
+            }
+          } else if (event.type === "text") {
+            this.messages[assistantIndex].content += event.delta || "";
+          } else if (event.type === "thinking") {
+            this.messages[assistantIndex].thinking =
+              (this.messages[assistantIndex].thinking || "") + (event.delta || "");
+          } else if (event.type === "done") {
+            if (event.message) {
+              this.messages.splice(assistantIndex, 1, {
+                ...event.message,
+                streaming: false,
+              });
+            } else {
+              this.messages[assistantIndex].streaming = false;
+            }
+            if (event.session_id && !this.currentSessionId) {
+              this.currentSessionId = event.session_id;
+              this.saveLastSessionId(event.session_id);
+            }
+          } else if (event.type === "error") {
+            this.messages[assistantIndex].content =
+              `Error: ${event.error || "Failed to send message"}`;
+            this.messages[assistantIndex].streaming = false;
           }
-          if (result.data.session_id && !this.currentSessionId) {
-            this.currentSessionId = result.data.session_id;
-            this.saveLastSessionId(result.data.session_id);
-          }
-        } else {
-          // Handle error response
-          const errorMsg = result.error || "Failed to send message";
-          this.messages.push({
-            role: "assistant",
-            content: `Error: ${errorMsg}`,
-            created_at: new Date().toISOString(),
-          });
+        }
+        if (!streamed) {
+          throw new Error("Empty stream response");
         }
       } catch (err) {
         console.error(err);
-        this.messages.push({
-          role: "assistant",
-          content:
-            "Error: Failed to send message. Please check your connection and try again.",
-          created_at: new Date().toISOString(),
-        });
+        this.messages[assistantIndex].content =
+          "Error: Failed to send message. Please check your connection and try again.";
+        this.messages[assistantIndex].streaming = false;
       } finally {
         this.loading = false;
       }
@@ -645,7 +664,14 @@ const ChatPanel = {
               </button>
               <div v-if="expandedThinking[index]" class="thinking-content" v-html="parseMarkdown(msg.thinking)"></div>
             </div>
-            <div class="message-content" v-html="parseMarkdown(msg.content)"></div>
+            <div v-if="msg.role === 'assistant' && msg.streaming && !msg.content" class="message-content loading-content">
+              <div class="typing-indicator">
+                <span></span>
+                <span></span>
+                <span></span>
+              </div>
+            </div>
+            <div v-else class="message-content" v-html="parseMarkdown(msg.content)"></div>
             <div class="message-footer">
               <div class="message-timestamp">
                 {{ formatTimestamp(msg.created_at) }}
@@ -672,15 +698,6 @@ const ChatPanel = {
                     copy message
                   </button>
                 </div>
-              </div>
-            </div>
-          </div>
-          <div v-if="loading" class="message-bubble assistant loading">
-            <div class="message-content loading-content">
-              <div class="typing-indicator">
-                <span></span>
-                <span></span>
-                <span></span>
               </div>
             </div>
           </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
@@ -865,11 +865,10 @@ const ChatPanel = {
               <button
                 class="tools-btn"
                 @click="toggleToolsMenu"
-                :class="{ open: showToolsMenu }"
+                :class="{ active: hasActiveTools }"
                 :title="hasActiveTools ? 'Tools (some active)' : 'Tools'"
               >
                 tools
-                <span class="tools-btn-check" :class="{ active: hasActiveTools }" aria-hidden="true">✓</span>
               </button>
               <div v-if="showToolsMenu" class="tools-menu">
                 <label class="tools-menu-item">

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
@@ -32,6 +32,7 @@ const ChatPanel = {
       messageMenus: {},
       expandedThinking: {},
       enableNotesTools: this.loadNotesToolsPref(),
+      showToolsMenu: false,
     };
   },
   mounted() {
@@ -87,6 +88,9 @@ const ChatPanel = {
     hasSessionStats() {
       return this.sessionStats.turns > 0;
     },
+    hasActiveTools() {
+      return this.enableNotesTools;
+    },
   },
   methods: {
     loadOpenState() {
@@ -120,6 +124,9 @@ const ChatPanel = {
         "chatPanel.enableNotesTools",
         JSON.stringify(this.enableNotesTools)
       );
+    },
+    toggleToolsMenu() {
+      this.showToolsMenu = !this.showToolsMenu;
     },
     saveWidth() {
       localStorage.setItem("chatPanel.width", this.width.toString());
@@ -678,6 +685,13 @@ const ChatPanel = {
     // Click outside to close panel
     setupClickOutsideListener() {
       this.clickOutsideHandler = (e) => {
+        // Close the tools popover when clicking anywhere outside it.
+        // Clicks on menu items (inside .tools-container) are allowed so
+        // users can flip multiple toggles in one session.
+        if (this.showToolsMenu && !e.target.closest(".tools-container")) {
+          this.showToolsMenu = false;
+        }
+
         // Only close if panel is open and click is outside the panel
         if (this.isOpen && !this.$el.contains(e.target)) {
           // Check if click is within the history dropdown (teleported content)
@@ -847,14 +861,30 @@ const ChatPanel = {
             >
               ctx
             </button>
-            <button
-              class="notes-tools-btn"
-              @click="toggleNotesTools"
-              :class="{ active: enableNotesTools }"
-              :title="enableNotesTools ? 'Notes tools enabled (Anthropic)' : 'Enable notes tools (Anthropic)'"
-            >
-              notes
-            </button>
+            <div class="tools-container">
+              <button
+                class="tools-btn"
+                @click="toggleToolsMenu"
+                :class="{ active: hasActiveTools, open: showToolsMenu }"
+                :title="hasActiveTools ? 'Tools (some active)' : 'Tools'"
+              >
+                tools
+                <span v-if="hasActiveTools" class="tools-btn-indicator" aria-hidden="true"></span>
+              </button>
+              <div v-if="showToolsMenu" class="tools-menu">
+                <label class="tools-menu-item">
+                  <input
+                    type="checkbox"
+                    :checked="enableNotesTools"
+                    @change="toggleNotesTools"
+                  />
+                  <span class="tools-menu-label">
+                    <span class="tools-menu-name">search notes</span>
+                    <span class="tools-menu-hint">Let the assistant search your notes (Anthropic only).</span>
+                  </span>
+                </label>
+              </div>
+            </div>
             <button class="settings-btn" @click="openSettings" title="AI Settings">cfg</button>
           </div>
           <div class="message-input">

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
@@ -30,6 +30,7 @@ const ChatPanel = {
       selectedModel: null,
       showContextArea: false,
       messageMenus: {},
+      expandedThinking: {},
     };
   },
   mounted() {
@@ -512,6 +513,31 @@ const ChatPanel = {
       }
     },
 
+    toggleThinking(messageIndex) {
+      this.expandedThinking = {
+        ...this.expandedThinking,
+        [messageIndex]: !this.expandedThinking[messageIndex],
+      };
+    },
+
+    formatUsage(usage) {
+      if (!usage) return "";
+      const parts = [];
+      if (usage.input_tokens != null) parts.push(`in ${usage.input_tokens}`);
+      if (usage.output_tokens != null) parts.push(`out ${usage.output_tokens}`);
+      const cached = usage.cache_read_input_tokens || 0;
+      if (cached > 0) parts.push(`cached ${cached}`);
+      return parts.join(" · ");
+    },
+
+    hasUsage(usage) {
+      if (!usage) return false;
+      return (
+        (usage.input_tokens != null && usage.input_tokens > 0) ||
+        (usage.output_tokens != null && usage.output_tokens > 0)
+      );
+    },
+
     // Message menu methods
     toggleMessageMenu(messageIndex) {
       // Close all other menus first
@@ -613,12 +639,21 @@ const ChatPanel = {
         </div>
         <div class="messages">
           <div v-for="(msg, index) in messages" :key="index" :class="['message-bubble', msg.role]">
+            <div v-if="msg.role === 'assistant' && msg.thinking" class="thinking-block">
+              <button class="thinking-toggle" @click="toggleThinking(index)">
+                {{ expandedThinking[index] ? '▾' : '▸' }} thinking
+              </button>
+              <div v-if="expandedThinking[index]" class="thinking-content" v-html="parseMarkdown(msg.thinking)"></div>
+            </div>
             <div class="message-content" v-html="parseMarkdown(msg.content)"></div>
             <div class="message-footer">
               <div class="message-timestamp">
                 {{ formatTimestamp(msg.created_at) }}
                 <span v-if="msg.role === 'assistant' && msg.ai_model" class="model-info">
                   · {{ msg.ai_model.display_name || msg.ai_model.name }}
+                </span>
+                <span v-if="msg.role === 'assistant' && hasUsage(msg.usage)" class="usage-info" :title="'Token usage'">
+                  · {{ formatUsage(msg.usage) }}
                 </span>
               </div>
               <div class="message-menu-container" v-if="msg.role === 'assistant'">

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
@@ -865,11 +865,11 @@ const ChatPanel = {
               <button
                 class="tools-btn"
                 @click="toggleToolsMenu"
-                :class="{ active: hasActiveTools, open: showToolsMenu }"
+                :class="{ open: showToolsMenu }"
                 :title="hasActiveTools ? 'Tools (some active)' : 'Tools'"
               >
                 tools
-                <span v-if="hasActiveTools" class="tools-btn-indicator" aria-hidden="true"></span>
+                <span v-if="hasActiveTools" class="tools-btn-check" aria-label="tool active">✓</span>
               </button>
               <div v-if="showToolsMenu" class="tools-menu">
                 <label class="tools-menu-item">

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
@@ -31,6 +31,7 @@ const ChatPanel = {
       showContextArea: false,
       messageMenus: {},
       expandedThinking: {},
+      enableNotesTools: this.loadNotesToolsPref(),
     };
   },
   mounted() {
@@ -78,6 +79,17 @@ const ChatPanel = {
     saveOpenState() {
       localStorage.setItem("chatPanel.isOpen", JSON.stringify(this.isOpen));
     },
+    loadNotesToolsPref() {
+      const saved = localStorage.getItem("chatPanel.enableNotesTools");
+      return saved === null ? false : JSON.parse(saved);
+    },
+    toggleNotesTools() {
+      this.enableNotesTools = !this.enableNotesTools;
+      localStorage.setItem(
+        "chatPanel.enableNotesTools",
+        JSON.stringify(this.enableNotesTools)
+      );
+    },
     saveWidth() {
       localStorage.setItem("chatPanel.width", this.width.toString());
     },
@@ -108,6 +120,7 @@ const ChatPanel = {
         model: this.selectedModel,
         session_id: this.currentSessionId,
         context_blocks: this.chatContextBlocks,
+        enable_notes_tools: this.enableNotesTools,
       };
       this.message = "";
       this.loading = true;
@@ -767,13 +780,21 @@ const ChatPanel = {
                 </div>
               </div>
             </div>
-            <button 
-              class="context-btn" 
-              @click="toggleContextArea" 
+            <button
+              class="context-btn"
+              @click="toggleContextArea"
               :class="{ active: hasContext() }"
               :title="hasContext() ? 'Context (' + getContextCount() + ')' : 'Add context'"
             >
               ctx
+            </button>
+            <button
+              class="notes-tools-btn"
+              @click="toggleNotesTools"
+              :class="{ active: enableNotesTools }"
+              :title="enableNotesTools ? 'Notes tools enabled (Anthropic)' : 'Enable notes tools (Anthropic)'"
+            >
+              notes
             </button>
             <button class="settings-btn" @click="openSettings" title="AI Settings">cfg</button>
           </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -318,6 +318,64 @@ class ApiService {
     });
   }
 
+  async *streamAIMessage(payload) {
+    const headers = {
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+    };
+    const csrfToken = this.getCsrfToken();
+    if (csrfToken) {
+      headers["X-CSRFToken"] = csrfToken;
+    }
+    if (this.token) {
+      headers["Authorization"] = `Token ${this.token}`;
+    }
+
+    const response = await fetch(`${this.baseURL}/api/ai-chat/stream/`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      let detail = "Streaming request failed";
+      try {
+        const data = await response.json();
+        detail = data.error || data.detail || detail;
+      } catch (_) {
+        // non-JSON error body
+      }
+      throw new Error(detail);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let boundary = buffer.indexOf("\n\n");
+      while (boundary !== -1) {
+        const frame = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + 2);
+        for (const line of frame.split("\n")) {
+          if (!line.startsWith("data:")) continue;
+          const raw = line.slice(5).trim();
+          if (!raw) continue;
+          try {
+            yield JSON.parse(raw);
+          } catch (e) {
+            console.error("Failed to parse SSE frame:", raw, e);
+          }
+        }
+        boundary = buffer.indexOf("\n\n");
+      }
+    }
+  }
+
   async getChatSessions() {
     return await this.request("/api/ai-chat/sessions/");
   }

--- a/packages/django-app/pyproject.toml
+++ b/packages/django-app/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "stringcase==1.2.0",
     "djangorestframework==3.14.0",
     "django-cors-headers==4.3.1",
-    "anthropic==0.55.0",
+    "anthropic>=0.70.0",
     "httpx>=0.24.0,<0.28.0",
     "openai",
     "google-generativeai",

--- a/packages/django-app/uv.lock
+++ b/packages/django-app/uv.lock
@@ -13,20 +13,21 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.55.0"
+version = "0.96.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
+    { name = "docstring-parser" },
     { name = "httpx" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/19/e2e09bc7fc0c4562ae865b3e5d487931c254c517e1c739b0c8aef2cf3186/anthropic-0.55.0.tar.gz", hash = "sha256:61826efa1bda0e4c7dc6f6a0d82b7d99b3fda970cd048d40ef5fca08a5eabd33", size = 408192, upload-time = "2025-06-23T18:52:26.27Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/7e/672f533dee813028d2c699bfd2a7f52c9118d7353680d9aa44b9e23f717f/anthropic-0.96.0.tar.gz", hash = "sha256:9de947b737f39452f68aa520f1c2239d44119c9b73b0fb6d4e6ca80f00279ee6", size = 658210, upload-time = "2026-04-16T14:28:02.846Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/8f/ba982f539db40f49a610f61562e9b54fb9c85e7b9ede9a46ff6f9e79042f/anthropic-0.55.0-py3-none-any.whl", hash = "sha256:3518433fc0372a13f2b793b4cabecc7734ec9176e063a0f28dac19aa17c57f94", size = 289318, upload-time = "2025-06-23T18:52:24.478Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/72f33204064b6e87601a71a6baf8d855769f8a0c1eaae8d06a1094872371/anthropic-0.96.0-py3-none-any.whl", hash = "sha256:9a6e335a354602a521cd9e777e92bfd46ba6e115bf9bbfe6135311e8fb2015b2", size = 635930, upload-time = "2026-04-16T14:28:01.436Z" },
 ]
 
 [[package]]
@@ -102,7 +103,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = "==0.55.0" },
+    { name = "anthropic", specifier = ">=0.70.0" },
     { name = "django", specifier = "==5.0.2" },
     { name = "django-cors-headers", specifier = "==4.3.1" },
     { name = "django-extensions", specifier = "==3.2.3" },
@@ -284,6 +285,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/53/5b2a002c5ebafd60dff1e1945a7d63dee40155830997439a9ba324f0fd50/djangorestframework-3.14.0.tar.gz", hash = "sha256:579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8", size = 1055343, upload-time = "2022-09-22T11:38:44.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/4b/3b46c0914ba4b7546a758c35fdfa8e7f017fcbe7f23c878239e93623337a/djangorestframework-3.14.0-py3-none-any.whl", hash = "sha256:eb63f58c9f218e1a7d064d17a70751f528ed4e1d35547fdade9aaf4cd103fd08", size = 1062761, upload-time = "2022-09-22T11:38:41.825Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR adds streaming response support to the AI chat system and enables extended thinking capabilities for Claude models. It introduces a new SSE-based streaming endpoint, refactors AI service responses into structured result objects, and adds custom tool execution for note-taking operations.

## Key Changes

### Streaming Infrastructure
- Added `StreamSendMessageView` SSE endpoint (`/api/ai-chat/stream/`) that yields incremental text and thinking deltas as they arrive
- Created `StreamSendMessageCommand` to mirror `SendMessageCommand` but stream events instead of buffering the full response
- Implemented `streamAIMessage()` in the JavaScript API service to consume SSE events and update the UI in real-time
- Updated `ChatPanel.js` to display streaming messages with live content and thinking block updates

### Structured Response Objects
- Introduced `AIServiceResult` dataclass to encapsulate content, thinking, and usage metadata
- Created `AIUsage` dataclass to track input/output tokens and cache metrics across providers
- Refactored all service implementations (`AnthropicService`, `OpenAIService`, `GoogleService`) to return `AIServiceResult` instead of plain strings
- Updated `send_message()` signature to accept optional `system` prompt and `tool_executor` parameters

### Extended Thinking (Claude)
- Added thinking support to `AnthropicService` with model capability detection via `THINKING_CAPABLE_MODEL_PREFIXES`
- Configured thinking budget (4000 tokens) and max tokens (8000) for models that support it
- Extracted thinking blocks from responses and stored separately in `ChatMessage.thinking` field
- System prompts now rendered as cacheable blocks for prompt caching optimization

### Custom Tool Execution
- Created `NotesToolExecutor` to execute read-only note queries (search, get page, get block)
- Defined `NOTES_TOOLS` with Anthropic/OpenAI-compatible schemas for note operations
- Implemented tool loop in `AnthropicService` with `MAX_TOOL_ITERATIONS` safety limit
- Tools are scoped to the requesting user and return JSON-serializable results

### Database & API Updates
- Added `thinking`, `input_tokens`, `output_tokens`, and cache token fields to `ChatMessage` model
- Added `enable_notes_tools` form field and localStorage persistence for tool preference
- Updated `ChatMessageRepository.add_message()` to accept thinking and usage data
- Added migration `0011_chatmessage_thinking_and_usage.py`

### UI Enhancements
- Added "Notes Tools" toggle button in chat controls to enable/disable custom tool access
- Implemented collapsible thinking blocks in message display with expand/collapse UI
- Added token usage display in message timestamps (input/output/cached counts)
- Streaming messages show live content updates with a `streaming: true` flag until completion

### Testing
- Added `test_anthropic_service.py` with thinking and usage extraction tests
- Added `test_openai_service.py` with cached token handling tests
- Added `test_notes_tool_executor.py` with user-scoped tool execution tests
- Added `test_stream_send_message_command.py` for streaming command behavior

## Notable Implementation Details
- System prompts are now stable and cacheable (`BRAINSPREAD_SYSTEM_PROMPT`) to enable provider-side prompt caching
- Tool execution is abstracted via `ToolExecutor` protocol, allowing custom implementations per provider
- Streaming uses standard SSE format with JSON payloads for easy client consumption
- All services now extract and normalize usage metrics into a common `AIUsage` structure
- Tool loops prevent infinite recursion with configurable iteration limits

https://claude.ai/code/session_01EyAX3BaqJCV8M1CbVM2Djd