### PR TITLE
Remove default content from tag page creation

### DIFF
--- a/packages/django-app/app/knowledge/commands/sync_block_tags_command.py
+++ b/packages/django-app/app/knowledge/commands/sync_block_tags_command.py
@@ -70,7 +70,6 @@ class SyncBlockTagsCommand(AbstractBaseCommand):
                 title=human_title,
                 slug=tag_name,
                 user=user,
-                content=f"Tag page for {human_title}",
                 is_published=True,
             )
         return tag_page


### PR DESCRIPTION
## Summary
Removed the automatic default content assignment when creating tag pages in the sync block tags command.

## Changes
- Removed the `content` parameter from the `Page` creation in `_get_or_create_tag_page()` method
- Tag pages will now be created without default content, allowing them to be populated separately or remain empty until explicitly edited

## Details
The `content=f"Tag page for {human_title}"` line has been removed from the Page instantiation. This change allows for more flexible tag page initialization, where content can be set independently of the page creation process rather than being automatically populated with a generic message.

https://claude.ai/code/session_017hp1H4iurqQCmrpyekMT8x