### PR TITLE
Shrink mobile leftnav rail to a small top-left toggle

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -24,13 +24,14 @@ jobs:
           PR_BRANCH: ${{ github.head_ref }}
           PORT: ${{ steps.vars.outputs.port }}
           STAGING_BASE_DIR: ${{ vars.DO_STAGING_BASE_DIR }}
+          DO_STAGING_HOST: ${{ vars.DO_STAGING_HOST }}
           DJANGO_SUPERUSER_EMAIL: ${{ secrets.SUPERUSER_EMAIL }}
           DJANGO_SUPERUSER_PASSWORD: ${{ secrets.SUPERUSER_PASSWORD }}
         with:
           host: ${{ secrets.DO_SSH_HOST }}
           username: ${{ secrets.DO_SSH_USER }}
           key: ${{ secrets.DO_SSH_KEY }}
-          envs: GITHUB_TOKEN,PR_NUM,PR_BRANCH,PORT,STAGING_BASE_DIR,DJANGO_SUPERUSER_EMAIL,DJANGO_SUPERUSER_PASSWORD
+          envs: GITHUB_TOKEN,PR_NUM,PR_BRANCH,PORT,STAGING_BASE_DIR,DO_STAGING_HOST,DJANGO_SUPERUSER_EMAIL,DJANGO_SUPERUSER_PASSWORD
           script: |
             set -euo pipefail
 
@@ -70,6 +71,7 @@ jobs:
             COMPOSE_PROJECT_NAME=${PROJECT}
             REMINDERS_ENABLED=true
             ENVIRONMENT=staging
+            SITE_URL=http://${DO_STAGING_HOST}:${PORT}
             EOF
             fi
 

--- a/packages/django-app/.env.template
+++ b/packages/django-app/.env.template
@@ -34,3 +34,10 @@ SCHEDULER_INTERVAL_SECONDS=60
 # deploy a ping came from. staging deploy sets ENVIRONMENT=staging,
 # prod sets ENVIRONMENT=prod.
 ENVIRONMENT=local
+
+# absolute base URL of this deploy, used to build links in outbound
+# notifications (e.g. the page-link appended to Discord reminders).
+# Must start with http:// or https:// — placeholder values are skipped
+# rather than producing broken links. Leave unset locally if you don't
+# need clickable links in test pings.
+SITE_URL=

--- a/packages/django-app/app/knowledge/commands/__init__.py
+++ b/packages/django-app/app/knowledge/commands/__init__.py
@@ -18,5 +18,6 @@ from .send_due_reminders_command import SendDueRemindersCommand
 from .set_block_type_command import SetBlockTypeCommand
 from .sync_block_tags_command import SyncBlockTagsCommand
 from .toggle_block_todo_command import ToggleBlockTodoCommand
+from .touch_page_command import TouchPageCommand
 from .update_block_command import UpdateBlockCommand
 from .update_page_command import UpdatePageCommand

--- a/packages/django-app/app/knowledge/commands/create_block_command.py
+++ b/packages/django-app/app/knowledge/commands/create_block_command.py
@@ -2,8 +2,10 @@ from common.commands.abstract_base_command import AbstractBaseCommand
 
 from ..forms.create_block_form import CreateBlockForm
 from ..forms.sync_block_tags_form import SyncBlockTagsForm
+from ..forms.touch_page_form import TouchPageForm
 from ..models import Block
 from .sync_block_tags_command import SyncBlockTagsCommand
+from .touch_page_command import TouchPageCommand
 
 
 class CreateBlockCommand(AbstractBaseCommand):
@@ -66,6 +68,12 @@ class CreateBlockCommand(AbstractBaseCommand):
         # Skip for code blocks — `key::value` inside code shouldn't be parsed.
         if block.content and block.block_type != "code":
             block.extract_properties_from_content()
+
+        # Bump the page's modified_at so it sorts to the top of the recent
+        # pages list — adding a block counts as activity on the page.
+        touch_form = TouchPageForm(data={"user": user.id, "page": str(page.uuid)})
+        if touch_form.is_valid():
+            TouchPageCommand(touch_form).execute()
 
         return block
 

--- a/packages/django-app/app/knowledge/commands/delete_block_command.py
+++ b/packages/django-app/app/knowledge/commands/delete_block_command.py
@@ -1,7 +1,10 @@
 from common.commands.abstract_base_command import AbstractBaseCommand
 from knowledge.forms.delete_block_form import DeleteBlockForm
+from knowledge.forms.touch_page_form import TouchPageForm
 from web_archives.commands import SoftDeleteWebArchiveCommand
 from web_archives.forms import SoftDeleteWebArchiveForm
+
+from .touch_page_command import TouchPageCommand
 
 
 class DeleteBlockCommand(AbstractBaseCommand):
@@ -26,5 +29,14 @@ class DeleteBlockCommand(AbstractBaseCommand):
         if archive_form.is_valid():
             SoftDeleteWebArchiveCommand(archive_form).execute()
 
+        # Capture the page reference before the delete cascades — afterwards
+        # block.page would still resolve from the unsaved instance, but we
+        # want the explicit local for clarity.
+        page = block.page
         block.delete()
+
+        touch_form = TouchPageForm(data={"user": user.id, "page": str(page.uuid)})
+        if touch_form.is_valid():
+            TouchPageCommand(touch_form).execute()
+
         return True

--- a/packages/django-app/app/knowledge/commands/move_block_to_daily_command.py
+++ b/packages/django-app/app/knowledge/commands/move_block_to_daily_command.py
@@ -7,9 +7,11 @@ from common.commands.abstract_base_command import AbstractBaseCommand
 from core.helpers import today_for_user
 
 from ..forms.move_block_to_daily_form import MoveBlockToDailyForm
+from ..forms.touch_page_form import TouchPageForm
 from ..models import BlockData, PageData
 from ..repositories import BlockRepository
 from ..repositories.page_repository import PageRepository
+from .touch_page_command import TouchPageCommand
 
 
 class MoveBlockToDailyCommand(AbstractBaseCommand):
@@ -39,6 +41,9 @@ class MoveBlockToDailyCommand(AbstractBaseCommand):
             }
 
         descendants = BlockRepository.get_block_descendants(block)
+        # Capture before reassignment so we still know where the block came
+        # from after block.page is repointed at target_page.
+        source_page = block.page
 
         with transaction.atomic():
             max_order = (
@@ -56,6 +61,13 @@ class MoveBlockToDailyCommand(AbstractBaseCommand):
             for descendant in descendants:
                 descendant.page = target_page
                 descendant.save(update_fields=["page"])
+
+        # Bump modified_at on both ends of the move so each daily page sorts
+        # to the top of the recent list when it loses or gains content.
+        for page in {source_page, target_page}:
+            touch_form = TouchPageForm(data={"user": user.id, "page": str(page.uuid)})
+            if touch_form.is_valid():
+                TouchPageCommand(touch_form).execute()
 
         return {
             "moved": True,

--- a/packages/django-app/app/knowledge/commands/move_undone_todos_command.py
+++ b/packages/django-app/app/knowledge/commands/move_undone_todos_command.py
@@ -4,9 +4,11 @@ from common.commands.abstract_base_command import AbstractBaseCommand
 from core.helpers import today_for_user
 
 from ..forms.move_undone_todos_form import MoveUndoneTodosForm
+from ..forms.touch_page_form import TouchPageForm
 from ..models import BlockData, PageData
 from ..repositories import BlockRepository
 from ..repositories.page_repository import PageRepository
+from .touch_page_command import TouchPageCommand
 
 
 class MoveUndoneTodosCommand(AbstractBaseCommand):
@@ -38,11 +40,22 @@ class MoveUndoneTodosCommand(AbstractBaseCommand):
                 "message": "No undone TODOs found to move",
             }
 
+        # Capture every distinct source page before the move — afterwards
+        # block.page would point at target_page and we'd lose the origin.
+        source_pages = {block.page for block in past_todos}
+
         # Move the blocks to target page
         success = BlockRepository.move_blocks_to_page(past_todos, target_page)
 
         if not success:
             raise Exception("Failed to move blocks to target page")
+
+        # Bump modified_at on each source plus the target so the recent
+        # pages sidebar reflects the activity on both ends.
+        for page in source_pages | {target_page}:
+            touch_form = TouchPageForm(data={"user": user.id, "page": str(page.uuid)})
+            if touch_form.is_valid():
+                TouchPageCommand(touch_form).execute()
 
         return {
             "moved_count": len(past_todos),

--- a/packages/django-app/app/knowledge/commands/reorder_blocks_command.py
+++ b/packages/django-app/app/knowledge/commands/reorder_blocks_command.py
@@ -3,7 +3,9 @@ from django.core.exceptions import ValidationError
 from common.commands.abstract_base_command import AbstractBaseCommand
 
 from ..forms.reorder_blocks_form import ReorderBlocksForm
+from ..forms.touch_page_form import TouchPageForm
 from ..repositories import BlockRepository
+from .touch_page_command import TouchPageCommand
 
 
 class ReorderBlocksCommand(AbstractBaseCommand):
@@ -23,6 +25,18 @@ class ReorderBlocksCommand(AbstractBaseCommand):
             for item in blocks_order_data
         ]
 
+        # Look up the affected pages before the reorder runs so we can
+        # bump their modified_at afterwards. A reorder typically targets a
+        # single page, but the form doesn't guarantee that, so we take the
+        # set of distinct pages the blocks belong to.
+        block_uuids = [item["uuid"] for item in normalized]
+        affected_pages = list(
+            BlockRepository.get_queryset()
+            .filter(user=user, uuid__in=block_uuids)
+            .values_list("page__uuid", flat=True)
+            .distinct()
+        )
+
         success = BlockRepository.reorder_blocks(normalized, user=user)
 
         if not success:
@@ -30,5 +44,10 @@ class ReorderBlocksCommand(AbstractBaseCommand):
                 "Failed to reorder blocks. Some blocks may not exist or "
                 "belong to a different user."
             )
+
+        for page_uuid in affected_pages:
+            touch_form = TouchPageForm(data={"user": user.id, "page": str(page_uuid)})
+            if touch_form.is_valid():
+                TouchPageCommand(touch_form).execute()
 
         return True

--- a/packages/django-app/app/knowledge/commands/schedule_block_command.py
+++ b/packages/django-app/app/knowledge/commands/schedule_block_command.py
@@ -5,7 +5,9 @@ import pytz
 from common.commands.abstract_base_command import AbstractBaseCommand
 
 from ..forms.schedule_block_form import ScheduleBlockForm
+from ..forms.touch_page_form import TouchPageForm
 from ..models import Block, Reminder
+from .touch_page_command import TouchPageCommand
 
 
 class ScheduleBlockCommand(AbstractBaseCommand):
@@ -22,6 +24,7 @@ class ScheduleBlockCommand(AbstractBaseCommand):
     def execute(self) -> Block:
         super().execute()
 
+        user = self.form.cleaned_data["user"]
         block: Block = self.form.cleaned_data["block"]
         scheduled_for = self.form.cleaned_data.get("scheduled_for")
         reminder_date = self.form.cleaned_data.get("reminder_date")
@@ -29,6 +32,10 @@ class ScheduleBlockCommand(AbstractBaseCommand):
 
         block.scheduled_for = scheduled_for
         block.save(update_fields=["scheduled_for", "modified_at"])
+
+        touch_form = TouchPageForm(data={"user": user.id, "page": str(block.page.uuid)})
+        if touch_form.is_valid():
+            TouchPageCommand(touch_form).execute()
 
         # Replace any pending reminder for this block. Sent reminders are
         # left alone — they're history.

--- a/packages/django-app/app/knowledge/commands/send_due_reminders_command.py
+++ b/packages/django-app/app/knowledge/commands/send_due_reminders_command.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import TypedDict
 
+from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
 
@@ -75,6 +76,7 @@ class SendDueRemindersCommand(AbstractBaseCommand):
                     block,
                     block.user.discord_user_id,
                     environment,
+                    settings.SITE_URL,
                 )
                 url = block.user.discord_webhook_url
                 # Look up post_webhook at call time (not via `self.deliver`)
@@ -121,6 +123,7 @@ def _format_content(
     block,
     discord_user_id: str = "",
     environment: str = "",
+    site_url: str = "",
 ) -> str:
     """Render the Discord message body for a reminder.
 
@@ -128,6 +131,8 @@ def _format_content(
     gets a desktop/push notification instead of just a silent channel post.
     When `environment` is set to anything other than prod/production, an
     `[<env>] ` label is prepended so non-prod pings are distinguishable.
+    When `site_url` is a real http(s) URL, appends a link to the page
+    that contains the block so the user can jump straight to it.
     """
     title = (block.content or "").strip().splitlines()[0] if block.content else ""
     if len(title) > 240:
@@ -141,4 +146,22 @@ def _format_content(
     env = (environment or "").strip().lower()
     if env and env not in _PROD_ENVIRONMENTS:
         body = f"[{env}] {body}"
+
+    page_link = _page_link(block, site_url)
+    if page_link:
+        body = f"{body}\n{page_link}"
     return body
+
+
+def _page_link(block, site_url: str) -> str:
+    """Build an absolute URL to the page that contains the block.
+
+    Skips when SITE_URL isn't a real http(s) URL (the default
+    placeholder is just "0.0.0.0", which would produce broken links).
+    """
+    if not site_url or not site_url.startswith(("http://", "https://")):
+        return ""
+    if not block.page_id or not block.page.slug:
+        return ""
+    base = site_url.rstrip("/")
+    return f"{base}/knowledge/page/{block.page.slug}/"

--- a/packages/django-app/app/knowledge/commands/set_block_type_command.py
+++ b/packages/django-app/app/knowledge/commands/set_block_type_command.py
@@ -6,7 +6,9 @@ from django.utils import timezone
 from common.commands.abstract_base_command import AbstractBaseCommand
 
 from ..forms.set_block_type_form import SetBlockTypeForm
+from ..forms.touch_page_form import TouchPageForm
 from ..models import Block
+from .touch_page_command import TouchPageCommand
 
 # Block types that carry a leading content prefix (e.g. "TODO write docs").
 STATE_PREFIXES = {
@@ -31,6 +33,7 @@ class SetBlockTypeCommand(AbstractBaseCommand):
         super().execute()
 
         block: Block = self.form.cleaned_data["block"]
+        user = self.form.cleaned_data["user"]
         new_type: str = self.form.cleaned_data["block_type"]
         old_type = block.block_type
 
@@ -43,6 +46,11 @@ class SetBlockTypeCommand(AbstractBaseCommand):
         )
         block.block_type = new_type
         block.save()
+
+        touch_form = TouchPageForm(data={"user": user.id, "page": str(block.page.uuid)})
+        if touch_form.is_valid():
+            TouchPageCommand(touch_form).execute()
+
         return block
 
     @staticmethod

--- a/packages/django-app/app/knowledge/commands/touch_page_command.py
+++ b/packages/django-app/app/knowledge/commands/touch_page_command.py
@@ -1,0 +1,24 @@
+from common.commands.abstract_base_command import AbstractBaseCommand
+
+from ..forms.touch_page_form import TouchPageForm
+from ..models import Page
+
+
+class TouchPageCommand(AbstractBaseCommand):
+    """Bump a page's modified_at to the current time.
+
+    Block-mutating commands call this so the page sorts to the top of the
+    "recently modified" sidebar list whenever its blocks change. modified_at
+    is auto_now=True, so saving with update_fields=["modified_at"] is enough
+    to move the timestamp forward without touching any other column.
+    """
+
+    def __init__(self, form: TouchPageForm) -> None:
+        self.form = form
+
+    def execute(self) -> Page:
+        super().execute()
+
+        page = self.form.cleaned_data["page"]
+        page.save(update_fields=["modified_at"])
+        return page

--- a/packages/django-app/app/knowledge/commands/update_block_command.py
+++ b/packages/django-app/app/knowledge/commands/update_block_command.py
@@ -3,9 +3,11 @@ from django.core.exceptions import ValidationError
 from common.commands.abstract_base_command import AbstractBaseCommand
 
 from ..forms.sync_block_tags_form import SyncBlockTagsForm
+from ..forms.touch_page_form import TouchPageForm
 from ..forms.update_block_form import UpdateBlockForm
 from ..models import Block
 from .sync_block_tags_command import SyncBlockTagsCommand
+from .touch_page_command import TouchPageCommand
 
 
 class UpdateBlockCommand(AbstractBaseCommand):
@@ -85,6 +87,12 @@ class UpdateBlockCommand(AbstractBaseCommand):
         # Skip for code blocks — `key::value` inside code shouldn't be parsed.
         if content_updated and block.content and block.block_type != "code":
             block.extract_properties_from_content()
+
+        # Bump the page's modified_at so the recent-pages sidebar reflects
+        # this edit even though only the block row changed.
+        touch_form = TouchPageForm(data={"user": user.id, "page": str(block.page.uuid)})
+        if touch_form.is_valid():
+            TouchPageCommand(touch_form).execute()
 
         return block
 

--- a/packages/django-app/app/knowledge/forms/__init__.py
+++ b/packages/django-app/app/knowledge/forms/__init__.py
@@ -18,5 +18,6 @@ from .send_due_reminders_form import SendDueRemindersForm
 from .set_block_type_form import SetBlockTypeForm
 from .sync_block_tags_form import SyncBlockTagsForm
 from .toggle_block_todo_form import ToggleBlockTodoForm
+from .touch_page_form import TouchPageForm
 from .update_block_form import UpdateBlockForm
 from .update_page_form import UpdatePageForm

--- a/packages/django-app/app/knowledge/forms/touch_page_form.py
+++ b/packages/django-app/app/knowledge/forms/touch_page_form.py
@@ -1,0 +1,29 @@
+from django import forms
+from django.core.exceptions import ValidationError
+
+from common.forms import BaseForm, UUIDModelChoiceField
+from core.models import User
+from core.repositories import UserRepository
+
+from ..models import Page
+from ..repositories import PageRepository
+
+
+class TouchPageForm(BaseForm):
+    user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
+    page = UUIDModelChoiceField(queryset=PageRepository.get_queryset(), required=True)
+
+    def clean_page(self) -> Page:
+        page = self.cleaned_data.get("page")
+        user = self.cleaned_data.get("user")
+
+        if page and user and page.user != user:
+            raise ValidationError("Page not found")
+
+        return page
+
+    def clean_user(self) -> User:
+        user = self.cleaned_data.get("user")
+        if not user:
+            raise ValidationError("User is required")
+        return user

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4547,9 +4547,12 @@ a.sidebar-item:visited {
   color: var(--text-primary);
   border: 2px solid var(--border-secondary);
   /* padding-right reserves just enough for the 14px calendar glyph
-     painted by .title-left::after. Sized to the date string so the
-     icon sits flush against the date text rather than a long gap. */
+     painted by .title-left::after. width: fit-content overrides the
+     locale-based intrinsic width Chromium gives <input type="date">,
+     which would otherwise leave empty space to the right of the date
+     string. */
   padding: 0.5rem 1.25rem 0.5rem 0.5rem;
+  width: fit-content;
   font-family: inherit;
   font-size: 1rem;
   cursor: pointer;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4547,11 +4547,12 @@ a.sidebar-item:visited {
   color: var(--text-primary);
   border: 2px solid var(--border-secondary);
   /* padding-right reserves just enough for the 14px calendar glyph
-     painted by .title-left::after. width: fit-content overrides the
-     locale-based intrinsic width Chromium gives <input type="date">,
-     which would otherwise leave empty space to the right of the date
-     string. */
+     painted by .title-left::after. field-sizing: content makes the
+     input shrink to its rendered text — width: fit-content doesn't
+     work on <input type="date"> because Chromium gives it a wider
+     locale-based intrinsic content size. */
   padding: 0.5rem 1.25rem 0.5rem 0.5rem;
+  field-sizing: content;
   width: fit-content;
   font-family: inherit;
   font-size: 1rem;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -1743,12 +1743,25 @@ kbd {
     align-items: center;
   }
 
-  /* Stack the daily date picker + context menu vertically and center
-     the picker so it clears the fixed leftnav toggle in the top-left. */
+  /* On the daily page, center the date picker (so it clears the fixed
+     leftnav toggle in the top-left) while keeping the context menu
+     anchored to the right edge. Three-column grid: empty | picker |
+     menu, with the empty 1fr balancing the menu's 1fr. */
   .daily-note-title.page-header-flex {
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
     align-items: center;
     gap: 0.5rem;
+  }
+
+  .daily-note-title.page-header-flex .title-left {
+    grid-column: 2;
+    justify-self: center;
+  }
+
+  .daily-note-title.page-header-flex .header-controls {
+    grid-column: 3;
+    justify-self: end;
   }
 
   .child-block {

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -172,6 +172,8 @@ body {
     monospace;
   margin: 0;
   padding: 0;
+  /* Respect device safe areas (Android nav bar, iPhone home indicator). */
+  padding-bottom: env(safe-area-inset-bottom);
   background-color: var(--bg-primary);
   color: var(--text-primary);
   line-height: 1.4;
@@ -1743,25 +1745,12 @@ kbd {
     align-items: center;
   }
 
-  /* On the daily page, center the date picker (so it clears the fixed
-     leftnav toggle in the top-left) while keeping the context menu
-     anchored to the right edge. Three-column grid: empty | picker |
-     menu, with the empty 1fr balancing the menu's 1fr. */
+  /* On the daily page, sit the date picker and context menu side by
+     side, centered as a pair. Anchoring the menu to the far right
+     would put it under the AI chat-toggle in the top-right corner. */
   .daily-note-title.page-header-flex {
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
+    justify-content: center;
     gap: 0.5rem;
-  }
-
-  .daily-note-title.page-header-flex .title-left {
-    grid-column: 2;
-    justify-self: center;
-  }
-
-  .daily-note-title.page-header-flex .header-controls {
-    grid-column: 3;
-    justify-self: end;
   }
 
   .child-block {
@@ -1791,11 +1780,6 @@ kbd {
   /* Always show delete button on mobile */
   .block-delete {
     opacity: 1 !important;
-  }
-
-  /* On mobile, don't reserve space for the leftnav (it overlays). */
-  .main-content {
-    padding-left: 2rem;
   }
 
   /* Simple fix - use margin-bottom only when chat is open and visible */
@@ -4520,7 +4504,7 @@ a.sidebar-item:visited {
   background: var(--bg-primary);
   color: var(--text-primary);
   border: 2px solid var(--border-secondary);
-  padding: 0.5rem;
+  padding: 0.5rem 1rem 0.5rem 0.5rem;
   font-family: inherit;
   font-size: 1rem;
   cursor: pointer;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -2587,22 +2587,26 @@ a.sidebar-item:visited {
     background: transparent;
     border: none;
     padding: 0;
-    top: 8px;
-    left: 8px;
+    top: 0;
+    left: 0;
   }
 
   .leftnav-rail-btn.leftnav-rail-action {
     display: none;
   }
 
+  /* Match the AI chat-toggle: 45x45 square inverse-color button. */
   .leftnav-rail-btn.leftnav-rail-toggle {
-    background: var(--bg-primary);
-    color: var(--text-primary);
-    border: 1px solid var(--border-primary);
-    border-radius: 3px;
-    padding: 0.15rem 0.35rem;
-    width: auto;
-    height: auto;
+    width: 45px;
+    height: 45px;
+    background: var(--text-primary);
+    color: var(--bg-primary);
+    border: 3px solid var(--border-primary);
+    border-radius: 0;
+    padding: 0;
+    font-weight: bold;
+    font-size: 1rem;
+    letter-spacing: 0.5px;
     box-shadow: none;
   }
 

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -1788,14 +1788,14 @@ kbd {
     padding-left: 2rem;
   }
 
-  /* Mobile: collapse the rail to just the floating toggle. */
+  /* Mobile: collapse the rail to just the floating toggle in the top-left. */
   .leftnav-rail {
     width: auto;
     height: auto;
     background: transparent;
     border: none;
     padding: 0;
-    top: 88px;
+    top: 8px;
     left: 8px;
   }
 
@@ -1806,12 +1806,12 @@ kbd {
   .leftnav-rail-toggle {
     background: var(--bg-primary);
     color: var(--text-primary);
-    border: 2px solid var(--border-primary);
-    padding: 0.4rem 0.6rem;
-    font-weight: bold;
+    border: 1px solid var(--border-primary);
+    border-radius: 3px;
+    padding: 0.15rem 0.35rem;
     width: auto;
     height: auto;
-    box-shadow: 2px 2px 0 var(--border-primary);
+    box-shadow: none;
   }
 
   /* Mobile drawer backdrop. */

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -1205,10 +1205,11 @@ kbd {
   content: "";
   position: absolute;
   top: 50%;
-  /* Lands inside the input's padding-right, clear of the date text.
-     1rem accounts for .date-picker margin-right, the rest centers the
-     14px glyph in the reserved 1.75rem padding. */
-  right: 1.4rem;
+  /* Sits ~4px inside the input's right border (.date-picker has no
+     margin-right, so .title-left's right edge equals the input's
+     right edge). The 14px glyph + a small gap to the date text fit
+     inside .date-picker's 1.5rem padding-right. */
+  right: 0.25rem;
   transform: translateY(-50%);
   width: 14px;
   height: 14px;
@@ -4546,11 +4547,14 @@ a.sidebar-item:visited {
   background: var(--bg-primary);
   color: var(--text-primary);
   border: 2px solid var(--border-secondary);
-  padding: 0.5rem 1.75rem 0.5rem 0.5rem;
+  /* padding-right reserves room for the calendar glyph painted by
+     .title-left::after; min-width keeps the full date string from
+     getting clipped by tight intrinsic widths on mobile. */
+  padding: 0.5rem 1.5rem 0.5rem 0.5rem;
+  min-width: 9rem;
   font-family: inherit;
   font-size: 1rem;
   cursor: pointer;
-  margin-right: 1rem;
 }
 
 /* Hide the native calendar-picker indicator on .date-picker — we paint

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -2078,12 +2078,16 @@ kbd {
   top: 0;
   left: 0;
   height: 100vh;
+  /* Dynamic viewport height shrinks when the Android URL/nav bar is
+     visible, so the footer (logout) stays above it. Falls back to
+     100vh on older browsers. */
+  height: 100dvh;
   background: var(--sidebar-bg);
   border-right: 1px solid var(--border-primary);
   overflow-y: auto;
   z-index: 999;
-  /* Keep the footer (logout) above the Android nav bar / iPhone home
-     indicator when the drawer extends to the viewport bottom. */
+  /* Also respect fixed safe areas (e.g. iPhone home indicator), which
+     env() reports even when the dynamic viewport doesn't. */
   padding-bottom: env(safe-area-inset-bottom);
 }
 

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -1165,16 +1165,6 @@ kbd {
   transform: none;
 }
 
-.date-picker {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.date-picker input[type="date"] {
-  cursor: pointer;
-}
-
 .daily-note-content h2 {
   color: var(--text-primary);
   margin-bottom: 0.75rem;
@@ -4546,14 +4536,13 @@ a.sidebar-item:visited {
   background: var(--bg-primary);
   color: var(--text-primary);
   border: 2px solid var(--border-secondary);
-  /* padding-right reserves just enough for the 14px calendar glyph
-     painted by .title-left::after. field-sizing: content makes the
-     input shrink to its rendered text — width: fit-content doesn't
-     work on <input type="date"> because Chromium gives it a wider
-     locale-based intrinsic content size. */
+  /* padding-right reserves room for the 14px calendar glyph painted
+     by .title-left::after. field-sizing: content shrinks the input to
+     its rendered text width — Chromium otherwise gives <input
+     type="date"> a wider locale-based intrinsic size, which leaves
+     empty space between the date and the icon. */
   padding: 0.5rem 1.25rem 0.5rem 0.5rem;
   field-sizing: content;
-  width: fit-content;
   font-family: inherit;
   font-size: 1rem;
   cursor: pointer;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -2082,6 +2082,9 @@ kbd {
   border-right: 1px solid var(--border-primary);
   overflow-y: auto;
   z-index: 999;
+  /* Keep the footer (logout) above the Android nav bar / iPhone home
+     indicator when the drawer extends to the viewport bottom. */
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .sidebar-resize-handle {

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -1772,58 +1772,9 @@ kbd {
     opacity: 1 !important;
   }
 
-  /* Left nav drawer behavior on mobile: overlay content, full-width drawer. */
-  .historical-sidebar {
-    width: 90vw !important;
-    max-width: 90vw !important;
-    z-index: 1100;
-  }
-
-  .leftnav-content {
-    padding: 0.5rem;
-  }
-
   /* On mobile, don't reserve space for the leftnav (it overlays). */
   .main-content {
     padding-left: 2rem;
-  }
-
-  /* Mobile: collapse the rail to just the floating toggle in the top-left. */
-  .leftnav-rail {
-    width: auto;
-    height: auto;
-    background: transparent;
-    border: none;
-    padding: 0;
-    top: 8px;
-    left: 8px;
-  }
-
-  .leftnav-rail-action {
-    display: none;
-  }
-
-  .leftnav-rail-toggle {
-    background: var(--bg-primary);
-    color: var(--text-primary);
-    border: 1px solid var(--border-primary);
-    border-radius: 3px;
-    padding: 0.15rem 0.35rem;
-    width: auto;
-    height: auto;
-    box-shadow: none;
-  }
-
-  /* Mobile drawer backdrop. */
-  .leftnav-backdrop {
-    display: block;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.4);
-    z-index: 1099;
   }
 
   /* Simple fix - use margin-bottom only when chat is open and visible */
@@ -2614,6 +2565,56 @@ a.sidebar-item:visited {
 
   .sidebar-resize-handle {
     display: none;
+  }
+
+  /* Left nav drawer behavior on mobile: overlay content, full-width drawer.
+     These overrides live AFTER the base .leftnav-* declarations above so
+     they win on source order at equal specificity. */
+  .historical-sidebar {
+    width: 90vw !important;
+    max-width: 90vw !important;
+    z-index: 1100;
+  }
+
+  .leftnav-content {
+    padding: 0.5rem;
+  }
+
+  /* Collapse the rail to just the floating arrow toggle in the top-left. */
+  .leftnav-rail {
+    width: auto;
+    height: auto;
+    background: transparent;
+    border: none;
+    padding: 0;
+    top: 8px;
+    left: 8px;
+  }
+
+  .leftnav-rail-btn.leftnav-rail-action {
+    display: none;
+  }
+
+  .leftnav-rail-btn.leftnav-rail-toggle {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-primary);
+    border-radius: 3px;
+    padding: 0.15rem 0.35rem;
+    width: auto;
+    height: auto;
+    box-shadow: none;
+  }
+
+  .leftnav-backdrop {
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 1099;
   }
 }
 

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -1743,6 +1743,14 @@ kbd {
     align-items: center;
   }
 
+  /* Stack the daily date picker + context menu vertically and center
+     the picker so it clears the fixed leftnav toggle in the top-left. */
+  .daily-note-title.page-header-flex {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
   .child-block {
     margin-left: 1rem;
     padding-left: 0.5rem;
@@ -2595,12 +2603,13 @@ a.sidebar-item:visited {
     display: none;
   }
 
-  /* Match the AI chat-toggle: 45x45 square inverse-color button. */
+  /* Match the AI chat-toggle's 45x45 square shape, but use the opposite
+     fill so the two corner buttons read as a pair instead of twins. */
   .leftnav-rail-btn.leftnav-rail-toggle {
     width: 45px;
     height: 45px;
-    background: var(--text-primary);
-    color: var(--bg-primary);
+    background: var(--bg-primary);
+    color: var(--text-primary);
     border: 3px solid var(--border-primary);
     border-radius: 0;
     padding: 0;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -1192,6 +1192,34 @@ kbd {
   display: flex;
   align-items: center;
   gap: 0;
+  position: relative;
+}
+
+/* Painted calendar glyph that overlays the right side of the date
+   input. We can't put a pseudo-element on the input itself (replaced
+   element), and Android Chrome doesn't honor mask styling on
+   ::-webkit-calendar-picker-indicator, so the wrapper renders the icon
+   via mask + currentColor — that picks up --text-primary across themes
+   and renders identically on desktop, Android, and iOS. */
+.title-left::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  /* Lands inside the input's padding-right, clear of the date text.
+     1rem accounts for .date-picker margin-right, the rest centers the
+     14px glyph in the reserved 1.75rem padding. */
+  right: 1.4rem;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 14px;
+  pointer-events: none;
+  background-color: currentColor;
+  color: var(--text-primary);
+  opacity: 0.7;
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='black' stroke-width='1.5' stroke-linejoin='round' stroke-linecap='round'><rect x='2' y='3' width='12' height='11' rx='1'/><line x1='2' y1='6.5' x2='14' y2='6.5'/><line x1='5.5' y1='1.5' x2='5.5' y2='4.5'/><line x1='10.5' y1='1.5' x2='10.5' y2='4.5'/></svg>")
+    center / contain no-repeat;
+  mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='black' stroke-width='1.5' stroke-linejoin='round' stroke-linecap='round'><rect x='2' y='3' width='12' height='11' rx='1'/><line x1='2' y1='6.5' x2='14' y2='6.5'/><line x1='5.5' y1='1.5' x2='5.5' y2='4.5'/><line x1='10.5' y1='1.5' x2='10.5' y2='4.5'/></svg>")
+    center / contain no-repeat;
 }
 
 .daily-note-title h2 {
@@ -4506,25 +4534,31 @@ a.sidebar-item:visited {
   }
 }
 
-/* Date picker styling to match existing design */
+/* Date picker styling to match existing design.
+
+   appearance: none suppresses the native chrome (including the down-
+   caret Android Chrome paints, which ignores ::-webkit-calendar-picker-
+   indicator masking). The padding-right reserves space for our own
+   calendar glyph painted by .title-left::after below. */
 .date-picker {
+  -webkit-appearance: none;
+  appearance: none;
   background: var(--bg-primary);
   color: var(--text-primary);
   border: 2px solid var(--border-secondary);
-  padding: 0.5rem;
+  padding: 0.5rem 1.75rem 0.5rem 0.5rem;
   font-family: inherit;
   font-size: 1rem;
   cursor: pointer;
   margin-right: 1rem;
 }
 
-/* The native dropdown caret on <input type="date"> sits inside the
-   input's padding-right area in WebKit, so adjusting padding only widens
-   the gap between the date text and the caret. Use margin on the
-   indicator pseudo-element instead to control its distance from the
-   right border. */
+/* Hide the native calendar-picker indicator on .date-picker — we paint
+   a themed glyph via .title-left::after instead. The indicator's click
+   target is irrelevant once appearance: none is set; clicking the
+   input field still opens the picker. */
 .date-picker::-webkit-calendar-picker-indicator {
-  margin-right: 0.25rem;
+  display: none;
 }
 
 .date-picker:focus {

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4511,11 +4511,20 @@ a.sidebar-item:visited {
   background: var(--bg-primary);
   color: var(--text-primary);
   border: 2px solid var(--border-secondary);
-  padding: 0.5rem 1rem 0.5rem 0.5rem;
+  padding: 0.5rem;
   font-family: inherit;
   font-size: 1rem;
   cursor: pointer;
   margin-right: 1rem;
+}
+
+/* The native dropdown caret on <input type="date"> sits inside the
+   input's padding-right area in WebKit, so adjusting padding only widens
+   the gap between the date text and the caret. Use margin on the
+   indicator pseudo-element instead to control its distance from the
+   right border. */
+.date-picker::-webkit-calendar-picker-indicator {
+  margin-right: 0.25rem;
 }
 
 .date-picker:focus {

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -1205,11 +1205,10 @@ kbd {
   content: "";
   position: absolute;
   top: 50%;
-  /* Sits ~4px inside the input's right border (.date-picker has no
-     margin-right, so .title-left's right edge equals the input's
-     right edge). The 14px glyph + a small gap to the date text fit
-     inside .date-picker's 1.5rem padding-right. */
-  right: 0.25rem;
+  /* Sits inside .date-picker's 1.25rem padding-right zone, hugging
+     the right border. .date-picker has no margin-right so .title-left's
+     right edge equals the input's right edge. */
+  right: 0.3rem;
   transform: translateY(-50%);
   width: 14px;
   height: 14px;
@@ -4547,11 +4546,10 @@ a.sidebar-item:visited {
   background: var(--bg-primary);
   color: var(--text-primary);
   border: 2px solid var(--border-secondary);
-  /* padding-right reserves room for the calendar glyph painted by
-     .title-left::after; min-width keeps the full date string from
-     getting clipped by tight intrinsic widths on mobile. */
-  padding: 0.5rem 1.5rem 0.5rem 0.5rem;
-  min-width: 9rem;
+  /* padding-right reserves just enough for the 14px calendar glyph
+     painted by .title-left::after. Sized to the date string so the
+     icon sits flush against the date text rather than a long gap. */
+  padding: 0.5rem 1.25rem 0.5rem 0.5rem;
   font-family: inherit;
   font-size: 1rem;
   cursor: pointer;

--- a/packages/django-app/app/knowledge/templates/knowledge/base.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/base.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>{% block title %}brainspread{% endblock %}</title>
     {% load static %} {% csrf_token %}
     <link rel="stylesheet" href="{% static 'knowledge/css/app.css' %}?v={{ STATIC_VERSION }}" />

--- a/packages/django-app/app/knowledge/test/commands/test_create_block_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_create_block_command.py
@@ -237,3 +237,21 @@ class TestCreateBlockCommand(TestCase):
         block.refresh_from_db()
         self.assertEqual(block.block_type, "code")
         self.assertEqual(block.properties, {"language": "python"})
+
+    def test_should_bump_page_modified_at(self):
+        """Creating a block should advance the page's modified_at so it
+        floats to the top of the recent-pages list."""
+        original_modified_at = self.page.modified_at
+
+        form = CreateBlockForm(
+            {
+                "user": self.user.id,
+                "page": self.page.uuid,
+                "content": "fresh content",
+            }
+        )
+        form.is_valid()
+        CreateBlockCommand(form).execute()
+
+        self.page.refresh_from_db()
+        self.assertGreater(self.page.modified_at, original_modified_at)

--- a/packages/django-app/app/knowledge/test/commands/test_move_block_to_daily_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_move_block_to_daily_command.py
@@ -280,3 +280,27 @@ class TestMoveBlockToDailyCommand(TestCase):
 
         self.assertTrue(result["moved"])
         self.assertEqual(result["target_page"]["date"], "2026-04-29")
+
+    def test_should_bump_modified_at_on_both_source_and_target(self):
+        target_date = date(2026, 4, 29)
+        source_page = PageFactory(user=self.user, title="Notes", slug="bump-notes")
+        block = BlockFactory(user=self.user, page=source_page, content="moved", order=1)
+
+        source_modified_before = source_page.modified_at
+
+        form = MoveBlockToDailyForm(
+            {"user": self.user, "block": block.uuid, "target_date": target_date}
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        result = MoveBlockToDailyCommand(form).execute()
+        self.assertTrue(result["moved"])
+
+        source_page.refresh_from_db()
+        self.assertGreater(source_page.modified_at, source_modified_before)
+
+        target_page = Page.objects.get(user=self.user, date=target_date)
+        # The target was created mid-execute, so we don't have a baseline
+        # to diff against; instead verify it's at least as fresh as the
+        # source after the move.
+        self.assertGreaterEqual(target_page.modified_at, source_page.modified_at)

--- a/packages/django-app/app/knowledge/test/commands/test_send_due_reminders_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_send_due_reminders_command.py
@@ -259,3 +259,54 @@ class TestSendDueRemindersCommand(TestCase):
         self.assertEqual(result["failed"], 1)
         self.assertEqual(reminder.status, Reminder.STATUS_FAILED)
         self.assertIn("no webhook", reminder.last_error.lower())
+
+    def test_appends_page_link_when_site_url_set(self):
+        page = PageFactory(user=self.user, title="Backlog", slug="backlog")
+        block = BlockFactory(user=self.user, page=page, content="TODO ship")
+        Reminder.objects.create(
+            block=block,
+            fire_at=timezone.now() - timedelta(minutes=1),
+        )
+
+        captured: dict = {}
+
+        def _capture(url: str, content: str, **_kwargs):
+            captured["content"] = content
+            return DiscordDeliveryResult(True, "")
+
+        with (
+            self.settings(SITE_URL="https://app.example.com"),
+            patch(
+                "knowledge.commands.send_due_reminders_command.post_webhook", _capture
+            ),
+        ):
+            self._run()
+
+        self.assertIn(
+            "https://app.example.com/knowledge/page/backlog/", captured["content"]
+        )
+
+    def test_omits_page_link_when_site_url_is_placeholder(self):
+        # Default SITE_URL is "0.0.0.0" with no scheme — produces a broken
+        # link, so the formatter should leave it out.
+        block = BlockFactory(user=self.user, page=self.page, content="TODO ship")
+        Reminder.objects.create(
+            block=block,
+            fire_at=timezone.now() - timedelta(minutes=1),
+        )
+
+        captured: dict = {}
+
+        def _capture(url: str, content: str, **_kwargs):
+            captured["content"] = content
+            return DiscordDeliveryResult(True, "")
+
+        with (
+            self.settings(SITE_URL="0.0.0.0"),
+            patch(
+                "knowledge.commands.send_due_reminders_command.post_webhook", _capture
+            ),
+        ):
+            self._run()
+
+        self.assertNotIn("/knowledge/page/", captured["content"])

--- a/packages/django-app/app/knowledge/test/commands/test_touch_page_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_touch_page_command.py
@@ -1,0 +1,35 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from knowledge.commands import TouchPageCommand
+from knowledge.forms import TouchPageForm
+
+from ..helpers import PageFactory, UserFactory
+
+
+class TestTouchPageCommand(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.page = PageFactory(user=cls.user)
+
+    def test_should_advance_modified_at(self):
+        original_modified_at = self.page.modified_at
+
+        form = TouchPageForm({"user": self.user.id, "page": str(self.page.uuid)})
+        self.assertTrue(form.is_valid(), form.errors)
+        TouchPageCommand(form).execute()
+
+        self.page.refresh_from_db()
+        self.assertGreater(self.page.modified_at, original_modified_at)
+
+    def test_should_reject_page_owned_by_another_user(self):
+        other_user = UserFactory()
+        form = TouchPageForm({"user": other_user.id, "page": str(self.page.uuid)})
+        self.assertFalse(form.is_valid())
+
+    def test_should_raise_when_form_invalid(self):
+        # Missing page entirely.
+        form = TouchPageForm({"user": self.user.id})
+        with self.assertRaises(ValidationError):
+            TouchPageCommand(form).execute()


### PR DESCRIPTION
The navbar removal left the collapsed rail floating at top: 88px with a
chunky FAB style, overlapping page content. Move it flush to the
top-left and slim the toggle to a small bordered button.

https://claude.ai/code/session_01Dbh82o8kUUosQ3VXSKqcAx