### PR TITLE
Add scheduler image cleanup to staging-cleanup-images task

### DIFF
--- a/packages/django-app/justfile
+++ b/packages/django-app/justfile
@@ -266,7 +266,7 @@ staging-logs LINES="100":
 staging-cleanup-images:
   docker rmi ${COMPOSE_PROJECT_NAME}-web:latest 2>/dev/null || true
   docker rmi ${COMPOSE_PROJECT_NAME}-scheduler:latest 2>/dev/null || true
-  docker image prune -f
+  docker image prune -f --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}"
 
 # Clean up project Docker resources
 dcp-cleanup:

--- a/packages/django-app/justfile
+++ b/packages/django-app/justfile
@@ -265,6 +265,8 @@ staging-logs LINES="100":
 # Remove Docker images built for the current staging environment
 staging-cleanup-images:
   docker rmi ${COMPOSE_PROJECT_NAME}-web:latest 2>/dev/null || true
+  docker rmi ${COMPOSE_PROJECT_NAME}-scheduler:latest 2>/dev/null || true
+  docker image prune -f
 
 # Clean up project Docker resources
 dcp-cleanup:


### PR DESCRIPTION
## Summary
Updated the `staging-cleanup-images` task in the justfile to properly clean up all Docker images built for the staging environment, including the scheduler service image.

## Key Changes
- Added removal of the scheduler Docker image (`${COMPOSE_PROJECT_NAME}-scheduler:latest`) to the staging cleanup routine
- Added `docker image prune -f` command to remove dangling images and free up disk space after cleanup

## Implementation Details
The changes ensure that both the web and scheduler service images are removed during staging cleanup, preventing orphaned images from accumulating. The addition of `docker image prune -f` provides a more thorough cleanup by removing any dangling images created during the build process.

https://claude.ai/code/session_01PK11Daze74yYViJWehj58c