### PR TITLE
Add force-directed graph visualization of pages and links

### DIFF
--- a/.ai/TODO.md
+++ b/.ai/TODO.md
@@ -22,6 +22,8 @@
   - [ ] move multiple blocks to current day
 - [ ] support for [[this syntax of tags]] in blocks
 - [ ] spotlight should allow for actions to, like creating a new page
+- [x] graph view of blocks/pages (#39) - force-directed canvas at `/knowledge/graph/`,
+  built from block→page tag M2M and `[[title]]` wiki links
 
 # Optimizations
 - [ ] need to cleanup frontend routes, django templates, and the vue app

--- a/packages/django-app/app/knowledge/commands/__init__.py
+++ b/packages/django-app/app/knowledge/commands/__init__.py
@@ -2,6 +2,7 @@ from .create_block_command import CreateBlockCommand
 from .create_page_command import CreatePageCommand
 from .delete_block_command import DeleteBlockCommand
 from .delete_page_command import DeletePageCommand
+from .get_graph_data_command import GetGraphDataCommand
 from .get_historical_data_command import GetHistoricalDataCommand
 from .get_page_with_blocks_command import GetPageWithBlocksCommand
 from .get_tag_content_command import GetTagContentCommand

--- a/packages/django-app/app/knowledge/commands/get_graph_data_command.py
+++ b/packages/django-app/app/knowledge/commands/get_graph_data_command.py
@@ -1,0 +1,140 @@
+import re
+from collections import defaultdict
+from typing import Dict, List, Tuple, TypedDict
+
+from django.db.models import Count
+
+from common.commands.abstract_base_command import AbstractBaseCommand
+from core.models import User
+
+from ..forms.get_graph_data_form import GetGraphDataForm
+from ..models import Block, Page
+
+
+class GraphNode(TypedDict):
+    uuid: str
+    title: str
+    slug: str
+    page_type: str
+    block_count: int
+    degree: int
+
+
+class GraphEdge(TypedDict):
+    source: str
+    target: str
+    weight: int
+
+
+class GraphData(TypedDict):
+    nodes: List[GraphNode]
+    edges: List[GraphEdge]
+
+
+class GetGraphDataCommand(AbstractBaseCommand):
+    """Build a node/edge graph of the user's pages and the links between them."""
+
+    def __init__(self, form: GetGraphDataForm) -> None:
+        super().__init__()
+        self.form = form
+
+    def execute(self) -> GraphData:
+        user: User = self.form.cleaned_data["user"]
+        include_daily: bool = bool(self.form.cleaned_data.get("include_daily", False))
+        include_orphans_raw = self.form.cleaned_data.get("include_orphans")
+        include_orphans: bool = (
+            True if include_orphans_raw is None else bool(include_orphans_raw)
+        )
+
+        pages_qs = Page.objects.filter(user=user).annotate(
+            block_count=Count("blocks", distinct=True)
+        )
+        if not include_daily:
+            pages_qs = pages_qs.exclude(page_type="daily")
+
+        pages = list(pages_qs)
+        page_by_uuid: Dict[str, Page] = {str(p.uuid): p for p in pages}
+        allowed_page_uuids = set(page_by_uuid.keys())
+
+        edge_weights: Dict[Tuple[str, str], int] = defaultdict(int)
+
+        self._collect_tag_edges(user, allowed_page_uuids, edge_weights)
+        self._collect_wiki_link_edges(user, pages, edge_weights)
+
+        degree: Dict[str, int] = defaultdict(int)
+        for (src, tgt), weight in edge_weights.items():
+            degree[src] += weight
+            degree[tgt] += weight
+
+        edges: List[GraphEdge] = [
+            {"source": src, "target": tgt, "weight": weight}
+            for (src, tgt), weight in edge_weights.items()
+        ]
+
+        nodes: List[GraphNode] = []
+        for page in pages:
+            page_uuid = str(page.uuid)
+            if not include_orphans and degree.get(page_uuid, 0) == 0:
+                continue
+            nodes.append(
+                {
+                    "uuid": page_uuid,
+                    "title": page.title,
+                    "slug": page.slug,
+                    "page_type": page.page_type,
+                    "block_count": getattr(page, "block_count", 0),
+                    "degree": degree.get(page_uuid, 0),
+                }
+            )
+
+        return {"nodes": nodes, "edges": edges}
+
+    def _collect_tag_edges(
+        self,
+        user: User,
+        allowed_page_uuids: set,
+        edge_weights: Dict[Tuple[str, str], int],
+    ) -> None:
+        """Edges from Block.pages M2M (hashtag-based references)."""
+        through = Block.pages.through
+        rows = through.objects.filter(block__user=user).values_list(
+            "block__page__uuid", "page__uuid"
+        )
+        for source_uuid, target_uuid in rows:
+            source = str(source_uuid)
+            target = str(target_uuid)
+            if source == target:
+                continue
+            if source not in allowed_page_uuids or target not in allowed_page_uuids:
+                continue
+            edge_weights[(source, target)] += 1
+
+    def _collect_wiki_link_edges(
+        self,
+        user: User,
+        pages: List[Page],
+        edge_weights: Dict[Tuple[str, str], int],
+    ) -> None:
+        """Edges from [[Title]] wiki-style links in block content."""
+        title_to_uuid: Dict[str, str] = {p.title.lower(): str(p.uuid) for p in pages}
+        if not title_to_uuid:
+            return
+
+        pattern = re.compile(r"\[\[([^\[\]\n]+?)\]\]")
+        blocks = (
+            Block.objects.filter(user=user)
+            .exclude(content="")
+            .values("page__uuid", "content")
+        )
+
+        for block in blocks:
+            source_uuid = str(block["page__uuid"])
+            if source_uuid not in title_to_uuid.values():
+                continue
+            content = block["content"] or ""
+            for match in pattern.finditer(content):
+                target_title = match.group(1).strip().lower()
+                target_uuid = title_to_uuid.get(target_title)
+                if not target_uuid or target_uuid == source_uuid:
+                    continue
+                edge_weights[(source_uuid, target_uuid)] += 1

--- a/packages/django-app/app/knowledge/forms/__init__.py
+++ b/packages/django-app/app/knowledge/forms/__init__.py
@@ -2,6 +2,7 @@ from .create_block_form import CreateBlockForm
 from .create_page_form import CreatePageForm
 from .delete_block_form import DeleteBlockForm
 from .delete_page_form import DeletePageForm
+from .get_graph_data_form import GetGraphDataForm
 from .get_historical_data_form import GetHistoricalDataForm
 from .get_page_with_blocks_form import GetPageWithBlocksForm
 from .get_tag_content_form import GetTagContentForm

--- a/packages/django-app/app/knowledge/forms/get_graph_data_form.py
+++ b/packages/django-app/app/knowledge/forms/get_graph_data_form.py
@@ -1,0 +1,43 @@
+from django import forms
+from django.core.exceptions import ValidationError
+
+from common.forms.base_form import BaseForm
+from core.models import User
+from core.repositories import UserRepository
+
+
+def _coerce_bool(raw, default: bool) -> bool:
+    """Coerce a query-string style boolean value to a real bool.
+
+    Django's forms.BooleanField treats any non-empty string as True, which
+    means `"false"` is truthy. We want the common url-encoded semantics
+    where `false`/`0`/`no`/`off` all map to False.
+    """
+    if raw is None:
+        return default
+    if isinstance(raw, bool):
+        return raw
+    text = str(raw).strip().lower()
+    if text in ("true", "1", "yes", "on"):
+        return True
+    if text in ("false", "0", "no", "off", ""):
+        return False
+    return default
+
+
+class GetGraphDataForm(BaseForm):
+    user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
+    include_daily = forms.CharField(required=False)
+    include_orphans = forms.CharField(required=False)
+
+    def clean_user(self) -> User:
+        user = self.cleaned_data.get("user")
+        if not user:
+            raise ValidationError("User is required")
+        return user
+
+    def clean_include_daily(self) -> bool:
+        return _coerce_bool(self.cleaned_data.get("include_daily"), default=False)
+
+    def clean_include_orphans(self) -> bool:
+        return _coerce_bool(self.cleaned_data.get("include_orphans"), default=True)

--- a/packages/django-app/app/knowledge/management/commands/seed_graph_demo.py
+++ b/packages/django-app/app/knowledge/management/commands/seed_graph_demo.py
@@ -1,0 +1,271 @@
+from typing import Dict, List, Optional, Tuple
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from knowledge.commands.sync_block_tags_command import SyncBlockTagsCommand
+from knowledge.forms.sync_block_tags_form import SyncBlockTagsForm
+from knowledge.models import Block, Page
+
+User = get_user_model()
+
+# Page spec: (slug, title, block contents).
+# Each block content may contain #hashtags — those become graph edges via
+# SyncBlockTagsCommand, which mirrors the real UI flow.
+PAGES: List[Tuple[str, str, List[str]]] = [
+    # Cluster 1: software
+    (
+        "python",
+        "Python",
+        [
+            "Dynamic, high-level language. See #django and #testing for common uses.",
+            "Type hints pair well with #mypy",
+            "Ecosystem highlights: #pytest #ruff #black",
+        ],
+    ),
+    (
+        "django",
+        "Django",
+        [
+            "Web framework built on #python",
+            "ORM patterns — prefer #repositories over fat models",
+            "Testing strategies live in #testing",
+        ],
+    ),
+    (
+        "testing",
+        "Testing",
+        [
+            "#pytest is the de-facto runner for #python",
+            "Use #factoryboy for realistic fixtures",
+            "Coverage goals: keep critical #django paths green",
+        ],
+    ),
+    (
+        "pytest",
+        "Pytest",
+        [
+            "Fixtures and parametrization make #testing concise",
+            "Markers let you split slow suites — see #testing",
+        ],
+    ),
+    (
+        "ruff",
+        "Ruff",
+        [
+            "Fast #python linter written in Rust",
+            "Pairs well with #black formatting",
+        ],
+    ),
+    (
+        "black",
+        "Black",
+        ["Opinionated #python formatter", "Keeps diffs small across #testing suites"],
+    ),
+    (
+        "mypy",
+        "Mypy",
+        [
+            "Static type checker for #python",
+            "Complements #testing with compile-time checks",
+        ],
+    ),
+    (
+        "factoryboy",
+        "FactoryBoy",
+        ["Fixture factories for #testing", "Works smoothly with #django models"],
+    ),
+    (
+        "repositories",
+        "Repository Pattern",
+        [
+            "Keeps queries out of views and commands",
+            "Used throughout this #django codebase",
+        ],
+    ),
+    # Cluster 2: knowledge management
+    (
+        "logseq",
+        "Logseq",
+        [
+            "Outliner-style #knowledge-management tool",
+            "Inspired this project's block model and #graph-view",
+            "Hashtags are first-class citizens, see #tagging",
+        ],
+    ),
+    (
+        "knowledge-management",
+        "Knowledge Management",
+        [
+            "Captures notes, ideas, and references over time",
+            "Tools: #logseq #obsidian #roam",
+            "Graph visualization (#graph-view) surfaces hidden connections",
+        ],
+    ),
+    (
+        "obsidian",
+        "Obsidian",
+        [
+            "Markdown-based #knowledge-management app",
+            "Strong community around #tagging",
+        ],
+    ),
+    (
+        "roam",
+        "Roam Research",
+        ["Pioneered the bidirectional-linking approach to #knowledge-management"],
+    ),
+    (
+        "tagging",
+        "Tagging",
+        [
+            "Hashtag syntax keeps linking lightweight",
+            "Every #tagging reference is also a graph edge, see #graph-view",
+        ],
+    ),
+    (
+        "graph-view",
+        "Graph View",
+        [
+            "Force-directed visualization of pages and their links",
+            "Nodes are pages; edges come from #tagging",
+            "Inspired by #logseq and #obsidian",
+        ],
+    ),
+    # Cluster 3: a standalone small cluster
+    (
+        "coffee",
+        "Coffee",
+        ["Morning fuel", "Pairs with #reading"],
+    ),
+    (
+        "reading",
+        "Reading",
+        ["Best with #coffee", "Recent focus: #knowledge-management essays"],
+    ),
+    # Orphans (no links in, no links out) — useful for testing the
+    # "hide orphans" toggle in the graph view.
+    ("orphan-one", "Orphan One", ["Standalone note with no references"]),
+    ("orphan-two", "Orphan Two", ["Another note that intentionally links nowhere"]),
+]
+
+
+class Command(BaseCommand):
+    help = (
+        "Seed a user with a linked set of pages designed to exercise the "
+        "graph view. Pages reference each other via #hashtags, which get "
+        "synced to the Block.pages M2M the same way the UI does."
+    )
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--user",
+            type=str,
+            help="Email of the user to seed. Defaults to the first superuser.",
+        )
+        parser.add_argument(
+            "--reset",
+            action="store_true",
+            help=(
+                "Delete previously-seeded demo pages for the user before "
+                "recreating them. Demo pages are identified by their known "
+                "slugs."
+            ),
+        )
+
+    def handle(self, *args, **options) -> None:
+        user = self._resolve_user(options.get("user"))
+        reset: bool = options.get("reset", False)
+
+        with transaction.atomic():
+            if reset:
+                self._delete_demo_pages(user)
+
+            pages, skipped_pages = self._create_pages(user)
+            created_blocks = self._create_blocks(user, pages)
+
+        new_pages = len(pages) - skipped_pages
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Seeded graph demo for {user.email}: "
+                f"{new_pages} new pages, "
+                f"{skipped_pages} already existed, "
+                f"{created_blocks} blocks created."
+            )
+        )
+
+    def _resolve_user(self, email: Optional[str]) -> User:
+        if email:
+            try:
+                return User.objects.get(email=email)
+            except User.DoesNotExist as exc:
+                raise CommandError(f"No user with email {email!r}") from exc
+        user = User.objects.filter(is_superuser=True).order_by("id").first()
+        if not user:
+            raise CommandError(
+                "No --user given and no superuser found. "
+                "Pass --user <email> or run createsuperuser first."
+            )
+        return user
+
+    def _delete_demo_pages(self, user: User) -> None:
+        slugs = [slug for slug, _title, _blocks in PAGES]
+        qs = Page.objects.filter(user=user, slug__in=slugs)
+        count = qs.count()
+        qs.delete()
+        if count:
+            self.stdout.write(f"Removed {count} existing demo pages.")
+
+    def _create_pages(self, user: User) -> Tuple[Dict[str, Page], int]:
+        """Get-or-create every demo page. Returns (slug->Page, skipped_count)."""
+        pages: Dict[str, Page] = {}
+        skipped = 0
+        for slug, title, _blocks in PAGES:
+            page, created = Page.objects.get_or_create(
+                user=user,
+                slug=slug,
+                defaults={
+                    "title": title,
+                    "page_type": "page",
+                    "is_published": True,
+                    "content": "",
+                },
+            )
+            pages[slug] = page
+            if not created:
+                skipped += 1
+        return pages, skipped
+
+    def _create_blocks(self, user: User, pages: Dict[str, Page]) -> int:
+        """Create blocks on each demo page and sync their hashtags."""
+        created = 0
+        for slug, _title, block_contents in PAGES:
+            page = pages[slug]
+            # Skip pages that already have blocks — avoids duplicating content
+            # on repeated non-reset runs.
+            if page.blocks.exists():
+                continue
+            for order, content in enumerate(block_contents):
+                block = Block.objects.create(
+                    user=user,
+                    page=page,
+                    content=content,
+                    content_type="text",
+                    block_type="bullet",
+                    order=order,
+                )
+                self._sync_tags(user, block)
+                created += 1
+        return created
+
+    def _sync_tags(self, user: User, block: Block) -> None:
+        form = SyncBlockTagsForm(
+            {
+                "block": str(block.uuid),
+                "content": block.content,
+                "user": user.id,
+            }
+        )
+        if form.is_valid():
+            SyncBlockTagsCommand(form).execute()

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -3817,6 +3817,7 @@ kbd {
   border: none;
   padding: 0.75rem 1rem;
   text-align: left;
+  white-space: nowrap;
   cursor: pointer;
   font-size: 1rem;
   font-family: inherit;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4274,3 +4274,121 @@ kbd {
 .whiteboard-status-error {
   color: var(--danger-color, #d33);
 }
+
+/* Graph view */
+.graph-layout {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 64px);
+  padding: 0.5rem 1rem 1rem 1rem;
+  box-sizing: border-box;
+}
+
+.graph-view {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  border: 1px solid var(--border-secondary);
+  background: var(--bg-primary);
+}
+
+.graph-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-secondary);
+  flex-wrap: wrap;
+}
+
+.graph-toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.graph-toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.graph-status {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.graph-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.graph-toggle input[type="checkbox"] {
+  cursor: pointer;
+}
+
+.graph-btn {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  padding: 0.25rem 0.6rem;
+  font-family: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.graph-btn:hover {
+  background: var(--hover-bg);
+}
+
+.graph-canvas-container {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+.graph-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  cursor: grab;
+}
+
+.graph-canvas:active {
+  cursor: grabbing;
+}
+
+.graph-overlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  text-align: center;
+  pointer-events: none;
+  padding: 0.5rem 1rem;
+}
+
+.graph-overlay-error {
+  color: var(--error-color);
+}
+
+.graph-help {
+  padding: 0.4rem 0.75rem;
+  border-top: 1px solid var(--border-secondary);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}

--- a/packages/django-app/app/knowledge/static/knowledge/js/app.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/app.js
@@ -15,10 +15,13 @@ const KnowledgeApp = createApp({
     const isAuth = window.apiService.isAuthenticated();
     const cachedUser = window.apiService.getCurrentUser();
 
+    const isGraphRoute = window.location.pathname === "/knowledge/graph/";
+    const initialView = isAuth ? (isGraphRoute ? "graph" : "journal") : "login";
+
     return {
       user: cachedUser, // Load user immediately from cache
       isAuthenticated: isAuth, // Check immediately
-      currentView: isAuth ? "journal" : "login", // Set view immediately
+      currentView: initialView, // Set view immediately
       loading: isAuth && !cachedUser, // Only show loading if we have token but no cached user
       showSettings: false, // Settings modal state
       settingsActiveTab: "general", // Default tab for settings modal
@@ -50,6 +53,7 @@ const KnowledgeApp = createApp({
     ChatPanel: window.ChatPanel,
     ToastNotifications: window.ToastNotifications,
     SpotlightSearch: window.SpotlightSearch,
+    GraphView: window.GraphView,
   },
 
   computed: {
@@ -71,7 +75,8 @@ const KnowledgeApp = createApp({
     },
 
     showChatPanel() {
-      // Whiteboards benefit from the full column width; chat is noise on them.
+      // Whiteboards and the graph view use the full column width; chat is noise there.
+      if (this.currentView === "graph") return false;
       return this.currentPagePageType !== "whiteboard";
     },
   },
@@ -105,6 +110,13 @@ const KnowledgeApp = createApp({
     if (this.isAuthenticated && window.location.pathname === "/knowledge/") {
       this.redirectToToday();
       return;
+    }
+
+    if (
+      this.isAuthenticated &&
+      window.location.pathname === "/knowledge/graph/"
+    ) {
+      this.currentView = "graph";
     }
 
     // Reapply theme after auth check in case user data was updated
@@ -449,6 +461,15 @@ const KnowledgeApp = createApp({
       this.createNewWhiteboard();
     },
 
+    onMenuGraph() {
+      this.closeMenu();
+      this.navigateToGraph();
+    },
+
+    navigateToGraph() {
+      window.location.href = "/knowledge/graph/";
+    },
+
     onMenuSettings() {
       this.closeMenu();
       this.openSettings();
@@ -566,6 +587,12 @@ const KnowledgeApp = createApp({
           label: "today",
           description: "go to today's daily note",
           icon: "→",
+        },
+        {
+          id: "graph",
+          label: "graph",
+          description: "view the knowledge graph",
+          icon: "◉",
         },
         {
           id: "settings",
@@ -738,6 +765,9 @@ const KnowledgeApp = createApp({
         case "today":
           this.redirectToToday();
           break;
+        case "graph":
+          this.navigateToGraph();
+          break;
         case "settings":
           this.openSettings();
           break;
@@ -823,6 +853,9 @@ const KnowledgeApp = createApp({
                                     <button @click="onMenuCreateWhiteboard" class="menu-item" role="menuitem">
                                         + whiteboard
                                     </button>
+                                    <button @click="onMenuGraph" class="menu-item" role="menuitem">
+                                        graph
+                                    </button>
                                     <button @click="onMenuSettings" class="menu-item" role="menuitem">
                                         settings
                                     </button>
@@ -848,8 +881,11 @@ const KnowledgeApp = createApp({
                     <div v-if="loading" class="loading-container">
                         <div class="loading">Loading...</div>
                     </div>
+                    <div v-else-if="currentView === 'graph'" class="graph-layout">
+                        <GraphView />
+                    </div>
                     <div v-else class="content-layout">
-                        <HistoricalSidebar 
+                        <HistoricalSidebar
                             @navigate-to-date="onNavigateToDate"
                             @navigate-to-slug="onNavigateToSlug" />
                         <div class="main-content-area">

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/GraphView.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/GraphView.js
@@ -1,0 +1,553 @@
+// GraphView - force-directed canvas visualization of pages and their links.
+const GraphView = {
+  data() {
+    return {
+      loading: true,
+      error: null,
+      nodes: [],
+      edges: [],
+      adjacency: new Map(),
+      includeDaily: false,
+      includeOrphans: true,
+      hoveredNode: null,
+      draggingNode: null,
+      dragOffset: { x: 0, y: 0 },
+      dragStartClient: { x: 0, y: 0 },
+      dragMoved: false,
+      panOffset: { x: 0, y: 0 },
+      zoom: 1,
+      isPanning: false,
+      panStart: { x: 0, y: 0 },
+      panOffsetStart: { x: 0, y: 0 },
+      width: 800,
+      height: 600,
+      animationFrame: null,
+      simulationAlpha: 1,
+      resizeObserver: null,
+      devicePixelRatio: window.devicePixelRatio || 1,
+      // Physics params
+      repulsionStrength: 1800,
+      linkDistance: 90,
+      linkStrength: 0.05,
+      centerStrength: 0.02,
+      friction: 0.85,
+    };
+  },
+
+  computed: {
+    nodeCount() {
+      return this.nodes.length;
+    },
+    edgeCount() {
+      return this.edges.length;
+    },
+    statusMessage() {
+      if (this.loading) return "loading graph...";
+      if (this.error) return `error: ${this.error}`;
+      if (!this.nodes.length) {
+        return "no pages to display - create some pages and link them with [[wikilinks]] or #hashtags";
+      }
+      return `${this.nodeCount} pages · ${this.edgeCount} connections`;
+    },
+  },
+
+  async mounted() {
+    await this.loadGraph();
+    this.setupCanvas();
+    this.setupResizeObserver();
+    this.startSimulation();
+    window.addEventListener("keydown", this.handleKeydown);
+  },
+
+  beforeUnmount() {
+    this.stopSimulation();
+    window.removeEventListener("keydown", this.handleKeydown);
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
+    }
+  },
+
+  methods: {
+    async loadGraph() {
+      this.loading = true;
+      this.error = null;
+      try {
+        const result = await window.apiService.getGraphData({
+          includeDaily: this.includeDaily,
+          includeOrphans: this.includeOrphans,
+        });
+        if (!result.success) {
+          this.error =
+            result.errors?.non_field_errors?.[0] || "failed to load graph";
+          this.nodes = [];
+          this.edges = [];
+          return;
+        }
+        this.initializeSimulation(result.data.nodes, result.data.edges);
+      } catch (err) {
+        console.error("Failed to load graph:", err);
+        this.error = err.message || "failed to load graph";
+        this.nodes = [];
+        this.edges = [];
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    initializeSimulation(rawNodes, rawEdges) {
+      const cx = this.width / 2;
+      const cy = this.height / 2;
+      const radius = Math.min(this.width, this.height) * 0.35;
+      const markRaw = (Vue && Vue.markRaw) || ((v) => v);
+
+      const nodes = rawNodes.map((n, i) => {
+        const angle = (i / Math.max(rawNodes.length, 1)) * Math.PI * 2;
+        return markRaw({
+          ...n,
+          x: cx + Math.cos(angle) * radius,
+          y: cy + Math.sin(angle) * radius,
+          vx: 0,
+          vy: 0,
+        });
+      });
+
+      const byUuid = new Map(nodes.map((n) => [n.uuid, n]));
+      const edges = rawEdges
+        .map((e) =>
+          markRaw({
+            source: byUuid.get(e.source),
+            target: byUuid.get(e.target),
+            weight: e.weight || 1,
+          })
+        )
+        .filter((e) => e.source && e.target);
+
+      this.nodes = markRaw(nodes);
+      this.edges = markRaw(edges);
+
+      const adj = new Map();
+      for (const node of this.nodes) adj.set(node.uuid, new Set());
+      for (const edge of this.edges) {
+        adj.get(edge.source.uuid).add(edge.target.uuid);
+        adj.get(edge.target.uuid).add(edge.source.uuid);
+      }
+      this.adjacency = adj;
+
+      this.simulationAlpha = 1;
+    },
+
+    setupCanvas() {
+      const canvas = this.$refs.canvas;
+      if (!canvas) return;
+      const container = this.$refs.container;
+      if (container) {
+        const rect = container.getBoundingClientRect();
+        this.width = Math.max(300, rect.width);
+        this.height = Math.max(300, rect.height);
+      }
+      this.resizeCanvas();
+    },
+
+    resizeCanvas() {
+      const canvas = this.$refs.canvas;
+      if (!canvas) return;
+      const dpr = this.devicePixelRatio;
+      canvas.width = this.width * dpr;
+      canvas.height = this.height * dpr;
+      canvas.style.width = `${this.width}px`;
+      canvas.style.height = `${this.height}px`;
+    },
+
+    setupResizeObserver() {
+      if (typeof ResizeObserver === "undefined") return;
+      const container = this.$refs.container;
+      if (!container) return;
+      this.resizeObserver = new ResizeObserver(() => {
+        const rect = container.getBoundingClientRect();
+        this.width = Math.max(300, rect.width);
+        this.height = Math.max(300, rect.height);
+        this.resizeCanvas();
+        this.render();
+      });
+      this.resizeObserver.observe(container);
+    },
+
+    startSimulation() {
+      const step = () => {
+        this.tick();
+        this.render();
+        this.animationFrame = requestAnimationFrame(step);
+      };
+      this.animationFrame = requestAnimationFrame(step);
+    },
+
+    stopSimulation() {
+      if (this.animationFrame) {
+        cancelAnimationFrame(this.animationFrame);
+        this.animationFrame = null;
+      }
+    },
+
+    tick() {
+      if (!this.nodes.length) return;
+
+      const alpha = Math.max(this.simulationAlpha, 0.02);
+
+      // Repulsion between all node pairs (O(n^2) - fine for the sizes we expect)
+      for (let i = 0; i < this.nodes.length; i++) {
+        const a = this.nodes[i];
+        if (a === this.draggingNode) continue;
+        for (let j = i + 1; j < this.nodes.length; j++) {
+          const b = this.nodes[j];
+          let dx = a.x - b.x;
+          let dy = a.y - b.y;
+          let distSq = dx * dx + dy * dy;
+          if (distSq < 0.01) {
+            dx = Math.random() - 0.5;
+            dy = Math.random() - 0.5;
+            distSq = dx * dx + dy * dy + 0.01;
+          }
+          const dist = Math.sqrt(distSq);
+          const force = (this.repulsionStrength * alpha) / distSq;
+          const fx = (dx / dist) * force;
+          const fy = (dy / dist) * force;
+          a.vx += fx;
+          a.vy += fy;
+          if (b !== this.draggingNode) {
+            b.vx -= fx;
+            b.vy -= fy;
+          }
+        }
+      }
+
+      // Spring attraction along edges
+      for (const edge of this.edges) {
+        const { source, target } = edge;
+        const dx = target.x - source.x;
+        const dy = target.y - source.y;
+        const dist = Math.sqrt(dx * dx + dy * dy) || 0.01;
+        const diff = dist - this.linkDistance;
+        const force = diff * this.linkStrength * alpha * edge.weight;
+        const fx = (dx / dist) * force;
+        const fy = (dy / dist) * force;
+        if (source !== this.draggingNode) {
+          source.vx += fx;
+          source.vy += fy;
+        }
+        if (target !== this.draggingNode) {
+          target.vx -= fx;
+          target.vy -= fy;
+        }
+      }
+
+      // Weak centering force
+      const cx = this.width / 2;
+      const cy = this.height / 2;
+      for (const node of this.nodes) {
+        if (node === this.draggingNode) continue;
+        node.vx += (cx - node.x) * this.centerStrength * alpha;
+        node.vy += (cy - node.y) * this.centerStrength * alpha;
+      }
+
+      // Apply velocities with friction
+      for (const node of this.nodes) {
+        if (node === this.draggingNode) {
+          node.vx = 0;
+          node.vy = 0;
+          continue;
+        }
+        node.vx *= this.friction;
+        node.vy *= this.friction;
+        // Clamp velocity so the simulation stays stable
+        const maxV = 30;
+        if (node.vx > maxV) node.vx = maxV;
+        if (node.vx < -maxV) node.vx = -maxV;
+        if (node.vy > maxV) node.vy = maxV;
+        if (node.vy < -maxV) node.vy = -maxV;
+        node.x += node.vx;
+        node.y += node.vy;
+      }
+
+      this.simulationAlpha *= 0.995;
+    },
+
+    nodeRadius(node) {
+      return 4 + Math.min(12, Math.sqrt(node.block_count + node.degree));
+    },
+
+    nodeColor(node) {
+      const styles = getComputedStyle(document.documentElement);
+      if (node.page_type === "daily") {
+        return styles.getPropertyValue("--text-muted").trim() || "#888";
+      }
+      if (node.page_type === "whiteboard") {
+        return styles.getPropertyValue("--context-color").trim() || "#ffaa00";
+      }
+      return styles.getPropertyValue("--text-primary").trim() || "#00ff00";
+    },
+
+    render() {
+      const canvas = this.$refs.canvas;
+      if (!canvas) return;
+      const ctx = canvas.getContext("2d");
+      const dpr = this.devicePixelRatio;
+
+      ctx.save();
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.scale(dpr, dpr);
+
+      ctx.translate(this.panOffset.x, this.panOffset.y);
+      ctx.scale(this.zoom, this.zoom);
+
+      const styles = getComputedStyle(document.documentElement);
+      const edgeColor =
+        styles.getPropertyValue("--border-secondary").trim() || "#333";
+      const edgeHighlight =
+        styles.getPropertyValue("--border-primary").trim() || "#00ff00";
+      const textColor =
+        styles.getPropertyValue("--text-primary").trim() || "#00ff00";
+      const bgColor = styles.getPropertyValue("--bg-primary").trim() || "#000";
+
+      const hoveredUuid = this.hoveredNode?.uuid || null;
+      const neighborUuids = hoveredUuid
+        ? this.adjacency.get(hoveredUuid) || new Set()
+        : new Set();
+
+      // Edges
+      ctx.lineWidth = 1;
+      for (const edge of this.edges) {
+        const touchesHovered =
+          hoveredUuid &&
+          (edge.source.uuid === hoveredUuid ||
+            edge.target.uuid === hoveredUuid);
+        ctx.strokeStyle = touchesHovered ? edgeHighlight : edgeColor;
+        ctx.globalAlpha = hoveredUuid && !touchesHovered ? 0.2 : 0.7;
+        ctx.lineWidth = touchesHovered ? 1.5 : 1;
+        ctx.beginPath();
+        ctx.moveTo(edge.source.x, edge.source.y);
+        ctx.lineTo(edge.target.x, edge.target.y);
+        ctx.stroke();
+      }
+
+      // Nodes
+      ctx.globalAlpha = 1;
+      for (const node of this.nodes) {
+        const radius = this.nodeRadius(node);
+        const color = this.nodeColor(node);
+        const isHovered = hoveredUuid === node.uuid;
+        const isNeighbor = neighborUuids.has(node.uuid);
+        const dimmed = hoveredUuid && !isHovered && !isNeighbor;
+
+        ctx.globalAlpha = dimmed ? 0.3 : 1;
+        ctx.fillStyle = color;
+        ctx.strokeStyle = bgColor;
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.arc(node.x, node.y, radius, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+
+        if (isHovered || (!hoveredUuid && radius >= 8) || isNeighbor) {
+          ctx.globalAlpha = dimmed ? 0.3 : 1;
+          ctx.fillStyle = textColor;
+          ctx.font = "12px ui-monospace, SFMono-Regular, Menlo, monospace";
+          ctx.textAlign = "left";
+          ctx.textBaseline = "middle";
+          ctx.fillText(node.title, node.x + radius + 6, node.y);
+        }
+      }
+
+      ctx.globalAlpha = 1;
+      ctx.restore();
+    },
+
+    toGraphCoords(clientX, clientY) {
+      const canvas = this.$refs.canvas;
+      const rect = canvas.getBoundingClientRect();
+      const localX = clientX - rect.left;
+      const localY = clientY - rect.top;
+      return {
+        x: (localX - this.panOffset.x) / this.zoom,
+        y: (localY - this.panOffset.y) / this.zoom,
+      };
+    },
+
+    pickNode(graphX, graphY) {
+      // Iterate in reverse so top-rendered nodes are picked first
+      for (let i = this.nodes.length - 1; i >= 0; i--) {
+        const node = this.nodes[i];
+        const dx = graphX - node.x;
+        const dy = graphY - node.y;
+        const r = this.nodeRadius(node) + 3;
+        if (dx * dx + dy * dy <= r * r) return node;
+      }
+      return null;
+    },
+
+    onMouseDown(event) {
+      const { x, y } = this.toGraphCoords(event.clientX, event.clientY);
+      const node = this.pickNode(x, y);
+      if (node) {
+        this.draggingNode = node;
+        this.dragOffset = { x: x - node.x, y: y - node.y };
+        this.dragStartClient = { x: event.clientX, y: event.clientY };
+        this.dragMoved = false;
+        this.simulationAlpha = Math.max(this.simulationAlpha, 0.5);
+      } else {
+        this.isPanning = true;
+        this.panStart = { x: event.clientX, y: event.clientY };
+        this.panOffsetStart = { ...this.panOffset };
+      }
+    },
+
+    onMouseMove(event) {
+      if (this.draggingNode) {
+        const dx = event.clientX - this.dragStartClient.x;
+        const dy = event.clientY - this.dragStartClient.y;
+        if (Math.abs(dx) > 3 || Math.abs(dy) > 3) {
+          this.dragMoved = true;
+        }
+        const { x, y } = this.toGraphCoords(event.clientX, event.clientY);
+        this.draggingNode.x = x - this.dragOffset.x;
+        this.draggingNode.y = y - this.dragOffset.y;
+        this.draggingNode.vx = 0;
+        this.draggingNode.vy = 0;
+        return;
+      }
+
+      if (this.isPanning) {
+        this.panOffset.x =
+          this.panOffsetStart.x + (event.clientX - this.panStart.x);
+        this.panOffset.y =
+          this.panOffsetStart.y + (event.clientY - this.panStart.y);
+        return;
+      }
+
+      const { x, y } = this.toGraphCoords(event.clientX, event.clientY);
+      this.hoveredNode = this.pickNode(x, y);
+      const canvas = this.$refs.canvas;
+      if (canvas) {
+        canvas.style.cursor = this.hoveredNode ? "pointer" : "grab";
+      }
+    },
+
+    onMouseUp() {
+      if (this.draggingNode && !this.dragMoved) {
+        this.navigateToNode(this.draggingNode);
+      }
+      this.draggingNode = null;
+      this.dragMoved = false;
+      this.isPanning = false;
+    },
+
+    onMouseLeave() {
+      this.draggingNode = null;
+      this.isPanning = false;
+      this.hoveredNode = null;
+    },
+
+    onWheel(event) {
+      event.preventDefault();
+      const canvas = this.$refs.canvas;
+      const rect = canvas.getBoundingClientRect();
+      const mouseX = event.clientX - rect.left;
+      const mouseY = event.clientY - rect.top;
+      const delta = -event.deltaY * 0.001;
+      const nextZoom = Math.max(0.2, Math.min(4, this.zoom * (1 + delta)));
+      // Zoom to cursor
+      const graphBefore = {
+        x: (mouseX - this.panOffset.x) / this.zoom,
+        y: (mouseY - this.panOffset.y) / this.zoom,
+      };
+      this.zoom = nextZoom;
+      this.panOffset.x = mouseX - graphBefore.x * this.zoom;
+      this.panOffset.y = mouseY - graphBefore.y * this.zoom;
+    },
+
+    navigateToNode(node) {
+      if (!node || !node.slug) return;
+      window.location.href = `/knowledge/page/${node.slug}/`;
+    },
+
+    resetView() {
+      this.zoom = 1;
+      this.panOffset = { x: 0, y: 0 };
+      this.simulationAlpha = 1;
+    },
+
+    async refresh() {
+      this.simulationAlpha = 1;
+      await this.loadGraph();
+    },
+
+    async onToggleDaily() {
+      this.includeDaily = !this.includeDaily;
+      await this.refresh();
+    },
+
+    async onToggleOrphans() {
+      this.includeOrphans = !this.includeOrphans;
+      await this.refresh();
+    },
+
+    handleKeydown(event) {
+      if (event.key === "Escape") {
+        window.location.href = "/knowledge/";
+      } else if (event.key === "r" && !event.metaKey && !event.ctrlKey) {
+        const target = event.target;
+        if (
+          target &&
+          (target.tagName === "INPUT" || target.tagName === "TEXTAREA")
+        ) {
+          return;
+        }
+        this.resetView();
+      }
+    },
+  },
+
+  template: `
+    <div class="graph-view">
+      <div class="graph-toolbar">
+        <div class="graph-toolbar-left">
+          <span class="graph-status">{{ statusMessage }}</span>
+        </div>
+        <div class="graph-toolbar-right">
+          <label class="graph-toggle">
+            <input type="checkbox" :checked="includeDaily" @change="onToggleDaily" />
+            daily notes
+          </label>
+          <label class="graph-toggle">
+            <input type="checkbox" :checked="includeOrphans" @change="onToggleOrphans" />
+            orphans
+          </label>
+          <button class="graph-btn" @click="resetView" title="reset zoom/pan (r)">reset</button>
+          <button class="graph-btn" @click="refresh" title="reload graph">reload</button>
+        </div>
+      </div>
+      <div class="graph-canvas-container" ref="container">
+        <canvas
+          ref="canvas"
+          class="graph-canvas"
+          @mousedown="onMouseDown"
+          @mousemove="onMouseMove"
+          @mouseup="onMouseUp"
+          @mouseleave="onMouseLeave"
+          @wheel="onWheel"
+        ></canvas>
+        <div v-if="loading" class="graph-overlay">loading graph...</div>
+        <div v-else-if="error" class="graph-overlay graph-overlay-error">{{ error }}</div>
+        <div v-else-if="!nodeCount" class="graph-overlay">
+          no pages to display yet - create pages and link them with [[wikilinks]] or #hashtags
+        </div>
+      </div>
+      <div class="graph-help">
+        drag nodes to reposition · scroll to zoom · click a node to open · press r to reset · esc to exit
+      </div>
+    </div>
+  `,
+};
+
+window.GraphView = GraphView;

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -233,6 +233,14 @@ class ApiService {
     );
   }
 
+  async getGraphData({ includeDaily = false, includeOrphans = true } = {}) {
+    const params = new URLSearchParams({
+      include_daily: includeDaily ? "true" : "false",
+      include_orphans: includeOrphans ? "true" : "false",
+    });
+    return await this.request(`/knowledge/api/graph/?${params.toString()}`);
+  }
+
   // Utility methods
   isAuthenticated() {
     return !!this.token;

--- a/packages/django-app/app/knowledge/templates/knowledge/base.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/base.html
@@ -40,6 +40,7 @@
     <script src="{% static 'knowledge/js/components/ChatPanel.js' %}"></script>
     <script src="{% static 'knowledge/js/components/ToastNotifications.js' %}"></script>
     <script src="{% static 'knowledge/js/components/SpotlightSearch.js' %}"></script>
+    <script src="{% static 'knowledge/js/components/GraphView.js' %}"></script>
 
     <!-- Main App -->
     <script src="{% static 'knowledge/js/app.js' %}"></script>

--- a/packages/django-app/app/knowledge/test/commands/test_get_graph_data_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_get_graph_data_command.py
@@ -1,0 +1,155 @@
+from django.test import TestCase
+
+from knowledge.commands import GetGraphDataCommand
+from knowledge.forms import GetGraphDataForm
+
+from ..helpers import BlockFactory, PageFactory, UserFactory
+
+
+class TestGetGraphDataCommand(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.other_user = UserFactory()
+
+    def _build_form(self, include_daily: bool = False, include_orphans: bool = True):
+        form = GetGraphDataForm(
+            {
+                "user": self.user.id,
+                "include_daily": "true" if include_daily else "false",
+                "include_orphans": "true" if include_orphans else "false",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        return form
+
+    def test_returns_empty_graph_when_user_has_no_pages(self):
+        form = self._build_form()
+        result = GetGraphDataCommand(form).execute()
+
+        self.assertEqual(result["nodes"], [])
+        self.assertEqual(result["edges"], [])
+
+    def test_returns_nodes_for_user_pages_excluding_daily_by_default(self):
+        page_a = PageFactory(user=self.user, title="Alpha", slug="alpha")
+        PageFactory(user=self.user, title="Daily", slug="daily", page_type="daily")
+        # Another user's pages should never appear
+        PageFactory(user=self.other_user, title="Leak", slug="leak")
+
+        form = self._build_form()
+        result = GetGraphDataCommand(form).execute()
+
+        uuids = {n["uuid"] for n in result["nodes"]}
+        self.assertIn(str(page_a.uuid), uuids)
+        self.assertEqual(len(result["nodes"]), 1)
+
+    def test_includes_daily_when_requested(self):
+        PageFactory(user=self.user, title="Alpha", slug="alpha")
+        PageFactory(user=self.user, title="Daily", slug="daily", page_type="daily")
+
+        form = self._build_form(include_daily=True)
+        result = GetGraphDataCommand(form).execute()
+
+        slugs = {n["slug"] for n in result["nodes"]}
+        self.assertSetEqual(slugs, {"alpha", "daily"})
+
+    def test_builds_edges_from_block_page_tags(self):
+        page_a = PageFactory(user=self.user, title="Alpha", slug="alpha")
+        page_b = PageFactory(user=self.user, title="Beta", slug="beta")
+
+        block = BlockFactory(user=self.user, page=page_a, content="has #beta tag")
+        block.pages.add(page_b)
+
+        form = self._build_form()
+        result = GetGraphDataCommand(form).execute()
+
+        self.assertEqual(len(result["edges"]), 1)
+        edge = result["edges"][0]
+        self.assertEqual(edge["source"], str(page_a.uuid))
+        self.assertEqual(edge["target"], str(page_b.uuid))
+        self.assertEqual(edge["weight"], 1)
+
+        degrees = {n["uuid"]: n["degree"] for n in result["nodes"]}
+        self.assertEqual(degrees[str(page_a.uuid)], 1)
+        self.assertEqual(degrees[str(page_b.uuid)], 1)
+
+    def test_builds_edges_from_wiki_links(self):
+        page_a = PageFactory(user=self.user, title="Alpha", slug="alpha")
+        page_b = PageFactory(user=self.user, title="Beta", slug="beta")
+
+        BlockFactory(
+            user=self.user,
+            page=page_a,
+            content="See [[Beta]] and [[beta]] for details",
+        )
+
+        form = self._build_form()
+        result = GetGraphDataCommand(form).execute()
+
+        edges = [(e["source"], e["target"], e["weight"]) for e in result["edges"]]
+        self.assertIn((str(page_a.uuid), str(page_b.uuid), 2), edges)
+
+    def test_aggregates_multiple_edges_between_same_pages(self):
+        page_a = PageFactory(user=self.user, title="Alpha", slug="alpha")
+        page_b = PageFactory(user=self.user, title="Beta", slug="beta")
+
+        block1 = BlockFactory(user=self.user, page=page_a, content="first")
+        block1.pages.add(page_b)
+        block2 = BlockFactory(user=self.user, page=page_a, content="second [[Beta]]")
+        block2.pages.add(page_b)
+
+        form = self._build_form()
+        result = GetGraphDataCommand(form).execute()
+
+        matching = [
+            e
+            for e in result["edges"]
+            if e["source"] == str(page_a.uuid) and e["target"] == str(page_b.uuid)
+        ]
+        self.assertEqual(len(matching), 1)
+        # two tag edges + one wiki-link match = weight 3
+        self.assertEqual(matching[0]["weight"], 3)
+
+    def test_excludes_self_loops(self):
+        page_a = PageFactory(user=self.user, title="Alpha", slug="alpha")
+        block = BlockFactory(
+            user=self.user, page=page_a, content="Self reference [[Alpha]]"
+        )
+        block.pages.add(page_a)
+
+        form = self._build_form()
+        result = GetGraphDataCommand(form).execute()
+
+        self.assertEqual(result["edges"], [])
+
+    def test_include_orphans_false_drops_unconnected_pages(self):
+        page_a = PageFactory(user=self.user, title="Alpha", slug="alpha")
+        page_b = PageFactory(user=self.user, title="Beta", slug="beta")
+        PageFactory(user=self.user, title="Orphan", slug="orphan")
+
+        block = BlockFactory(user=self.user, page=page_a, content="link")
+        block.pages.add(page_b)
+
+        form = self._build_form(include_orphans=False)
+        result = GetGraphDataCommand(form).execute()
+
+        slugs = {n["slug"] for n in result["nodes"]}
+        self.assertSetEqual(slugs, {"alpha", "beta"})
+
+    def test_excludes_other_users_edges(self):
+        page_a = PageFactory(user=self.user, title="Alpha", slug="alpha")
+        page_b = PageFactory(user=self.user, title="Beta", slug="beta")
+
+        other_page = PageFactory(user=self.other_user, title="Other", slug="other")
+        other_block = BlockFactory(
+            user=self.other_user, page=other_page, content="hidden"
+        )
+        # Cross-user M2M should not appear for self.user's graph
+        other_block.pages.add(page_b)
+
+        form = self._build_form()
+        result = GetGraphDataCommand(form).execute()
+
+        self.assertEqual(result["edges"], [])
+        uuids = {n["uuid"] for n in result["nodes"]}
+        self.assertSetEqual(uuids, {str(page_a.uuid), str(page_b.uuid)})

--- a/packages/django-app/app/knowledge/urls.py
+++ b/packages/django-app/app/knowledge/urls.py
@@ -7,6 +7,7 @@ app_name = "knowledge"
 urlpatterns = [
     # Static pages
     path("", views.index, name="index"),
+    path("graph/", views.index, name="graph"),
     path("page/<str:slug>/", views.index, name="page"),
     # Block-centric API endpoints
     path("api/blocks/", views.create_block, name="create_block"),
@@ -27,5 +28,6 @@ urlpatterns = [
     path("api/pages/search/", views.search_pages, name="search_pages"),
     path("api/page/", views.get_page_with_blocks, name="get_page_with_blocks"),
     path("api/historical/", views.get_historical_data, name="get_historical_data"),
+    path("api/graph/", views.get_graph_data, name="get_graph_data"),
     path("api/tag/<str:tag_name>/", views.get_tag_content, name="get_tag_content"),
 ]

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -12,6 +12,7 @@ from knowledge.commands import (
     CreatePageCommand,
     DeleteBlockCommand,
     DeletePageCommand,
+    GetGraphDataCommand,
     GetHistoricalDataCommand,
     GetPageWithBlocksCommand,
     GetTagContentCommand,
@@ -23,6 +24,7 @@ from knowledge.commands import (
     UpdateBlockCommand,
     UpdatePageCommand,
 )
+from knowledge.commands.get_graph_data_command import GraphData
 from knowledge.commands.get_historical_data_command import HistoricalData
 from knowledge.commands.get_tag_content_command import TagContentData
 from knowledge.commands.move_undone_todos_command import MoveUndoneTodosData
@@ -31,6 +33,7 @@ from knowledge.forms import (
     CreatePageForm,
     DeleteBlockForm,
     DeletePageForm,
+    GetGraphDataForm,
     GetHistoricalDataForm,
     GetPageWithBlocksForm,
     GetTagContentForm,
@@ -92,6 +95,12 @@ class GetPageWithBlocksResponse(TypedDict):
 class MoveUndoneTodosResponse(TypedDict):
     success: bool
     data: Optional[MoveUndoneTodosData]
+    errors: Optional[Dict[str, List[str]]]
+
+
+class GraphDataResponse(TypedDict):
+    success: bool
+    data: Optional[GraphData]
     errors: Optional[Dict[str, List[str]]]
 
 
@@ -691,6 +700,42 @@ def move_undone_todos(request):
 
     except Exception as e:
         response: MoveUndoneTodosResponse = {
+            "success": False,
+            "data": None,
+            "errors": {"non_field_errors": [str(e)]},
+        }
+        return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def get_graph_data(request):
+    """Return the user's pages and their connections as a node/edge graph."""
+    try:
+        data = request.query_params.copy()
+        data["user"] = request.user.id
+        form = GetGraphDataForm(data)
+
+        if not form.is_valid():
+            response: GraphDataResponse = {
+                "success": False,
+                "data": None,
+                "errors": form.errors,
+            }
+            return Response(response, status=status.HTTP_400_BAD_REQUEST)
+
+        command = GetGraphDataCommand(form)
+        result: GraphData = command.execute()
+
+        response: GraphDataResponse = {
+            "success": True,
+            "data": result,
+            "errors": None,
+        }
+        return Response(response)
+
+    except Exception as e:
+        response: GraphDataResponse = {
             "success": False,
             "data": None,
             "errors": {"non_field_errors": [str(e)]},


### PR DESCRIPTION
## Summary
Adds an interactive force-directed graph visualization of a user's knowledge base pages and their connections. The graph view is accessible at `/knowledge/graph/` and displays pages as nodes with edges representing links between them (via wikilinks and hashtags).

## Key Changes

### Backend
- **GetGraphDataCommand**: New command that builds a node/edge graph from user pages and their connections
  - Collects edges from Block.pages M2M relationships (hashtag-based references)
  - Collects edges from `[[Title]]` wiki-style links in block content
  - Aggregates multiple edges between the same pages with weighted counts
  - Filters by user, excludes self-loops, and optionally filters daily notes and orphaned pages
  
- **GetGraphDataForm**: Form for validating graph query parameters (include_daily, include_orphans)
  - Includes custom boolean coercion to handle query-string style booleans ("true"/"false" strings)

- **API endpoint** (`get_graph_data`): REST endpoint returning graph data as JSON with nodes and edges

### Frontend
- **GraphView component**: Vue component implementing a force-directed canvas visualization
  - Physics simulation with repulsion, spring attraction, centering force, and friction
  - Interactive features: drag nodes, pan canvas, zoom with mouse wheel
  - Hover highlighting showing connected nodes and edges
  - Click nodes to navigate to the page
  - Toolbar with toggles for daily notes and orphaned pages, plus reset/reload buttons
  - Keyboard shortcuts: `r` to reset view, `Esc` to exit
  - Responsive canvas with device pixel ratio support

- **Styling**: New CSS for graph layout, toolbar, canvas container, and overlays

- **Integration**: Updated app.js to route to graph view, updated API service with getGraphData method

## Implementation Details
- Uses canvas 2D rendering for performance with force-directed physics simulation
- Nodes sized by block count and degree (number of connections)
- Node colors vary by page type (daily, whiteboard, regular)
- Edge weights reflect the number of connections between pages
- Simulation uses alpha decay to gradually settle the layout
- Supports high-DPI displays via devicePixelRatio scaling

https://claude.ai/code/session_01317rVGRqX2vuVaBL9niHRr