### PR TITLE
Add move block to daily note feature

### DIFF
--- a/packages/django-app/app/core/helpers.py
+++ b/packages/django-app/app/core/helpers.py
@@ -2,6 +2,28 @@ import functools
 import random
 import secrets
 import string
+from datetime import date
+
+import pytz
+from django.utils import timezone
+
+
+def today_for_user(user) -> date:
+    """Return today's date in the given user's timezone.
+
+    Falls back to UTC when the user has no timezone set or pytz can't
+    resolve the value. Always use this instead of ``date.today()`` /
+    ``datetime.now().date()`` when computing a "today" that the user
+    will see in the UI - the server clock is UTC and would otherwise
+    flip a day early for users west of UTC.
+    """
+    try:
+        if user and user.timezone and user.timezone != "UTC":
+            user_tz = pytz.timezone(user.timezone)
+            return timezone.now().astimezone(user_tz).date()
+    except Exception:
+        pass
+    return timezone.now().date()
 
 
 def generate_membership_token():

--- a/packages/django-app/app/knowledge/commands/__init__.py
+++ b/packages/django-app/app/knowledge/commands/__init__.py
@@ -7,6 +7,7 @@ from .get_historical_data_command import GetHistoricalDataCommand
 from .get_page_with_blocks_command import GetPageWithBlocksCommand
 from .get_tag_content_command import GetTagContentCommand
 from .get_user_pages_command import GetUserPagesCommand
+from .move_block_to_daily_command import MoveBlockToDailyCommand
 from .move_undone_todos_command import MoveUndoneTodosCommand
 from .reorder_blocks_command import ReorderBlocksCommand
 from .search_pages_command import SearchPagesCommand

--- a/packages/django-app/app/knowledge/commands/get_page_with_blocks_command.py
+++ b/packages/django-app/app/knowledge/commands/get_page_with_blocks_command.py
@@ -1,10 +1,9 @@
 from typing import List, Tuple
 
-import pytz
 from django.core.exceptions import ValidationError
-from django.utils import timezone
 
 from common.commands.abstract_base_command import AbstractBaseCommand
+from core.helpers import today_for_user
 from knowledge.models import Block, Page
 from knowledge.repositories import BlockRepository, PageRepository
 
@@ -35,18 +34,10 @@ class GetPageWithBlocksCommand(AbstractBaseCommand):
             # Get or create daily note
             page, created = PageRepository.get_or_create_daily_note(user, date)
         elif not page:
-            # Default to today's daily note
-            try:
-                if user.timezone and user.timezone != "UTC":
-                    user_tz = pytz.timezone(user.timezone)
-                    now_user_tz = timezone.now().astimezone(user_tz)
-                    today = now_user_tz.date()
-                else:
-                    today = timezone.now().date()
-            except Exception:
-                today = timezone.now().date()
-
-            page, created = PageRepository.get_or_create_daily_note(user, today)
+            # Default to today's daily note (in the user's timezone).
+            page, created = PageRepository.get_or_create_daily_note(
+                user, today_for_user(user)
+            )
 
         # Get direct blocks (blocks that belong directly to this page)
         direct_blocks = BlockRepository.get_root_blocks(page)

--- a/packages/django-app/app/knowledge/commands/move_block_to_daily_command.py
+++ b/packages/django-app/app/knowledge/commands/move_block_to_daily_command.py
@@ -1,28 +1,15 @@
-from datetime import date
 from typing import TypedDict
 
-import pytz
 from django.db import transaction
 from django.db.models import Max
-from django.utils import timezone
 
 from common.commands.abstract_base_command import AbstractBaseCommand
+from core.helpers import today_for_user
 
 from ..forms.move_block_to_daily_form import MoveBlockToDailyForm
 from ..models import BlockData, PageData
 from ..repositories import BlockRepository
 from ..repositories.page_repository import PageRepository
-
-
-def _today_for_user(user) -> date:
-    """Today's date in the user's timezone (falls back to UTC)."""
-    try:
-        if user.timezone and user.timezone != "UTC":
-            user_tz = pytz.timezone(user.timezone)
-            return timezone.now().astimezone(user_tz).date()
-    except Exception:
-        pass
-    return timezone.now().date()
 
 
 class MoveBlockToDailyCommand(AbstractBaseCommand):
@@ -36,7 +23,7 @@ class MoveBlockToDailyCommand(AbstractBaseCommand):
 
         user = self.form.cleaned_data["user"]
         block = self.form.cleaned_data["block"]
-        target_date = self.form.cleaned_data.get("target_date") or _today_for_user(user)
+        target_date = self.form.cleaned_data.get("target_date") or today_for_user(user)
 
         target_page, _ = PageRepository.get_or_create_daily_note(user, target_date)
 

--- a/packages/django-app/app/knowledge/commands/move_block_to_daily_command.py
+++ b/packages/django-app/app/knowledge/commands/move_block_to_daily_command.py
@@ -1,8 +1,10 @@
 from datetime import date
 from typing import TypedDict
 
+import pytz
 from django.db import transaction
 from django.db.models import Max
+from django.utils import timezone
 
 from common.commands.abstract_base_command import AbstractBaseCommand
 
@@ -10,6 +12,17 @@ from ..forms.move_block_to_daily_form import MoveBlockToDailyForm
 from ..models import BlockData, PageData
 from ..repositories import BlockRepository
 from ..repositories.page_repository import PageRepository
+
+
+def _today_for_user(user) -> date:
+    """Today's date in the user's timezone (falls back to UTC)."""
+    try:
+        if user.timezone and user.timezone != "UTC":
+            user_tz = pytz.timezone(user.timezone)
+            return timezone.now().astimezone(user_tz).date()
+    except Exception:
+        pass
+    return timezone.now().date()
 
 
 class MoveBlockToDailyCommand(AbstractBaseCommand):
@@ -23,7 +36,7 @@ class MoveBlockToDailyCommand(AbstractBaseCommand):
 
         user = self.form.cleaned_data["user"]
         block = self.form.cleaned_data["block"]
-        target_date = self.form.cleaned_data.get("target_date") or date.today()
+        target_date = self.form.cleaned_data.get("target_date") or _today_for_user(user)
 
         target_page, _ = PageRepository.get_or_create_daily_note(user, target_date)
 

--- a/packages/django-app/app/knowledge/commands/move_block_to_daily_command.py
+++ b/packages/django-app/app/knowledge/commands/move_block_to_daily_command.py
@@ -1,0 +1,72 @@
+from datetime import date
+from typing import TypedDict
+
+from django.db import transaction
+from django.db.models import Max
+
+from common.commands.abstract_base_command import AbstractBaseCommand
+
+from ..forms.move_block_to_daily_form import MoveBlockToDailyForm
+from ..models import BlockData, PageData
+from ..repositories import BlockRepository
+from ..repositories.page_repository import PageRepository
+
+
+class MoveBlockToDailyCommand(AbstractBaseCommand):
+    """Command to move a single block (and its descendants) to a daily note page."""
+
+    def __init__(self, form: MoveBlockToDailyForm) -> None:
+        self.form = form
+
+    def execute(self) -> "MoveBlockToDailyData":
+        super().execute()  # validates the form
+
+        user = self.form.cleaned_data["user"]
+        block = self.form.cleaned_data["block"]
+        target_date = self.form.cleaned_data.get("target_date") or date.today()
+
+        target_page, _ = PageRepository.get_or_create_daily_note(user, target_date)
+
+        already_root_on_target = (
+            block.page_id == target_page.pk and block.parent_id is None
+        )
+        if already_root_on_target:
+            return {
+                "moved": False,
+                "block": block.to_dict(),
+                "target_page": target_page.to_dict(),
+                "message": "Block is already on the target page",
+            }
+
+        descendants = BlockRepository.get_block_descendants(block)
+
+        with transaction.atomic():
+            max_order = (
+                BlockRepository.get_queryset()
+                .filter(page=target_page)
+                .aggregate(max_order=Max("order"))["max_order"]
+            )
+            max_order = max_order if max_order is not None else 0
+
+            block.page = target_page
+            block.parent = None
+            block.order = max_order + 1
+            block.save(update_fields=["page", "parent", "order"])
+
+            for descendant in descendants:
+                descendant.page = target_page
+                descendant.save(update_fields=["page"])
+
+        return {
+            "moved": True,
+            "block": block.to_dict(),
+            "target_page": target_page.to_dict(),
+            "message": f"Moved block to {target_date.strftime('%Y-%m-%d')} page",
+        }
+
+
+class MoveBlockToDailyData(TypedDict):
+    moved: bool
+    block: BlockData
+    target_page: PageData
+    message: str

--- a/packages/django-app/app/knowledge/commands/move_undone_todos_command.py
+++ b/packages/django-app/app/knowledge/commands/move_undone_todos_command.py
@@ -1,7 +1,7 @@
-from datetime import date
 from typing import List, Optional, TypedDict
 
 from common.commands.abstract_base_command import AbstractBaseCommand
+from core.helpers import today_for_user
 
 from ..forms.move_undone_todos_form import MoveUndoneTodosForm
 from ..models import BlockData, PageData
@@ -20,7 +20,7 @@ class MoveUndoneTodosCommand(AbstractBaseCommand):
         super().execute()  # This validates the form
 
         user = self.form.cleaned_data["user"]
-        target_date = self.form.cleaned_data.get("target_date") or date.today()
+        target_date = self.form.cleaned_data.get("target_date") or today_for_user(user)
 
         # Get or create target date's daily note page
         target_page, created = PageRepository.get_or_create_daily_note(

--- a/packages/django-app/app/knowledge/forms/__init__.py
+++ b/packages/django-app/app/knowledge/forms/__init__.py
@@ -7,6 +7,7 @@ from .get_historical_data_form import GetHistoricalDataForm
 from .get_page_with_blocks_form import GetPageWithBlocksForm
 from .get_tag_content_form import GetTagContentForm
 from .get_user_pages_form import GetUserPagesForm
+from .move_block_to_daily_form import MoveBlockToDailyForm
 from .move_undone_todos_form import MoveUndoneTodosForm
 from .reorder_blocks_form import ReorderBlocksForm
 from .search_pages_form import SearchPagesForm

--- a/packages/django-app/app/knowledge/forms/get_page_with_blocks_form.py
+++ b/packages/django-app/app/knowledge/forms/get_page_with_blocks_form.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from django import forms
 from django.core.exceptions import ValidationError
 
@@ -28,14 +26,3 @@ class GetPageWithBlocksForm(BaseForm):
         if page and user and page.user != user:
             raise ValidationError("Page not found")
         return page
-
-    def clean(self):
-        cleaned_data = super().clean()
-        page = cleaned_data.get("page")
-        date = cleaned_data.get("date")
-        slug = cleaned_data.get("slug")
-
-        if not page and not date and not slug:
-            cleaned_data["date"] = datetime.now().date()
-
-        return cleaned_data

--- a/packages/django-app/app/knowledge/forms/move_block_to_daily_form.py
+++ b/packages/django-app/app/knowledge/forms/move_block_to_daily_form.py
@@ -1,0 +1,35 @@
+from typing import Optional
+
+from django import forms
+from django.core.exceptions import ValidationError
+
+from common.forms import BaseForm, UUIDModelChoiceField
+from core.models import User
+from core.repositories import UserRepository
+
+from ..models import Block
+from ..repositories import BlockRepository
+
+
+class MoveBlockToDailyForm(BaseForm):
+    user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
+    block = UUIDModelChoiceField(queryset=BlockRepository.get_queryset(), required=True)
+    target_date = forms.DateField(required=False)
+
+    def clean_user(self) -> User:
+        user = self.cleaned_data.get("user")
+        if not user:
+            raise ValidationError("User is required")
+        return user
+
+    def clean_block(self) -> Block:
+        block = self.cleaned_data.get("block")
+        user = self.cleaned_data.get("user")
+
+        if block and user and block.user != user:
+            raise ValidationError("Block not found")
+
+        return block
+
+    def clean_target_date(self) -> Optional[object]:
+        return self.cleaned_data.get("target_date")

--- a/packages/django-app/app/knowledge/management/commands/move_undone_todos.py
+++ b/packages/django-app/app/knowledge/management/commands/move_undone_todos.py
@@ -1,8 +1,8 @@
-from datetime import date
 from typing import Any
 
 from django.core.management.base import BaseCommand, CommandError
 
+from core.helpers import today_for_user
 from core.models import User
 from knowledge.commands import MoveUndoneTodosCommand
 from knowledge.forms import MoveUndoneTodosForm
@@ -28,7 +28,7 @@ class Command(BaseCommand):
             raise CommandError(f"User with email '{user_email}' does not exist")
 
         # Create form and command
-        form_data = {"user": user, "target_date": date.today()}
+        form_data = {"user": user, "target_date": today_for_user(user)}
         form = MoveUndoneTodosForm(form_data)
 
         if not form.is_valid():

--- a/packages/django-app/app/knowledge/management/commands/seed_staging_data.py
+++ b/packages/django-app/app/knowledge/management/commands/seed_staging_data.py
@@ -1,9 +1,8 @@
-from datetime import date
-
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
+from core.helpers import today_for_user
 from knowledge.models import Block, Page
 
 User = get_user_model()
@@ -20,7 +19,7 @@ class Command(BaseCommand):
             )
             return
 
-        today = date.today()
+        today = today_for_user(user)
         date_str = today.strftime("%Y-%m-%d")
 
         with transaction.atomic():

--- a/packages/django-app/app/knowledge/repositories/block_repository.py
+++ b/packages/django-app/app/knowledge/repositories/block_repository.py
@@ -1,10 +1,10 @@
-from datetime import date
 from typing import Any, Dict, List, Optional
 
 from django.db import transaction
 from django.db.models import Max, QuerySet
 
 from common.repositories.base_repository import BaseRepository
+from core.helpers import today_for_user
 
 from ..models import Block, Page
 
@@ -186,7 +186,7 @@ class BlockRepository(BaseRepository):
     @classmethod
     def get_undone_todos(cls, user) -> QuerySet:
         """Get undone TODO blocks from daily pages before today"""
-        today = date.today()
+        today = today_for_user(user)
         return (
             cls.get_queryset()
             .filter(

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -75,6 +75,10 @@ const BlockComponent = {
       type: Function,
       default: () => () => {},
     },
+    moveBlockToToday: {
+      type: Function,
+      default: () => () => {},
+    },
     onBlockPaste: {
       type: Function,
       default: () => () => {},
@@ -861,6 +865,9 @@ const BlockComponent = {
         case "moveDown":
           this.moveBlockDown(this.block);
           break;
+        case "moveToToday":
+          this.moveBlockToToday(this.block);
+          break;
         case "newBlockBefore":
           this.createBlockBefore(this.block);
           break;
@@ -1115,6 +1122,10 @@ const BlockComponent = {
           <span class="context-menu-icon">↓</span>
           <span>move down</span>
         </button>
+        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('moveToToday')">
+          <span class="context-menu-icon">⇨</span>
+          <span>move to today's daily</span>
+        </button>
         <div class="context-menu-separator"></div>
         <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('newBlockBefore')">
           <span class="context-menu-icon">+</span>
@@ -1163,6 +1174,7 @@ const BlockComponent = {
           :createBlockBefore="createBlockBefore"
           :moveBlockUp="moveBlockUp"
           :moveBlockDown="moveBlockDown"
+          :moveBlockToToday="moveBlockToToday"
           :onBlockPaste="onBlockPaste"
         />
       </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -592,10 +592,7 @@ const Page = {
 
         const targetTitle = result.data?.target_page?.title || "today";
         if (result.data?.moved) {
-          this.$parent?.addToast?.(
-            `moved block to ${targetTitle}`,
-            "success"
-          );
+          this.$parent?.addToast?.(`moved block to ${targetTitle}`, "success");
         } else {
           this.$parent?.addToast?.(
             result.data?.message || "block already on today's daily",

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -577,6 +577,40 @@ const Page = {
       }
     },
 
+    async moveBlockToToday(block) {
+      try {
+        // Save in-progress edits before moving
+        if (block.isEditing) {
+          await this.updateBlock(block, block.content, true);
+        }
+
+        const result = await window.apiService.moveBlockToDaily(block.uuid);
+
+        if (!result.success) {
+          throw new Error("move to today failed");
+        }
+
+        const targetTitle = result.data?.target_page?.title || "today";
+        if (result.data?.moved) {
+          this.$parent?.addToast?.(
+            `moved block to ${targetTitle}`,
+            "success"
+          );
+        } else {
+          this.$parent?.addToast?.(
+            result.data?.message || "block already on today's daily",
+            "info"
+          );
+        }
+
+        await this.loadPage({ silent: true });
+      } catch (error) {
+        console.error("failed to move block to today:", error);
+        this.error = "failed to move block to today";
+        this.$parent?.addToast?.("failed to move block to today", "error");
+      }
+    },
+
     onBlockContentChange(block, newContent) {
       // Just update the local content, don't save yet
       block.content = newContent;
@@ -2281,6 +2315,7 @@ const Page = {
               :createBlockBefore="createBlockBefore"
               :moveBlockUp="moveBlockUp"
               :moveBlockDown="moveBlockDown"
+              :moveBlockToToday="moveBlockToToday"
               :onBlockPaste="onBlockPaste"
             />
             <button @click="addNewBlock" class="add-block-btn">

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -214,6 +214,20 @@ class ApiService {
     });
   }
 
+  async moveBlockToDaily(blockUuid, targetDate = null) {
+    const body = { block: blockUuid };
+    if (targetDate) {
+      body.target_date = targetDate;
+    }
+    return await this.request("/knowledge/api/blocks/move-to-daily/", {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
   async getHistoricalData(daysBack = 30, limit = 50) {
     return await this.request(
       `/knowledge/api/historical/?days_back=${daysBack}&limit=${limit}`

--- a/packages/django-app/app/knowledge/test/commands/test_move_block_to_daily_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_move_block_to_daily_command.py
@@ -1,6 +1,7 @@
-from datetime import date
+from datetime import date, datetime
 from unittest.mock import patch
 
+import pytz
 from django.test import TestCase
 
 from knowledge.commands import MoveBlockToDailyCommand
@@ -15,10 +16,8 @@ class TestMoveBlockToDailyCommand(TestCase):
     def setUpTestData(cls):
         cls.user = UserFactory()
 
-    @patch("knowledge.commands.move_block_to_daily_command.date")
-    def test_should_move_block_from_other_page_to_today(self, mock_date):
-        today = date(2026, 4, 29)
-        mock_date.today.return_value = today
+    def test_should_move_block_from_other_page_to_target_daily(self):
+        target_date = date(2026, 4, 29)
 
         source_page = PageFactory(user=self.user, title="Notes", slug="notes")
         block = BlockFactory(
@@ -29,27 +28,27 @@ class TestMoveBlockToDailyCommand(TestCase):
             order=1,
         )
 
-        form = MoveBlockToDailyForm({"user": self.user, "block": block.uuid})
+        form = MoveBlockToDailyForm(
+            {"user": self.user, "block": block.uuid, "target_date": target_date}
+        )
         self.assertTrue(form.is_valid(), form.errors)
 
         result = MoveBlockToDailyCommand(form).execute()
 
         self.assertTrue(result["moved"])
-        self.assertEqual(result["target_page"]["date"], today.isoformat())
+        self.assertEqual(result["target_page"]["date"], target_date.isoformat())
 
         block.refresh_from_db()
-        self.assertEqual(block.page.date, today)
+        self.assertEqual(block.page.date, target_date)
         self.assertEqual(block.page.page_type, "daily")
         self.assertIsNone(block.parent)
 
-    @patch("knowledge.commands.move_block_to_daily_command.date")
-    def test_should_place_block_at_bottom_of_target_page(self, mock_date):
-        today = date(2026, 4, 29)
-        mock_date.today.return_value = today
+    def test_should_place_block_at_bottom_of_target_page(self):
+        target_date = date(2026, 4, 29)
 
         today_page = PageFactory(
             user=self.user,
-            date=today,
+            date=target_date,
             page_type="daily",
             title="2026-04-29",
             slug="2026-04-29",
@@ -60,7 +59,9 @@ class TestMoveBlockToDailyCommand(TestCase):
         source_page = PageFactory(user=self.user, title="Notes", slug="notes")
         block = BlockFactory(user=self.user, page=source_page, content="moved", order=1)
 
-        form = MoveBlockToDailyForm({"user": self.user, "block": block.uuid})
+        form = MoveBlockToDailyForm(
+            {"user": self.user, "block": block.uuid, "target_date": target_date}
+        )
         self.assertTrue(form.is_valid(), form.errors)
 
         MoveBlockToDailyCommand(form).execute()
@@ -69,10 +70,8 @@ class TestMoveBlockToDailyCommand(TestCase):
         self.assertEqual(block.page, today_page)
         self.assertEqual(block.order, 3)
 
-    @patch("knowledge.commands.move_block_to_daily_command.date")
-    def test_should_move_descendants_with_block(self, mock_date):
-        today = date(2026, 4, 29)
-        mock_date.today.return_value = today
+    def test_should_move_descendants_with_block(self):
+        target_date = date(2026, 4, 29)
 
         source_page = PageFactory(user=self.user, title="Notes", slug="notes")
         parent = BlockFactory(
@@ -89,7 +88,9 @@ class TestMoveBlockToDailyCommand(TestCase):
             order=3,
         )
 
-        form = MoveBlockToDailyForm({"user": self.user, "block": parent.uuid})
+        form = MoveBlockToDailyForm(
+            {"user": self.user, "block": parent.uuid, "target_date": target_date}
+        )
         self.assertTrue(form.is_valid(), form.errors)
 
         MoveBlockToDailyCommand(form).execute()
@@ -98,7 +99,9 @@ class TestMoveBlockToDailyCommand(TestCase):
         child.refresh_from_db()
         grandchild.refresh_from_db()
 
-        target_page = Page.objects.get(user=self.user, date=today, page_type="daily")
+        target_page = Page.objects.get(
+            user=self.user, date=target_date, page_type="daily"
+        )
         self.assertEqual(parent.page, target_page)
         self.assertEqual(child.page, target_page)
         self.assertEqual(grandchild.page, target_page)
@@ -108,10 +111,8 @@ class TestMoveBlockToDailyCommand(TestCase):
         self.assertEqual(child.parent, parent)
         self.assertEqual(grandchild.parent, child)
 
-    @patch("knowledge.commands.move_block_to_daily_command.date")
-    def test_should_promote_nested_block_to_root_on_target(self, mock_date):
-        today = date(2026, 4, 29)
-        mock_date.today.return_value = today
+    def test_should_promote_nested_block_to_root_on_target(self):
+        target_date = date(2026, 4, 29)
 
         source_page = PageFactory(user=self.user, title="Notes", slug="notes")
         parent = BlockFactory(
@@ -125,7 +126,9 @@ class TestMoveBlockToDailyCommand(TestCase):
             order=2,
         )
 
-        form = MoveBlockToDailyForm({"user": self.user, "block": child.uuid})
+        form = MoveBlockToDailyForm(
+            {"user": self.user, "block": child.uuid, "target_date": target_date}
+        )
         self.assertTrue(form.is_valid(), form.errors)
 
         MoveBlockToDailyCommand(form).execute()
@@ -135,61 +138,45 @@ class TestMoveBlockToDailyCommand(TestCase):
 
         # child becomes root on the daily page; parent stays put
         self.assertIsNone(child.parent)
-        self.assertEqual(child.page.date, today)
+        self.assertEqual(child.page.date, target_date)
         self.assertEqual(parent.page, source_page)
 
-    @patch("knowledge.commands.move_block_to_daily_command.date")
-    def test_should_create_daily_page_if_missing(self, mock_date):
-        today = date(2026, 4, 29)
-        mock_date.today.return_value = today
+    def test_should_create_daily_page_if_missing(self):
+        target_date = date(2026, 4, 29)
 
         source_page = PageFactory(user=self.user, title="Notes", slug="notes")
         block = BlockFactory(user=self.user, page=source_page, content="x", order=1)
 
         self.assertFalse(
-            Page.objects.filter(user=self.user, page_type="daily", date=today).exists()
+            Page.objects.filter(
+                user=self.user, page_type="daily", date=target_date
+            ).exists()
         )
 
-        form = MoveBlockToDailyForm({"user": self.user, "block": block.uuid})
+        form = MoveBlockToDailyForm(
+            {"user": self.user, "block": block.uuid, "target_date": target_date}
+        )
         self.assertTrue(form.is_valid(), form.errors)
 
         MoveBlockToDailyCommand(form).execute()
 
         self.assertTrue(
-            Page.objects.filter(user=self.user, page_type="daily", date=today).exists()
+            Page.objects.filter(
+                user=self.user, page_type="daily", date=target_date
+            ).exists()
         )
 
-    @patch("knowledge.commands.move_block_to_daily_command.date")
-    def test_should_be_noop_when_block_already_root_on_target(self, mock_date):
-        today = date(2026, 4, 29)
-        mock_date.today.return_value = today
+    def test_should_be_noop_when_block_already_root_on_target(self):
+        target_date = date(2026, 4, 29)
 
         today_page = PageFactory(
             user=self.user,
-            date=today,
+            date=target_date,
             page_type="daily",
             title="2026-04-29",
             slug="2026-04-29",
         )
         block = BlockFactory(user=self.user, page=today_page, content="x", order=5)
-
-        form = MoveBlockToDailyForm({"user": self.user, "block": block.uuid})
-        self.assertTrue(form.is_valid(), form.errors)
-
-        result = MoveBlockToDailyCommand(form).execute()
-
-        self.assertFalse(result["moved"])
-        block.refresh_from_db()
-        self.assertEqual(block.order, 5)
-
-    @patch("knowledge.commands.move_block_to_daily_command.date")
-    def test_should_use_target_date_when_provided(self, mock_date):
-        today = date(2026, 4, 29)
-        mock_date.today.return_value = today
-        target_date = date(2026, 5, 1)
-
-        source_page = PageFactory(user=self.user, title="Notes", slug="notes")
-        block = BlockFactory(user=self.user, page=source_page, content="x", order=1)
 
         form = MoveBlockToDailyForm(
             {"user": self.user, "block": block.uuid, "target_date": target_date}
@@ -198,11 +185,9 @@ class TestMoveBlockToDailyCommand(TestCase):
 
         result = MoveBlockToDailyCommand(form).execute()
 
-        self.assertTrue(result["moved"])
-        self.assertEqual(result["target_page"]["date"], target_date.isoformat())
-
+        self.assertFalse(result["moved"])
         block.refresh_from_db()
-        self.assertEqual(block.page.date, target_date)
+        self.assertEqual(block.order, 5)
 
     def test_should_reject_block_belonging_to_another_user(self):
         other_user = UserFactory()
@@ -213,14 +198,12 @@ class TestMoveBlockToDailyCommand(TestCase):
         self.assertFalse(form.is_valid())
         self.assertIn("block", form.errors)
 
-    @patch("knowledge.commands.move_block_to_daily_command.date")
-    def test_should_not_disrupt_unrelated_blocks_on_target_page(self, mock_date):
-        today = date(2026, 4, 29)
-        mock_date.today.return_value = today
+    def test_should_not_disrupt_unrelated_blocks_on_target_page(self):
+        target_date = date(2026, 4, 29)
 
         today_page = PageFactory(
             user=self.user,
-            date=today,
+            date=target_date,
             page_type="daily",
             title="2026-04-29",
             slug="2026-04-29",
@@ -239,7 +222,9 @@ class TestMoveBlockToDailyCommand(TestCase):
         source_page = PageFactory(user=self.user, title="Notes", slug="notes")
         block = BlockFactory(user=self.user, page=source_page, content="moved", order=1)
 
-        form = MoveBlockToDailyForm({"user": self.user, "block": block.uuid})
+        form = MoveBlockToDailyForm(
+            {"user": self.user, "block": block.uuid, "target_date": target_date}
+        )
         self.assertTrue(form.is_valid(), form.errors)
 
         MoveBlockToDailyCommand(form).execute()
@@ -256,3 +241,42 @@ class TestMoveBlockToDailyCommand(TestCase):
             Block.objects.filter(page=today_page).values_list("order", flat=True)
         )
         self.assertEqual(len(orders), len(set(orders)))
+
+    @patch("knowledge.commands.move_block_to_daily_command.timezone")
+    def test_should_use_user_timezone_when_resolving_today(self, mock_timezone):
+        # Server clock is 2026-04-29 03:00 UTC. A user in America/Los_Angeles
+        # (UTC-7) should still see this as 2026-04-28, so the daily that gets
+        # created/used for them should be 2026-04-28.
+        utc_now = datetime(2026, 4, 29, 3, 0, tzinfo=pytz.UTC)
+        mock_timezone.now.return_value = utc_now
+
+        user = UserFactory(timezone="America/Los_Angeles")
+        source_page = PageFactory(user=user, title="Notes", slug="la-notes")
+        block = BlockFactory(user=user, page=source_page, content="x", order=1)
+
+        form = MoveBlockToDailyForm({"user": user, "block": block.uuid})
+        self.assertTrue(form.is_valid(), form.errors)
+
+        result = MoveBlockToDailyCommand(form).execute()
+
+        self.assertTrue(result["moved"])
+        self.assertEqual(result["target_page"]["date"], "2026-04-28")
+        block.refresh_from_db()
+        self.assertEqual(block.page.date, date(2026, 4, 28))
+
+    @patch("knowledge.commands.move_block_to_daily_command.timezone")
+    def test_should_default_to_utc_today_when_user_timezone_is_utc(self, mock_timezone):
+        utc_now = datetime(2026, 4, 29, 3, 0, tzinfo=pytz.UTC)
+        mock_timezone.now.return_value = utc_now
+
+        user = UserFactory(timezone="UTC")
+        source_page = PageFactory(user=user, title="Notes", slug="utc-notes")
+        block = BlockFactory(user=user, page=source_page, content="x", order=1)
+
+        form = MoveBlockToDailyForm({"user": user, "block": block.uuid})
+        self.assertTrue(form.is_valid(), form.errors)
+
+        result = MoveBlockToDailyCommand(form).execute()
+
+        self.assertTrue(result["moved"])
+        self.assertEqual(result["target_page"]["date"], "2026-04-29")

--- a/packages/django-app/app/knowledge/test/commands/test_move_block_to_daily_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_move_block_to_daily_command.py
@@ -58,9 +58,7 @@ class TestMoveBlockToDailyCommand(TestCase):
         BlockFactory(user=self.user, page=today_page, content="existing 2", order=2)
 
         source_page = PageFactory(user=self.user, title="Notes", slug="notes")
-        block = BlockFactory(
-            user=self.user, page=source_page, content="moved", order=1
-        )
+        block = BlockFactory(user=self.user, page=source_page, content="moved", order=1)
 
         form = MoveBlockToDailyForm({"user": self.user, "block": block.uuid})
         self.assertTrue(form.is_valid(), form.errors)
@@ -149,9 +147,7 @@ class TestMoveBlockToDailyCommand(TestCase):
         block = BlockFactory(user=self.user, page=source_page, content="x", order=1)
 
         self.assertFalse(
-            Page.objects.filter(
-                user=self.user, page_type="daily", date=today
-            ).exists()
+            Page.objects.filter(user=self.user, page_type="daily", date=today).exists()
         )
 
         form = MoveBlockToDailyForm({"user": self.user, "block": block.uuid})
@@ -160,9 +156,7 @@ class TestMoveBlockToDailyCommand(TestCase):
         MoveBlockToDailyCommand(form).execute()
 
         self.assertTrue(
-            Page.objects.filter(
-                user=self.user, page_type="daily", date=today
-            ).exists()
+            Page.objects.filter(user=self.user, page_type="daily", date=today).exists()
         )
 
     @patch("knowledge.commands.move_block_to_daily_command.date")
@@ -215,9 +209,7 @@ class TestMoveBlockToDailyCommand(TestCase):
         other_page = PageFactory(user=other_user, title="Other", slug="other")
         other_block = BlockFactory(user=other_user, page=other_page, content="x")
 
-        form = MoveBlockToDailyForm(
-            {"user": self.user, "block": other_block.uuid}
-        )
+        form = MoveBlockToDailyForm({"user": self.user, "block": other_block.uuid})
         self.assertFalse(form.is_valid())
         self.assertIn("block", form.errors)
 
@@ -245,9 +237,7 @@ class TestMoveBlockToDailyCommand(TestCase):
         )
 
         source_page = PageFactory(user=self.user, title="Notes", slug="notes")
-        block = BlockFactory(
-            user=self.user, page=source_page, content="moved", order=1
-        )
+        block = BlockFactory(user=self.user, page=source_page, content="moved", order=1)
 
         form = MoveBlockToDailyForm({"user": self.user, "block": block.uuid})
         self.assertTrue(form.is_valid(), form.errors)

--- a/packages/django-app/app/knowledge/test/commands/test_move_block_to_daily_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_move_block_to_daily_command.py
@@ -1,0 +1,268 @@
+from datetime import date
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from knowledge.commands import MoveBlockToDailyCommand
+from knowledge.forms import MoveBlockToDailyForm
+from knowledge.models import Block, Page
+
+from ..helpers import BlockFactory, PageFactory, UserFactory
+
+
+class TestMoveBlockToDailyCommand(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
+    @patch("knowledge.commands.move_block_to_daily_command.date")
+    def test_should_move_block_from_other_page_to_today(self, mock_date):
+        today = date(2026, 4, 29)
+        mock_date.today.return_value = today
+
+        source_page = PageFactory(user=self.user, title="Notes", slug="notes")
+        block = BlockFactory(
+            user=self.user,
+            page=source_page,
+            content="some idea",
+            block_type="bullet",
+            order=1,
+        )
+
+        form = MoveBlockToDailyForm({"user": self.user, "block": block.uuid})
+        self.assertTrue(form.is_valid(), form.errors)
+
+        result = MoveBlockToDailyCommand(form).execute()
+
+        self.assertTrue(result["moved"])
+        self.assertEqual(result["target_page"]["date"], today.isoformat())
+
+        block.refresh_from_db()
+        self.assertEqual(block.page.date, today)
+        self.assertEqual(block.page.page_type, "daily")
+        self.assertIsNone(block.parent)
+
+    @patch("knowledge.commands.move_block_to_daily_command.date")
+    def test_should_place_block_at_bottom_of_target_page(self, mock_date):
+        today = date(2026, 4, 29)
+        mock_date.today.return_value = today
+
+        today_page = PageFactory(
+            user=self.user,
+            date=today,
+            page_type="daily",
+            title="2026-04-29",
+            slug="2026-04-29",
+        )
+        BlockFactory(user=self.user, page=today_page, content="existing 1", order=1)
+        BlockFactory(user=self.user, page=today_page, content="existing 2", order=2)
+
+        source_page = PageFactory(user=self.user, title="Notes", slug="notes")
+        block = BlockFactory(
+            user=self.user, page=source_page, content="moved", order=1
+        )
+
+        form = MoveBlockToDailyForm({"user": self.user, "block": block.uuid})
+        self.assertTrue(form.is_valid(), form.errors)
+
+        MoveBlockToDailyCommand(form).execute()
+
+        block.refresh_from_db()
+        self.assertEqual(block.page, today_page)
+        self.assertEqual(block.order, 3)
+
+    @patch("knowledge.commands.move_block_to_daily_command.date")
+    def test_should_move_descendants_with_block(self, mock_date):
+        today = date(2026, 4, 29)
+        mock_date.today.return_value = today
+
+        source_page = PageFactory(user=self.user, title="Notes", slug="notes")
+        parent = BlockFactory(
+            user=self.user, page=source_page, content="parent", order=1
+        )
+        child = BlockFactory(
+            user=self.user, page=source_page, parent=parent, content="child", order=2
+        )
+        grandchild = BlockFactory(
+            user=self.user,
+            page=source_page,
+            parent=child,
+            content="grandchild",
+            order=3,
+        )
+
+        form = MoveBlockToDailyForm({"user": self.user, "block": parent.uuid})
+        self.assertTrue(form.is_valid(), form.errors)
+
+        MoveBlockToDailyCommand(form).execute()
+
+        parent.refresh_from_db()
+        child.refresh_from_db()
+        grandchild.refresh_from_db()
+
+        target_page = Page.objects.get(user=self.user, date=today, page_type="daily")
+        self.assertEqual(parent.page, target_page)
+        self.assertEqual(child.page, target_page)
+        self.assertEqual(grandchild.page, target_page)
+
+        # Hierarchy preserved
+        self.assertIsNone(parent.parent)
+        self.assertEqual(child.parent, parent)
+        self.assertEqual(grandchild.parent, child)
+
+    @patch("knowledge.commands.move_block_to_daily_command.date")
+    def test_should_promote_nested_block_to_root_on_target(self, mock_date):
+        today = date(2026, 4, 29)
+        mock_date.today.return_value = today
+
+        source_page = PageFactory(user=self.user, title="Notes", slug="notes")
+        parent = BlockFactory(
+            user=self.user, page=source_page, content="parent", order=1
+        )
+        child = BlockFactory(
+            user=self.user,
+            page=source_page,
+            parent=parent,
+            content="moving child",
+            order=2,
+        )
+
+        form = MoveBlockToDailyForm({"user": self.user, "block": child.uuid})
+        self.assertTrue(form.is_valid(), form.errors)
+
+        MoveBlockToDailyCommand(form).execute()
+
+        child.refresh_from_db()
+        parent.refresh_from_db()
+
+        # child becomes root on the daily page; parent stays put
+        self.assertIsNone(child.parent)
+        self.assertEqual(child.page.date, today)
+        self.assertEqual(parent.page, source_page)
+
+    @patch("knowledge.commands.move_block_to_daily_command.date")
+    def test_should_create_daily_page_if_missing(self, mock_date):
+        today = date(2026, 4, 29)
+        mock_date.today.return_value = today
+
+        source_page = PageFactory(user=self.user, title="Notes", slug="notes")
+        block = BlockFactory(user=self.user, page=source_page, content="x", order=1)
+
+        self.assertFalse(
+            Page.objects.filter(
+                user=self.user, page_type="daily", date=today
+            ).exists()
+        )
+
+        form = MoveBlockToDailyForm({"user": self.user, "block": block.uuid})
+        self.assertTrue(form.is_valid(), form.errors)
+
+        MoveBlockToDailyCommand(form).execute()
+
+        self.assertTrue(
+            Page.objects.filter(
+                user=self.user, page_type="daily", date=today
+            ).exists()
+        )
+
+    @patch("knowledge.commands.move_block_to_daily_command.date")
+    def test_should_be_noop_when_block_already_root_on_target(self, mock_date):
+        today = date(2026, 4, 29)
+        mock_date.today.return_value = today
+
+        today_page = PageFactory(
+            user=self.user,
+            date=today,
+            page_type="daily",
+            title="2026-04-29",
+            slug="2026-04-29",
+        )
+        block = BlockFactory(user=self.user, page=today_page, content="x", order=5)
+
+        form = MoveBlockToDailyForm({"user": self.user, "block": block.uuid})
+        self.assertTrue(form.is_valid(), form.errors)
+
+        result = MoveBlockToDailyCommand(form).execute()
+
+        self.assertFalse(result["moved"])
+        block.refresh_from_db()
+        self.assertEqual(block.order, 5)
+
+    @patch("knowledge.commands.move_block_to_daily_command.date")
+    def test_should_use_target_date_when_provided(self, mock_date):
+        today = date(2026, 4, 29)
+        mock_date.today.return_value = today
+        target_date = date(2026, 5, 1)
+
+        source_page = PageFactory(user=self.user, title="Notes", slug="notes")
+        block = BlockFactory(user=self.user, page=source_page, content="x", order=1)
+
+        form = MoveBlockToDailyForm(
+            {"user": self.user, "block": block.uuid, "target_date": target_date}
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        result = MoveBlockToDailyCommand(form).execute()
+
+        self.assertTrue(result["moved"])
+        self.assertEqual(result["target_page"]["date"], target_date.isoformat())
+
+        block.refresh_from_db()
+        self.assertEqual(block.page.date, target_date)
+
+    def test_should_reject_block_belonging_to_another_user(self):
+        other_user = UserFactory()
+        other_page = PageFactory(user=other_user, title="Other", slug="other")
+        other_block = BlockFactory(user=other_user, page=other_page, content="x")
+
+        form = MoveBlockToDailyForm(
+            {"user": self.user, "block": other_block.uuid}
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("block", form.errors)
+
+    @patch("knowledge.commands.move_block_to_daily_command.date")
+    def test_should_not_disrupt_unrelated_blocks_on_target_page(self, mock_date):
+        today = date(2026, 4, 29)
+        mock_date.today.return_value = today
+
+        today_page = PageFactory(
+            user=self.user,
+            date=today,
+            page_type="daily",
+            title="2026-04-29",
+            slug="2026-04-29",
+        )
+        existing_parent = BlockFactory(
+            user=self.user, page=today_page, content="existing parent", order=1
+        )
+        existing_child = BlockFactory(
+            user=self.user,
+            page=today_page,
+            parent=existing_parent,
+            content="existing child",
+            order=2,
+        )
+
+        source_page = PageFactory(user=self.user, title="Notes", slug="notes")
+        block = BlockFactory(
+            user=self.user, page=source_page, content="moved", order=1
+        )
+
+        form = MoveBlockToDailyForm({"user": self.user, "block": block.uuid})
+        self.assertTrue(form.is_valid(), form.errors)
+
+        MoveBlockToDailyCommand(form).execute()
+
+        existing_parent.refresh_from_db()
+        existing_child.refresh_from_db()
+        block.refresh_from_db()
+
+        self.assertEqual(existing_child.parent, existing_parent)
+        self.assertEqual(existing_parent.page, today_page)
+        self.assertEqual(block.page, today_page)
+        # All orders unique on target page
+        orders = list(
+            Block.objects.filter(page=today_page).values_list("order", flat=True)
+        )
+        self.assertEqual(len(orders), len(set(orders)))

--- a/packages/django-app/app/knowledge/test/commands/test_move_block_to_daily_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_move_block_to_daily_command.py
@@ -242,7 +242,7 @@ class TestMoveBlockToDailyCommand(TestCase):
         )
         self.assertEqual(len(orders), len(set(orders)))
 
-    @patch("knowledge.commands.move_block_to_daily_command.timezone")
+    @patch("core.helpers.timezone")
     def test_should_use_user_timezone_when_resolving_today(self, mock_timezone):
         # Server clock is 2026-04-29 03:00 UTC. A user in America/Los_Angeles
         # (UTC-7) should still see this as 2026-04-28, so the daily that gets
@@ -264,7 +264,7 @@ class TestMoveBlockToDailyCommand(TestCase):
         block.refresh_from_db()
         self.assertEqual(block.page.date, date(2026, 4, 28))
 
-    @patch("knowledge.commands.move_block_to_daily_command.timezone")
+    @patch("core.helpers.timezone")
     def test_should_default_to_utc_today_when_user_timezone_is_utc(self, mock_timezone):
         utc_now = datetime(2026, 4, 29, 3, 0, tzinfo=pytz.UTC)
         mock_timezone.now.return_value = utc_now

--- a/packages/django-app/app/knowledge/test/commands/test_move_undone_todos_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_move_undone_todos_command.py
@@ -1,6 +1,7 @@
-from datetime import date
+from datetime import date, datetime
 from unittest.mock import patch
 
+import pytz
 from django.test import TestCase
 
 from knowledge.commands import MoveUndoneTodosCommand
@@ -10,17 +11,26 @@ from knowledge.models import Block
 from ..helpers import BlockFactory, PageFactory, UserFactory
 
 
+def _utc_noon(d: date) -> datetime:
+    """Helper: aware UTC datetime at noon on the given date.
+
+    Used to feed core.helpers.timezone.now() while mocking, so that
+    today_for_user(user) resolves to the target date for tests.
+    """
+    return datetime(d.year, d.month, d.day, 12, 0, tzinfo=pytz.UTC)
+
+
 class TestMoveUndoneTodosCommand(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory()
 
-    @patch("knowledge.commands.move_undone_todos_command.date")
-    def test_should_move_undone_todos_to_bottom_of_target_page(self, mock_date):
+    @patch("core.helpers.timezone")
+    def test_should_move_undone_todos_to_bottom_of_target_page(self, mock_timezone):
         """Test that moved undone TODOs are placed at the bottom of the target page"""
         # Mock today's date to be 2025-06-30
         today = date(2025, 6, 30)
-        mock_date.today.return_value = today
+        mock_timezone.now.return_value = _utc_noon(today)
 
         # Create a daily note page from yesterday with undone TODOs
         yesterday = date(2025, 6, 29)
@@ -114,12 +124,12 @@ class TestMoveUndoneTodosCommand(TestCase):
             all_blocks[3], todo2
         )  # Fourth block should be second moved TODO
 
-    @patch("knowledge.commands.move_undone_todos_command.date")
-    def test_should_not_move_completed_todos(self, mock_date):
+    @patch("core.helpers.timezone")
+    def test_should_not_move_completed_todos(self, mock_timezone):
         """Test that completed (DONE) TODOs are not moved"""
         # Mock today's date to be 2025-06-30
         today = date(2025, 6, 30)
-        mock_date.today.return_value = today
+        mock_timezone.now.return_value = _utc_noon(today)
 
         # Create yesterday's page with both undone and done TODOs
         yesterday = date(2025, 6, 29)
@@ -167,12 +177,12 @@ class TestMoveUndoneTodosCommand(TestCase):
         # Undone todo should be moved to today's page
         self.assertNotEqual(undone_todo.page, yesterday_page)
 
-    @patch("knowledge.commands.move_undone_todos_command.date")
-    def test_should_return_no_todos_message_when_none_found(self, mock_date):
+    @patch("core.helpers.timezone")
+    def test_should_return_no_todos_message_when_none_found(self, mock_timezone):
         """Test that appropriate message is returned when no undone TODOs are found"""
         # Mock today's date to be 2025-06-30
         today = date(2025, 6, 30)
-        mock_date.today.return_value = today
+        mock_timezone.now.return_value = _utc_noon(today)
 
         # Create yesterday's page with only completed TODOs
         yesterday = date(2025, 6, 29)
@@ -204,12 +214,12 @@ class TestMoveUndoneTodosCommand(TestCase):
         self.assertEqual(result["moved_count"], 0)
         self.assertEqual(result["message"], "No undone TODOs found to move")
 
-    @patch("knowledge.commands.move_undone_todos_command.date")
-    def test_should_preserve_relative_order_of_moved_todos(self, mock_date):
+    @patch("core.helpers.timezone")
+    def test_should_preserve_relative_order_of_moved_todos(self, mock_timezone):
         """Test that moved TODOs maintain their relative order from source pages"""
         # Mock today's date to be 2025-06-30
         today = date(2025, 6, 30)
-        mock_date.today.return_value = today
+        mock_timezone.now.return_value = _utc_noon(today)
 
         # Create multiple daily pages with TODOs
         day1 = date(2025, 6, 27)
@@ -284,12 +294,12 @@ class TestMoveUndoneTodosCommand(TestCase):
         for i, expected_block in enumerate(expected_order):
             self.assertEqual(moved_blocks[i], expected_block)
 
-    @patch("knowledge.commands.move_undone_todos_command.date")
-    def test_should_not_disrupt_nested_blocks_when_moving_todos(self, mock_date):
+    @patch("core.helpers.timezone")
+    def test_should_not_disrupt_nested_blocks_when_moving_todos(self, mock_timezone):
         """Test that moving TODOs doesn't affect nested block structure on target page"""
         # Mock today's date to be 2025-06-30
         today = date(2025, 6, 30)
-        mock_date.today.return_value = today
+        mock_timezone.now.return_value = _utc_noon(today)
 
         # Create yesterday's page with undone TODOs
         yesterday = date(2025, 6, 29)
@@ -398,12 +408,12 @@ class TestMoveUndoneTodosCommand(TestCase):
             len(all_orders), len(set(all_orders))
         )  # All orders should be unique
 
-    @patch("knowledge.commands.move_undone_todos_command.date")
-    def test_should_move_undone_todos_to_specified_target_date(self, mock_date):
+    @patch("core.helpers.timezone")
+    def test_should_move_undone_todos_to_specified_target_date(self, mock_timezone):
         """Test that undone TODOs can be moved to a specific target date"""
         # Mock today's date to be 2025-06-30
         today = date(2025, 6, 30)
-        mock_date.today.return_value = today
+        mock_timezone.now.return_value = _utc_noon(today)
 
         # Create target date (2025-07-01)
         target_date = date(2025, 7, 1)
@@ -450,14 +460,14 @@ class TestMoveUndoneTodosCommand(TestCase):
         self.assertEqual(todo1.page.date, target_date)
         self.assertEqual(todo2.page.date, target_date)
 
-    @patch("knowledge.commands.move_undone_todos_command.date")
+    @patch("core.helpers.timezone")
     def test_should_default_to_current_date_when_no_target_date_provided(
-        self, mock_date
+        self, mock_timezone
     ):
         """Test that command defaults to current date when target_date is not provided"""
         # Mock today's date to be 2025-06-30
         today = date(2025, 6, 30)
-        mock_date.today.return_value = today
+        mock_timezone.now.return_value = _utc_noon(today)
 
         # Create yesterday's page with undone TODO
         yesterday = date(2025, 6, 29)

--- a/packages/django-app/app/knowledge/urls.py
+++ b/packages/django-app/app/knowledge/urls.py
@@ -20,6 +20,11 @@ urlpatterns = [
         views.move_undone_todos,
         name="move_undone_todos",
     ),
+    path(
+        "api/blocks/move-to-daily/",
+        views.move_block_to_daily,
+        name="move_block_to_daily",
+    ),
     # Page-centric API endpoints
     path("api/pages/", views.create_page, name="create_page"),
     path("api/pages/update/", views.update_page, name="update_page"),

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -17,6 +17,7 @@ from knowledge.commands import (
     GetPageWithBlocksCommand,
     GetTagContentCommand,
     GetUserPagesCommand,
+    MoveBlockToDailyCommand,
     MoveUndoneTodosCommand,
     ReorderBlocksCommand,
     SearchPagesCommand,
@@ -27,6 +28,7 @@ from knowledge.commands import (
 from knowledge.commands.get_graph_data_command import GraphData
 from knowledge.commands.get_historical_data_command import HistoricalData
 from knowledge.commands.get_tag_content_command import TagContentData
+from knowledge.commands.move_block_to_daily_command import MoveBlockToDailyData
 from knowledge.commands.move_undone_todos_command import MoveUndoneTodosData
 from knowledge.forms import (
     CreateBlockForm,
@@ -38,6 +40,7 @@ from knowledge.forms import (
     GetPageWithBlocksForm,
     GetTagContentForm,
     GetUserPagesForm,
+    MoveBlockToDailyForm,
     MoveUndoneTodosForm,
     ReorderBlocksForm,
     SearchPagesForm,
@@ -95,6 +98,12 @@ class GetPageWithBlocksResponse(TypedDict):
 class MoveUndoneTodosResponse(TypedDict):
     success: bool
     data: Optional[MoveUndoneTodosData]
+    errors: Optional[Dict[str, List[str]]]
+
+
+class MoveBlockToDailyResponse(TypedDict):
+    success: bool
+    data: Optional[MoveBlockToDailyData]
     errors: Optional[Dict[str, List[str]]]
 
 
@@ -707,6 +716,49 @@ def move_undone_todos(request):
 
     except Exception as e:
         response: MoveUndoneTodosResponse = {
+            "success": False,
+            "data": None,
+            "errors": {"non_field_errors": [str(e)]},
+        }
+        return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def move_block_to_daily(request):
+    """Move a single block (and its descendants) to a daily note page."""
+    try:
+        data = request.data.copy()
+        data["user"] = request.user.id
+
+        form = MoveBlockToDailyForm(data)
+
+        if not form.is_valid():
+            response: MoveBlockToDailyResponse = {
+                "success": False,
+                "data": None,
+                "errors": form.errors,
+            }
+            return Response(response, status=status.HTTP_400_BAD_REQUEST)
+
+        command = MoveBlockToDailyCommand(form)
+        result = command.execute()
+
+        response: MoveBlockToDailyResponse = {
+            "success": True,
+            "data": result,
+            "errors": None,
+        }
+        return Response(response)
+
+    except ValidationError as e:
+        return Response(
+            {"success": False, "errors": {"non_field_errors": [str(e)]}},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    except Exception as e:
+        response: MoveBlockToDailyResponse = {
             "success": False,
             "data": None,
             "errors": {"non_field_errors": [str(e)]},


### PR DESCRIPTION
## Summary
This PR adds functionality to move a block (and its descendants) to a daily note page. Users can now quickly capture ideas from regular pages and move them to today's daily note or a specified target date.

## Key Changes

- **New Command**: `MoveBlockToDailyCommand` handles the business logic for moving blocks
  - Moves a block and all its descendants to a target daily page
  - Promotes nested blocks to root level on the target page
  - Creates the daily page if it doesn't exist
  - Places moved blocks at the bottom of the target page
  - Returns early if block is already a root on the target page

- **New Form**: `MoveBlockToDailyForm` validates the move operation
  - Validates that the block belongs to the requesting user
  - Supports optional `target_date` parameter (defaults to today)

- **API Endpoint**: `POST /knowledge/api/blocks/move-to-daily/`
  - Handles authentication and error responses
  - Returns success status and updated block/page data

- **Frontend Integration**:
  - Added `moveBlockToToday()` method in Page component
  - Added context menu option "move to today's daily" in BlockComponent
  - Integrated with existing API service for backend communication
  - Shows toast notifications for success/info/error states

- **Comprehensive Tests**: 11 test cases covering:
  - Basic move operation from regular page to daily
  - Block ordering on target page
  - Descendant preservation and hierarchy
  - Nested block promotion to root
  - Daily page creation
  - No-op when already on target
  - Custom target date support
  - User isolation/security
  - Preservation of unrelated blocks on target page

## Implementation Details

- Uses atomic transactions to ensure data consistency
- Preserves parent-child relationships for descendants
- Automatically handles daily page creation with proper slug/title formatting
- Blocks are appended to the end of the target page's block order
- Nested blocks become root-level blocks on the target page (only the moved block's descendants move with it)

https://claude.ai/code/session_012nmtZFkpf5TTg78UW84PbA