### PR TITLE
Add cache-busting version tokens to static assets

### DIFF
--- a/packages/django-app/app/app/settings.py
+++ b/packages/django-app/app/app/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 
 import os
+import time
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -88,6 +89,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "common.context_processors.static_version",
             ],
         },
     },
@@ -149,6 +151,11 @@ STATIC_URL = os.environ.get("STATIC_URL", "/static/")
 # path to static directory in docker container.
 # this is where files are created when running `collectstatic`
 STATIC_ROOT = os.environ.get("STATIC_ROOT", os.path.join(BASE_DIR, "static"))
+
+# Cache-busting token appended to static asset URLs. Prefer an explicit
+# STATIC_VERSION set by deploys (e.g. a git SHA); otherwise use process
+# start time so every web process restart invalidates cached assets.
+STATIC_VERSION = os.environ.get("STATIC_VERSION") or str(int(time.time()))
 
 # https://docs.djangoproject.com/en/4.0/topics/files/
 MEDIA_URL = os.environ.get("MEDIA_URL", "/media/")

--- a/packages/django-app/app/common/context_processors.py
+++ b/packages/django-app/app/common/context_processors.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def static_version(request):
+    return {"STATIC_VERSION": settings.STATIC_VERSION}

--- a/packages/django-app/app/knowledge/templates/knowledge/base.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{% block title %}brainspread{% endblock %}</title>
     {% load static %} {% csrf_token %}
-    <link rel="stylesheet" href="{% static 'knowledge/css/app.css' %}" />
+    <link rel="stylesheet" href="{% static 'knowledge/css/app.css' %}?v={{ STATIC_VERSION }}" />
     <link rel="stylesheet" href="https://esm.sh/tldraw@3/tldraw.css" />
     {% block extra_css %}{% endblock %}
   </head>
@@ -20,30 +20,30 @@
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-core.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
-    
+
     <!-- Prism CSS Theme -->
     <link href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
     <!-- API Service -->
-    <script src="{% static 'knowledge/js/services/api.js' %}?v=3"></script>
+    <script src="{% static 'knowledge/js/services/api.js' %}?v={{ STATIC_VERSION }}"></script>
 
     <!-- Vue Components -->
-    <script src="{% static 'knowledge/js/components/BlockComponent.js' %}"></script>
-    <script src="{% static 'knowledge/js/components/LoginForm.js' %}"></script>
-    <script src="{% static 'knowledge/js/components/Whiteboard.js' %}"></script>
-    <script src="{% static 'knowledge/js/components/Page.js' %}"></script>
-    <script src="{% static 'knowledge/js/components/TaggedBlockDisplay.js' %}"></script>
-    <script src="{% static 'knowledge/js/components/HistoricalSidebar.js' %}"></script>
-    <script src="{% static 'knowledge/js/components/SettingsModal.js' %}"></script>
-    <script src="{% static 'knowledge/js/components/HelpModal.js' %}"></script>
-    <script src="{% static 'knowledge/js/components/ChatHistory.js' %}"></script>
-    <script src="{% static 'knowledge/js/components/ChatPanel.js' %}"></script>
-    <script src="{% static 'knowledge/js/components/ToastNotifications.js' %}"></script>
-    <script src="{% static 'knowledge/js/components/SpotlightSearch.js' %}"></script>
-    <script src="{% static 'knowledge/js/components/GraphView.js' %}"></script>
+    <script src="{% static 'knowledge/js/components/BlockComponent.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/components/LoginForm.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/components/Whiteboard.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/components/Page.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/components/TaggedBlockDisplay.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/components/HistoricalSidebar.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/components/SettingsModal.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/components/HelpModal.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/components/ChatHistory.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/components/ChatPanel.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/components/ToastNotifications.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/components/SpotlightSearch.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/components/GraphView.js' %}?v={{ STATIC_VERSION }}"></script>
 
     <!-- Main App -->
-    <script src="{% static 'knowledge/js/app.js' %}"></script>
+    <script src="{% static 'knowledge/js/app.js' %}?v={{ STATIC_VERSION }}"></script>
     {% block extra_js %}{% endblock %}
   </body>
 </html>

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -105,7 +105,14 @@ class GraphDataResponse(TypedDict):
 
 
 def index(request, date=None, tag_name=None, slug=None):
-    return render(request, "knowledge/index.html")
+    # The HTML shell references hashed/versioned asset URLs, so it must
+    # never be cached - otherwise mobile browsers keep serving stale script
+    # tags and never pick up new deploys.
+    response = render(request, "knowledge/index.html")
+    response["Cache-Control"] = "no-cache, no-store, must-revalidate, max-age=0"
+    response["Pragma"] = "no-cache"
+    response["Expires"] = "0"
+    return response
 
 
 # Page management endpoints


### PR DESCRIPTION
## Summary
Implements cache-busting for static assets by appending version tokens to all script and stylesheet URLs, and ensures the HTML shell is never cached so browsers pick up new deploys.

## Key Changes
- **Static asset versioning**: Added `?v={{ STATIC_VERSION }}` query parameters to all CSS and JavaScript asset URLs in the base template
- **HTML cache control**: Added strict no-cache headers to the index view to prevent browsers from serving stale HTML with outdated asset references
- **Version configuration**: 
  - Created `STATIC_VERSION` setting that uses an explicit version (e.g., git SHA from environment) or falls back to process start time
  - Added `static_version` context processor to make the version available in templates
- **Code cleanup**: Fixed trailing whitespace in the template

## Implementation Details
The version token approach solves a critical issue where mobile browsers would cache the HTML shell and continue serving stale script tags even after new deploys. By:
1. Making the HTML uncacheable with explicit Cache-Control headers
2. Appending version tokens to all asset URLs so they're treated as new resources when the version changes
3. Using either a deploy-provided version (ideal for coordinated deployments) or process start time (for automatic invalidation on restarts)

This ensures that when new code is deployed, browsers will fetch fresh versions of all JavaScript and CSS files.

https://claude.ai/code/session_01MkwRzg3SBz5SjhVba8wW1U