### PR TITLE
Add embed tag chips UI for tagging links without polluting titles

### DIFF
--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4970,3 +4970,97 @@ kbd {
 .block-embed-status-failed {
   color: var(--error-color, #c0392b);
 }
+
+.block-embed-tags {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+  font-size: 0.8rem;
+  cursor: default;
+}
+
+.block-embed-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  background-color: var(--tag-bg);
+  color: var(--tag-text);
+  border: 1px solid var(--tag-bg);
+  text-decoration: none;
+  line-height: 1.2;
+}
+
+.block-embed-tag-chip:hover {
+  background-color: var(--tag-hover);
+  text-decoration: none;
+}
+
+.block-embed-tag-chip-label {
+  white-space: nowrap;
+}
+
+.block-embed-tag-chip-remove {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1;
+  padding: 0 0.1rem;
+  opacity: 0.7;
+}
+
+.block-embed-tag-chip-remove:hover {
+  opacity: 1;
+}
+
+.block-embed-tag-add {
+  background: transparent;
+  border: 1px dashed var(--border-secondary);
+  border-radius: 999px;
+  padding: 0.1rem 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.block-embed-tag-add:hover {
+  color: var(--text-primary);
+  border-color: var(--border-primary);
+}
+
+.block-embed-tag-input-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.block-embed-tag-input {
+  font-family: inherit;
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-secondary);
+  border-radius: 999px;
+  padding: 0.1rem 0.5rem;
+  min-width: 6rem;
+  max-width: 12rem;
+}
+
+.block-embed-tag-input:focus {
+  outline: none;
+  border-color: var(--border-primary);
+}
+
+.block-embed-tag-suggestions {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 20;
+  min-width: 12rem;
+}

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4986,7 +4986,7 @@ kbd {
   align-items: center;
   gap: 0.15rem;
   padding: 0.1rem 0.4rem;
-  border-radius: 999px;
+  border-radius: 3px;
   background-color: var(--tag-bg);
   color: var(--tag-text);
   border: 1px solid var(--tag-bg);
@@ -5021,7 +5021,7 @@ kbd {
 .block-embed-tag-add {
   background: transparent;
   border: 1px dashed var(--border-secondary);
-  border-radius: 999px;
+  border-radius: 3px;
   padding: 0.1rem 0.5rem;
   font-size: 0.75rem;
   color: var(--text-muted);
@@ -5046,7 +5046,7 @@ kbd {
   color: var(--text-primary);
   background: var(--bg-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 999px;
+  border-radius: 3px;
   padding: 0.1rem 0.5rem;
   min-width: 6rem;
   max-width: 12rem;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -98,6 +98,12 @@ const BlockComponent = {
       // Web archive state (loaded lazily for embed blocks)
       webArchive: null,
       webArchiveLoading: false,
+      // Embed tag chip UI state
+      addingEmbedTag: false,
+      embedTagInputValue: "",
+      embedTagSuggestions: [],
+      embedTagSelectedIndex: 0,
+      embedTagSearchToken: 0,
     };
   },
   computed: {
@@ -134,14 +140,26 @@ const BlockComponent = {
         return "";
       }
     },
+    embedContentParts() {
+      // Split block.content into a "title" part and a list of trailing
+      // hashtag slugs. Trailing tags are rendered as chips so the user can
+      // tag a link without polluting the visible label.
+      return BlockComponent.parseEmbedContent(this.block.content);
+    },
     embedTitle() {
       // After archive capture completes, the backend overwrites
       // block.content with the extracted title. Before that, content is
       // just the URL, so fall back to the hostname for a cleaner card.
-      const c = (this.block.content || "").trim();
-      if (!c) return this.embedHostname;
-      if (c === this.block.media_url) return this.embedHostname;
-      return c;
+      const t = (this.embedContentParts.title || "").trim();
+      if (!t) return this.embedHostname;
+      if (t === this.block.media_url) return this.embedHostname;
+      return t;
+    },
+    embedTags() {
+      return this.embedContentParts.tags;
+    },
+    showEmbedTagSuggestions() {
+      return this.addingEmbedTag && this.embedTagSuggestions.length > 0;
     },
     webArchiveReady() {
       return !!(this.webArchive && this.webArchive.status === "ready");
@@ -690,6 +708,128 @@ const BlockComponent = {
       this.stopEditing(this.block);
     },
 
+    // --- Embed tag chips ---
+    startAddEmbedTag() {
+      this.addingEmbedTag = true;
+      this.embedTagInputValue = "";
+      this.embedTagSuggestions = [];
+      this.embedTagSelectedIndex = 0;
+      this.$nextTick(() => {
+        const input = this.$refs.embedTagInput;
+        if (input) input.focus();
+      });
+    },
+    cancelAddEmbedTag() {
+      this.addingEmbedTag = false;
+      this.embedTagInputValue = "";
+      this.embedTagSuggestions = [];
+      this.embedTagSelectedIndex = 0;
+    },
+    handleEmbedTagInputBlur() {
+      // Delay so a click on a suggestion still registers before close.
+      setTimeout(() => this.cancelAddEmbedTag(), 150);
+    },
+    async handleEmbedTagInputChange() {
+      const raw = (this.embedTagInputValue || "").trim();
+      if (!raw) {
+        this.embedTagSuggestions = [];
+        this.embedTagSelectedIndex = 0;
+        return;
+      }
+      const token = ++this.embedTagSearchToken;
+      try {
+        const result = await window.apiService.searchPages(raw, 8);
+        if (token !== this.embedTagSearchToken) return;
+        const pages = (result && result.data && result.data.pages) || [];
+        // Hide pages already attached as a trailing tag on this embed.
+        const existing = new Set(this.embedTags);
+        this.embedTagSuggestions = pages.filter((p) => !existing.has(p.slug));
+        if (this.embedTagSelectedIndex >= this.embedTagSuggestions.length) {
+          this.embedTagSelectedIndex = 0;
+        }
+      } catch (error) {
+        console.error("embed tag search failed:", error);
+        if (token === this.embedTagSearchToken) {
+          this.embedTagSuggestions = [];
+        }
+      }
+    },
+    handleEmbedTagInputKeydown(event) {
+      if (event.key === "ArrowDown" && this.embedTagSuggestions.length) {
+        event.preventDefault();
+        this.embedTagSelectedIndex =
+          (this.embedTagSelectedIndex + 1) % this.embedTagSuggestions.length;
+        return;
+      }
+      if (event.key === "ArrowUp" && this.embedTagSuggestions.length) {
+        event.preventDefault();
+        this.embedTagSelectedIndex =
+          (this.embedTagSelectedIndex - 1 + this.embedTagSuggestions.length) %
+          this.embedTagSuggestions.length;
+        return;
+      }
+      if (event.key === "Enter") {
+        event.preventDefault();
+        const choice = this.embedTagSuggestions[this.embedTagSelectedIndex];
+        if (choice) {
+          this.commitEmbedTag(choice.slug);
+        } else {
+          this.commitEmbedTag(this.embedTagInputValue);
+        }
+        return;
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        this.cancelAddEmbedTag();
+        return;
+      }
+    },
+    selectEmbedTagSuggestion(page) {
+      this.commitEmbedTag(page.slug);
+    },
+    commitEmbedTag(rawSlug) {
+      const slug = BlockComponent.slugifyTag(rawSlug);
+      if (!slug) {
+        this.cancelAddEmbedTag();
+        return;
+      }
+      // Reject duplicates - the chip is already there.
+      if (this.embedTags.includes(slug)) {
+        this.cancelAddEmbedTag();
+        return;
+      }
+      const current = this.block.content || "";
+      const sep = current && !/\s$/.test(current) ? " " : "";
+      const newContent = `${current}${sep}#${slug}`;
+      this.cancelAddEmbedTag();
+      this.onBlockContentChange(this.block, newContent);
+      // Persist immediately - chips are click-to-commit, not editor input.
+      this.persistEmbedContent(newContent);
+    },
+    removeEmbedTag(slug) {
+      const current = this.block.content || "";
+      const next = BlockComponent.removeTagFromContent(current, slug);
+      if (next === current) return;
+      this.onBlockContentChange(this.block, next);
+      this.persistEmbedContent(next);
+    },
+    async persistEmbedContent(newContent) {
+      try {
+        const result = await window.apiService.updateBlock(this.block.uuid, {
+          content: newContent,
+          parent: this.block.parent ? this.block.parent.uuid : null,
+        });
+        if (!result || !result.success) {
+          throw new Error("updateBlock did not succeed");
+        }
+        if (result.data && Array.isArray(result.data.tags)) {
+          this.block.tags = result.data.tags;
+        }
+      } catch (error) {
+        console.error("failed to persist embed tags:", error);
+      }
+    },
+
     handleContextMenuAction(action) {
       this.hideContextMenu();
 
@@ -800,6 +940,65 @@ const BlockComponent = {
               <span class="block-embed-url">{{ block.media_url }}</span>
               <span v-if="webArchive && (webArchive.status === 'pending' || webArchive.status === 'in_progress')" class="block-embed-status">· capturing…</span>
               <span v-else-if="webArchive && webArchive.status === 'failed'" class="block-embed-status block-embed-status-failed">· capture failed</span>
+            </div>
+            <div class="block-embed-tags" @click.stop>
+              <a
+                v-for="slug in embedTags"
+                :key="slug"
+                class="block-embed-tag-chip"
+                :href="'/knowledge/page/' + slug + '/'"
+                :data-tag="slug"
+                @click.stop
+              >
+                <span class="block-embed-tag-chip-label">#{{ slug }}</span>
+                <button
+                  type="button"
+                  class="block-embed-tag-chip-remove"
+                  :aria-label="'Remove tag ' + slug"
+                  title="Remove tag"
+                  @click.stop.prevent="removeEmbedTag(slug)"
+                >×</button>
+              </a>
+              <div v-if="addingEmbedTag" class="block-embed-tag-input-wrapper">
+                <input
+                  ref="embedTagInput"
+                  type="text"
+                  class="block-embed-tag-input"
+                  placeholder="tag…"
+                  v-model="embedTagInputValue"
+                  @input="handleEmbedTagInputChange"
+                  @keydown="handleEmbedTagInputKeydown"
+                  @blur="handleEmbedTagInputBlur"
+                />
+                <div
+                  v-if="showEmbedTagSuggestions"
+                  class="tag-suggestions block-embed-tag-suggestions"
+                  @mousedown.prevent
+                  role="listbox"
+                >
+                  <button
+                    v-for="(page, idx) in embedTagSuggestions"
+                    :key="page.uuid || page.slug"
+                    type="button"
+                    role="option"
+                    :aria-selected="idx === embedTagSelectedIndex"
+                    class="tag-suggestion-item"
+                    :class="{ 'is-selected': idx === embedTagSelectedIndex }"
+                    @click="selectEmbedTagSuggestion(page)"
+                    @mouseenter="embedTagSelectedIndex = idx"
+                  >
+                    <span class="tag-suggestion-slug">#{{ page.slug }}</span>
+                    <span v-if="page.title && page.title !== page.slug" class="tag-suggestion-title">{{ page.title }}</span>
+                  </button>
+                </div>
+              </div>
+              <button
+                v-else
+                type="button"
+                class="block-embed-tag-add"
+                title="Add a tag"
+                @click.stop="startAddEmbedTag"
+              >+ tag</button>
             </div>
           </div>
           <button
@@ -969,6 +1168,57 @@ const BlockComponent = {
       </div>
     </div>
   `,
+};
+
+// Parse embed-block content into a "title" portion and an array of trailing
+// hashtag slugs. Trailing tags are stripped from the displayed title and
+// rendered as chips on the embed card so the visible label stays clean.
+BlockComponent.parseEmbedContent = function parseEmbedContent(content) {
+  if (!content) return { title: "", tags: [] };
+  const original = content;
+  // Match a trailing run of `#tag` tokens. Either the first token sits at the
+  // very start of the string, or every token is preceded by whitespace.
+  const trailingRe = /(?:^|\s)#[a-zA-Z0-9_-]+(?:\s+#[a-zA-Z0-9_-]+)*\s*$/;
+  const match = original.match(trailingRe);
+  if (!match) return { title: original.trim(), tags: [] };
+  const tagPart = match[0];
+  const titlePart = original.slice(0, original.length - tagPart.length).trim();
+  const tagMatches = tagPart.match(/#([a-zA-Z0-9_-]+)/g) || [];
+  const seen = new Set();
+  const tags = [];
+  tagMatches.forEach((t) => {
+    const slug = t.slice(1);
+    if (!seen.has(slug)) {
+      seen.add(slug);
+      tags.push(slug);
+    }
+  });
+  return { title: titlePart, tags };
+};
+
+// Convert a free-text input into a tag slug compatible with the existing
+// hashtag regex (alphanumerics, underscore, hyphen). Spaces become hyphens.
+BlockComponent.slugifyTag = function slugifyTag(raw) {
+  if (!raw) return "";
+  return String(raw)
+    .trim()
+    .toLowerCase()
+    .replace(/^#+/, "")
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9_-]/g, "")
+    .replace(/^[-_]+|[-_]+$/g, "");
+};
+
+// Remove a `#slug` from content. Strips a single preceding whitespace
+// character along with the tag so we don't leave a stray space behind.
+// Slugs are [a-zA-Z0-9_-], none of which need regex escaping.
+BlockComponent.removeTagFromContent = function removeTagFromContent(
+  content,
+  slug
+) {
+  if (!content || !slug) return content;
+  const re = new RegExp(`(^|\\s)#${slug}(?![a-zA-Z0-9_-])`, "g");
+  return content.replace(re, "").trimEnd();
 };
 
 // Make it available globally

--- a/packages/django-app/app/web_archives/commands/capture_web_archive_command.py
+++ b/packages/django-app/app/web_archives/commands/capture_web_archive_command.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import mimetypes
+import re
 import threading
 from typing import Callable, Optional
 from urllib.parse import unquote, urlparse
@@ -173,11 +174,35 @@ def _capture_html(archive: WebArchive, fetched) -> None:
         archive.save()
 
     # Mirror the extracted title onto the block so the embed renders with
-    # real text as soon as capture finishes.
+    # real text as soon as capture finishes. If the user added trailing
+    # hashtags before capture finished (via the embed tag chips), preserve
+    # them so we don't silently drop their tagging work.
     if extracted.title:
-        Block.objects.filter(pk=archive.block_id).update(
-            content=extracted.title, modified_at=timezone.now()
-        )
+        block = Block.objects.filter(pk=archive.block_id).first()
+        if block is not None:
+            trailing_tags = _extract_trailing_hashtags(block.content)
+            new_content = (
+                f"{extracted.title} {trailing_tags}".rstrip()
+                if trailing_tags
+                else extracted.title
+            )
+            Block.objects.filter(pk=archive.block_id).update(
+                content=new_content, modified_at=timezone.now()
+            )
+
+
+# Match a run of trailing hashtags so we can carry tags across the
+# title-overwrite that happens when capture completes.
+_TRAILING_HASHTAGS_RE = re.compile(r"(?:(?:^|\s)#[a-zA-Z0-9_-]+)+\s*$")
+
+
+def _extract_trailing_hashtags(content: Optional[str]) -> str:
+    if not content:
+        return ""
+    match = _TRAILING_HASHTAGS_RE.search(content)
+    if not match:
+        return ""
+    return match.group(0).strip()
 
 
 def _capture_binary(archive: WebArchive, fetched) -> None:

--- a/packages/django-app/app/web_archives/test/commands/test_capture_web_archive_command.py
+++ b/packages/django-app/app/web_archives/test/commands/test_capture_web_archive_command.py
@@ -160,6 +160,25 @@ class TestCaptureWebArchiveCommand(TestCase):
         block.refresh_from_db()
         self.assertEqual(block.content, "Example Article - OG")
 
+    def test_should_preserve_trailing_tags_when_overwriting_title(self):
+        # User can tag an embed via the chip UI before capture finishes;
+        # those trailing hashtags must survive the title overwrite so we
+        # don't silently drop their work.
+        block = BlockFactory(
+            user=self.user,
+            page=self.page,
+            content="https://example.com/article #news #ai-research",
+        )
+        form = self._make_form(block_uuid=block.uuid)
+        self.assertTrue(form.is_valid())
+
+        CaptureWebArchiveCommand(
+            form, run_async=False, fetcher=make_fake_fetcher()
+        ).execute()
+
+        block.refresh_from_db()
+        self.assertEqual(block.content, "Example Article - OG #news #ai-research")
+
     def test_should_reject_block_owned_by_other_user(self):
         other_user = UserFactory()
         other_page = PageFactory(user=other_user)


### PR DESCRIPTION
## Summary
This PR adds a new tag chip UI to embed blocks, allowing users to tag links with hashtags that are stored separately from the visible title. Tags are appended to the block content as trailing hashtags and rendered as removable chips below the embed card, keeping the displayed title clean.

## Key Changes

- **Embed tag chip UI**: Added interactive chip components below embed cards that display trailing hashtags as removable tags with a "+ tag" button to add new ones
- **Tag input with autocomplete**: Implemented a tag input field with keyboard navigation (arrow keys, Enter, Escape) and autocomplete suggestions via `apiService.searchPages()`
- **Content parsing**: Added `parseEmbedContent()` to split block content into a title portion and trailing hashtag slugs, with `slugifyTag()` and `removeTagFromContent()` utilities for tag manipulation
- **Persistence**: Tags are persisted immediately via `updateBlock()` API calls when added or removed
- **Web archive integration**: Modified `capture_web_archive_command.py` to preserve user-added trailing hashtags when the archive capture completes and overwrites the content with the extracted title
- **Styling**: Added comprehensive CSS for tag chips, input field, suggestions dropdown, and hover states using existing design variables

## Notable Implementation Details

- Tags are stored as trailing `#slug` tokens in `block.content` (e.g., "Example Title #news #ai-research")
- The regex pattern `(?:^|\s)#[a-zA-Z0-9_-]+` matches valid tag slugs and ensures they're only recognized at the end of content
- Tag suggestions are filtered to exclude already-attached tags, preventing duplicates
- The tag input uses a search token mechanism to ignore stale autocomplete results from previous searches
- Web archive title extraction now extracts and preserves trailing tags before overwriting content, preventing silent loss of user tagging work

https://claude.ai/code/session_019RospckdpoeU2Nheajacmv