### PR TITLE
Add resource limits and restart policy for staging environment

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -68,9 +68,16 @@ jobs:
             ALLOWED_HOSTS=*
             DJANGO_SECRET_KEY=${SECRET_KEY}
             COMPOSE_PROJECT_NAME=${PROJECT}
+            COMPOSE_FILE=docker-compose.yml:docker-compose.staging.yml
             REMINDERS_ENABLED=true
             ENVIRONMENT=staging
             EOF
+            fi
+
+            # Backfill COMPOSE_FILE for staging envs that pre-date the staging
+            # compose override (so resource caps actually apply on redeploy).
+            if ! grep -q '^COMPOSE_FILE=' .env; then
+              echo 'COMPOSE_FILE=docker-compose.yml:docker-compose.staging.yml' >> .env
             fi
 
             docker volume create --name="${VOLUME}" 2>/dev/null || true

--- a/packages/django-app/docker-compose.staging.yml
+++ b/packages/django-app/docker-compose.staging.yml
@@ -1,0 +1,12 @@
+services:
+  web:
+    ports:
+      - "${WEB_PORT:-8000}:${WEB_PORT:-8000}"
+    mem_limit: 512m
+    mem_reservation: 256m
+  db:
+    mem_limit: 384m
+    mem_reservation: 192m
+  scheduler:
+    mem_limit: 128m
+    mem_reservation: 64m

--- a/packages/django-app/docker-compose.yml
+++ b/packages/django-app/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - .:/code
     depends_on:
       - db
+    restart: unless-stopped
   # Periodic task runner — polls the reminders table once a minute and
   # dispatches any that are due. See bin/run-scheduler.sh and issue #59.
   # Gated by REMINDERS_ENABLED (defaults to false); the staging deploy


### PR DESCRIPTION
## Summary
This PR adds resource constraints and improved reliability for the staging environment by introducing a Docker Compose override file and updating deployment configuration.

## Key Changes
- **New staging compose override file** (`docker-compose.staging.yml`): Defines memory limits and reservations for all services
  - Web service: 512m limit / 256m reservation
  - Database service: 384m limit / 192m reservation
  - Scheduler service: 128m limit / 64m reservation
  - Configurable web port via environment variable

- **Updated staging deployment workflow** (`.github/workflows/staging.yml`):
  - Added `COMPOSE_FILE` environment variable to stack the staging override with the base compose file
  - Added backfill logic to ensure existing staging environments get the compose override on redeploy, applying resource caps retroactively

- **Improved web service reliability** (`docker-compose.yml`):
  - Added `restart: unless-stopped` policy to the web service for automatic recovery from crashes

## Implementation Details
The staging compose override uses Docker Compose's file composition feature to layer resource constraints on top of the base configuration without modifying the base file. The backfill logic in the workflow ensures that previously deployed staging environments will pick up these resource limits on their next deployment cycle.

https://claude.ai/code/session_01S8NFAe5mE1p4Qj8EYnaLW4