### PR TITLE
Render mermaid, CSV, markdown, and syntax-highlighted code in blocks

### DIFF
--- a/packages/django-app/app/assets/forms/upload_asset_form.py
+++ b/packages/django-app/app/assets/forms/upload_asset_form.py
@@ -1,3 +1,5 @@
+import os
+
 from django import forms
 from django.conf import settings
 
@@ -6,6 +8,15 @@ from core.models import User
 from core.repositories import UserRepository
 
 from ..models import Asset
+
+# Extensions that browsers commonly upload as application/octet-stream
+# because the OS MIME database doesn't know about them. We treat these
+# as text/plain so they pass the `text/*` whitelist; the original
+# filename is preserved separately on the Asset row.
+_TEXT_LIKE_EXTENSIONS = {
+    ".mmd": "text/plain",
+    ".mermaid": "text/plain",
+}
 
 
 class UploadAssetForm(BaseForm):
@@ -42,10 +53,21 @@ class UploadAssetForm(BaseForm):
                 f"maximum is {max_bytes} bytes"
             )
 
-        whitelist = settings.ASSET_UPLOAD_MIME_WHITELIST
         # content_type can include parameters (e.g. "text/html; charset=utf-8");
         # only the bare type counts for the whitelist check.
         content_type = (uploaded.content_type or "").split(";", 1)[0].strip().lower()
+
+        # Normalize for known text-shaped extensions that browsers don't
+        # have a MIME for. Mutate the upload so the downstream command
+        # records the corrected type rather than `application/octet-stream`.
+        if content_type in ("", "application/octet-stream"):
+            ext = os.path.splitext(uploaded.name or "")[1].lower()
+            override = _TEXT_LIKE_EXTENSIONS.get(ext)
+            if override:
+                content_type = override
+                uploaded.content_type = override
+
+        whitelist = settings.ASSET_UPLOAD_MIME_WHITELIST
         if whitelist and not _mime_matches_whitelist(content_type, whitelist):
             raise forms.ValidationError(
                 f"Unsupported file type: {content_type or 'unknown'}"

--- a/packages/django-app/app/assets/forms/upload_asset_form.py
+++ b/packages/django-app/app/assets/forms/upload_asset_form.py
@@ -16,6 +16,8 @@ from ..models import Asset
 _TEXT_LIKE_EXTENSIONS = {
     ".mmd": "text/plain",
     ".mermaid": "text/plain",
+    ".md": "text/markdown",
+    ".markdown": "text/markdown",
 }
 
 

--- a/packages/django-app/app/assets/test/views/test_asset_api.py
+++ b/packages/django-app/app/assets/test/views/test_asset_api.py
@@ -157,6 +157,31 @@ class AssetAPITestCase(TestCase):
                 )
                 self.assertEqual(response.status_code, status.HTTP_200_OK, mime)
 
+    def test_upload_accepts_mermaid_extensions_with_octet_stream(self):
+        # Browsers send application/octet-stream for .mmd / .mermaid
+        # because there's no registered MIME for them. The form
+        # normalizes those to text/plain by extension so the upload
+        # passes the whitelist instead of erroring out.
+        cases = [
+            ("diagram.mmd", b"flowchart LR\nA --> B\n"),
+            ("diagram.mermaid", b"sequenceDiagram\nA->>B: hi\n"),
+        ]
+        for filename, content in cases:
+            with self.subTest(filename=filename):
+                upload = SimpleUploadedFile(
+                    filename, content, content_type="application/octet-stream"
+                )
+                response = self.client.post(
+                    "/api/assets/", {"file": upload}, format="multipart"
+                )
+                self.assertEqual(
+                    response.status_code,
+                    status.HTTP_200_OK,
+                    f"{filename} should upload: {response.data}",
+                )
+                self.assertEqual(response.data["data"]["mime_type"], "text/plain")
+                self.assertEqual(response.data["data"]["original_filename"], filename)
+
     def test_upload_assigns_image_file_type(self):
         upload = SimpleUploadedFile(
             "pic.png", b"\x89PNG\r\n\x1a\n", content_type="image/png"

--- a/packages/django-app/app/assets/test/views/test_asset_api.py
+++ b/packages/django-app/app/assets/test/views/test_asset_api.py
@@ -182,6 +182,30 @@ class AssetAPITestCase(TestCase):
                 self.assertEqual(response.data["data"]["mime_type"], "text/plain")
                 self.assertEqual(response.data["data"]["original_filename"], filename)
 
+    def test_upload_accepts_markdown_extensions_with_octet_stream(self):
+        # Same story as .mmd: some browsers send octet-stream for .md
+        # because the OS hasn't registered a MIME. Normalize to
+        # text/markdown so the upload passes the text/* whitelist.
+        cases = [
+            ("notes.md", b"# Hello\n\nworld\n"),
+            ("README.markdown", b"## Title\n\n- item\n"),
+        ]
+        for filename, content in cases:
+            with self.subTest(filename=filename):
+                upload = SimpleUploadedFile(
+                    filename, content, content_type="application/octet-stream"
+                )
+                response = self.client.post(
+                    "/api/assets/", {"file": upload}, format="multipart"
+                )
+                self.assertEqual(
+                    response.status_code,
+                    status.HTTP_200_OK,
+                    f"{filename} should upload: {response.data}",
+                )
+                self.assertEqual(response.data["data"]["mime_type"], "text/markdown")
+                self.assertEqual(response.data["data"]["original_filename"], filename)
+
     def test_upload_assigns_image_file_type(self):
         upload = SimpleUploadedFile(
             "pic.png", b"\x89PNG\r\n\x1a\n", content_type="image/png"

--- a/packages/django-app/app/core/test/views/test_user_api.py
+++ b/packages/django-app/app/core/test/views/test_user_api.py
@@ -126,6 +126,25 @@ class UserAPITestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
+    def test_me_refreshes_session_for_token_only_caller(self):
+        """
+        /me/ called with token auth and no active session should
+        re-establish a Django session, so cookie-only consumers
+        (e.g. <img src="/api/assets/.../">) keep working after the
+        original session cookie expires.
+        """
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
+        # Sanity check: the test client has no session cookie yet.
+        self.assertNotIn("sessionid", self.client.cookies)
+
+        response = self.client.get("/api/auth/me/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # The response should set a session cookie that subsequent
+        # cookie-only requests can use.
+        self.assertIn("sessionid", response.cookies)
+        self.assertTrue(response.cookies["sessionid"].value)
+
     def test_update_timezone_success(self):
         """Test successful timezone update"""
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)

--- a/packages/django-app/app/core/views.py
+++ b/packages/django-app/app/core/views.py
@@ -163,6 +163,15 @@ def logout(request):
 def me(request):
     """Get current user info"""
     try:
+        # Re-establish a Django session if the cookie has expired but the
+        # API token is still valid. Token auth has no expiry; the session
+        # cookie defaults to 2 weeks. Without this, <img src="/api/assets/.../">
+        # tags 401 after the cookie expires (they can only carry cookies,
+        # not the Authorization header) and the user has to log out and
+        # back in to render images. The frontend hits /me/ on every app
+        # boot, so this is the natural place to keep the cookie fresh.
+        if not request.session.session_key:
+            django_login(request, request.user)
         data: GetUserProfileResponse = {"user": request.user.to_user_data()}
         return Response({"success": True, "data": data})
     except Exception as e:

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -5086,6 +5086,86 @@ kbd {
   font-style: italic;
 }
 
+.block-markdown {
+  font-size: 0.95em;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+.block-markdown > :first-child {
+  margin-top: 0;
+}
+
+.block-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+.block-markdown h1,
+.block-markdown h2,
+.block-markdown h3,
+.block-markdown h4,
+.block-markdown h5,
+.block-markdown h6 {
+  margin: 0.6em 0 0.3em;
+  font-weight: 600;
+}
+
+.block-markdown p,
+.block-markdown ul,
+.block-markdown ol,
+.block-markdown blockquote {
+  margin: 0.4em 0;
+}
+
+.block-markdown ul,
+.block-markdown ol {
+  padding-left: 1.5em;
+}
+
+.block-markdown code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.85em;
+  background-color: var(--bg-secondary, rgba(0, 0, 0, 0.08));
+  padding: 0.1em 0.3em;
+  border-radius: 3px;
+}
+
+.block-markdown pre {
+  background-color: var(--bg-secondary, rgba(0, 0, 0, 0.08));
+  border: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
+  border-radius: 4px;
+  padding: 0.5em 0.75em;
+  overflow-x: auto;
+}
+
+.block-markdown pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+}
+
+.block-markdown blockquote {
+  border-left: 3px solid var(--border-color, rgba(0, 0, 0, 0.2));
+  padding-left: 0.75em;
+  color: var(--text-secondary, #666);
+}
+
+.block-markdown table {
+  border-collapse: collapse;
+  font-size: 0.9em;
+}
+
+.block-markdown th,
+.block-markdown td {
+  border: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
+  padding: 0.3em 0.6em;
+}
+
+.block-markdown a {
+  color: var(--accent-color, #4a90e2);
+  text-decoration: underline;
+}
+
 /* Whiteboard page (tldraw) */
 .page-content-whiteboard {
   display: flex;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -5031,6 +5031,50 @@ kbd {
   white-space: pre-wrap;
 }
 
+.block-csv-wrapper {
+  position: relative;
+  display: block;
+  margin: 0.25em 0;
+}
+
+.block-csv-scroll {
+  overflow-x: auto;
+  border: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
+  border-radius: 4px;
+  background-color: var(--bg-secondary, rgba(0, 0, 0, 0.04));
+}
+
+.block-csv {
+  border-collapse: collapse;
+  font-size: 0.85em;
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.block-csv th,
+.block-csv td {
+  padding: 0.35em 0.7em;
+  border-right: 1px solid var(--border-color, rgba(0, 0, 0, 0.08));
+  border-bottom: 1px solid var(--border-color, rgba(0, 0, 0, 0.08));
+  text-align: left;
+  vertical-align: top;
+  white-space: pre-wrap;
+}
+
+.block-csv th:last-child,
+.block-csv td:last-child {
+  border-right: none;
+}
+
+.block-csv tr:last-child td {
+  border-bottom: none;
+}
+
+.block-csv th {
+  font-weight: 600;
+  background-color: var(--bg-tertiary, rgba(0, 0, 0, 0.06));
+}
+
 /* Whiteboard page (tldraw) */
 .page-content-whiteboard {
   display: flex;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -5145,9 +5145,13 @@ kbd {
 /* After the user has dragged the corner handle, the wrapper has an
    explicit width. Stretch the image to fill it so dragging actually
    scales the picture rather than just leaving empty space inside the
-   wrapper. */
+   wrapper. The default .block-asset-image rule (further down in this
+   file) caps the height at 480px which would break the aspect ratio
+   once the user widens the picture past that — drop the cap when a
+   saved size exists so width × auto height stays proportional. */
 .block-asset-image-wrapper.has-saved-size > .block-asset-image {
   width: 100%;
+  max-height: none;
 }
 
 .block-markdown {

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -5128,14 +5128,26 @@ kbd {
 
 .block-asset-image-wrapper {
   position: relative;
-  display: block;
+  display: inline-block;
   max-width: 100%;
 }
 
+/* Default: render the image at its natural pixel size, clamped to the
+   column. The wrapper is `inline-block` so it shrinks around the
+   image and the resize handle pins to the actual image edge instead
+   of the empty column to the right. */
 .block-asset-image-wrapper > .block-asset-image {
-  width: 100%;
+  max-width: 100%;
   height: auto;
   display: block;
+}
+
+/* After the user has dragged the corner handle, the wrapper has an
+   explicit width. Stretch the image to fill it so dragging actually
+   scales the picture rather than just leaving empty space inside the
+   wrapper. */
+.block-asset-image-wrapper.has-saved-size > .block-asset-image {
+  width: 100%;
 }
 
 .block-markdown {

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -5075,6 +5075,17 @@ kbd {
   background-color: var(--bg-tertiary, rgba(0, 0, 0, 0.06));
 }
 
+.block-asset-rendered {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.block-asset-loading {
+  font-size: 0.85em;
+  color: var(--text-secondary, #888);
+  font-style: italic;
+}
+
 /* Whiteboard page (tldraw) */
 .page-content-whiteboard {
   display: flex;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -5005,6 +5005,7 @@ kbd {
   position: relative;
   display: block;
   margin: 0.25em 0;
+  max-width: 100%;
 }
 
 .block-mermaid {
@@ -5019,8 +5020,9 @@ kbd {
 }
 
 .block-mermaid svg {
-  max-width: 100%;
+  width: 100%;
   height: auto;
+  display: block;
 }
 
 .block-mermaid-error {
@@ -5084,6 +5086,56 @@ kbd {
   font-size: 0.85em;
   color: var(--text-secondary, #888);
   font-style: italic;
+}
+
+/* Proportional resize handle for renders with an intrinsic aspect
+   ratio (mermaid SVGs, images). Width is the only thing the user
+   controls; the inner content's `height: auto` keeps the ratio. */
+.block-resizable {
+  position: relative;
+  display: block;
+  max-width: 100%;
+}
+
+.block-resize-handle {
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  width: 14px;
+  height: 14px;
+  cursor: nwse-resize;
+  opacity: 0;
+  background: linear-gradient(
+    135deg,
+    transparent 50%,
+    var(--text-secondary, #888) 50%,
+    var(--text-secondary, #888) 60%,
+    transparent 60%,
+    transparent 70%,
+    var(--text-secondary, #888) 70%,
+    var(--text-secondary, #888) 80%,
+    transparent 80%
+  );
+  transition: opacity 120ms ease;
+  z-index: 1;
+  user-select: none;
+}
+
+.block-resizable:hover .block-resize-handle,
+.block-resize-handle.is-resizing {
+  opacity: 0.7;
+}
+
+.block-asset-image-wrapper {
+  position: relative;
+  display: block;
+  max-width: 100%;
+}
+
+.block-asset-image-wrapper > .block-asset-image {
+  width: 100%;
+  height: auto;
+  display: block;
 }
 
 .block-markdown {

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4918,6 +4918,36 @@ kbd {
   pointer-events: none;
 }
 
+.block-mermaid-wrapper {
+  position: relative;
+  display: block;
+  margin: 0.25em 0;
+}
+
+.block-mermaid {
+  background-color: var(--bg-secondary, rgba(0, 0, 0, 0.08));
+  border: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
+  border-radius: 4px;
+  padding: 0.75em;
+  overflow-x: auto;
+  text-align: center;
+  color: var(--text-primary);
+  min-height: 1.5em;
+}
+
+.block-mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.block-mermaid-error {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.85em;
+  color: var(--text-secondary, #b00);
+  text-align: left;
+  white-space: pre-wrap;
+}
+
 /* Whiteboard page (tldraw) */
 .page-content-whiteboard {
   display: flex;

--- a/packages/django-app/app/knowledge/static/knowledge/js/app.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/app.js
@@ -290,6 +290,12 @@ const KnowledgeApp = createApp({
     applyTheme() {
       const theme = this.user?.theme || "dark";
       document.documentElement.setAttribute("data-theme", theme);
+      // Mermaid diagrams pick their palette at render time, so a theme
+      // swap only takes effect on already-rendered SVGs if we reset and
+      // re-render them.
+      if (window.brainspreadMermaid) {
+        window.brainspreadMermaid.rerenderAll(theme);
+      }
     },
 
     // Chat context management methods
@@ -853,6 +859,9 @@ const KnowledgeApp = createApp({
 
       document.documentElement.setAttribute("data-theme", theme);
       this.user = { ...this.user, theme };
+      if (window.brainspreadMermaid) {
+        window.brainspreadMermaid.rerenderAll(theme);
+      }
 
       try {
         const result = await window.apiService.updateUserTheme(theme);
@@ -863,6 +872,9 @@ const KnowledgeApp = createApp({
         console.error("failed to persist theme:", error);
         document.documentElement.setAttribute("data-theme", previous);
         this.user = { ...this.user, theme: previous };
+        if (window.brainspreadMermaid) {
+          window.brainspreadMermaid.rerenderAll(previous);
+        }
       }
     },
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -157,12 +157,20 @@ const BlockComponent = {
       return this.isBlockInContext(this.block.uuid);
     },
     canToggleCodeRender() {
-      // Only code blocks whose language has a specialized renderer can
-      // toggle between rendered and raw views. Plain code (python, js,
-      // …) always renders the same way, so the toggle would be a no-op.
-      if (this.block.block_type !== "code") return false;
-      const lang = (this.block.properties?.language || "").toLowerCase();
-      return ["mermaid", "csv", "tsv"].includes(lang);
+      // Code-typed blocks: only those whose language has a specialized
+      // renderer get the toggle. Plain code (python, js, …) renders the
+      // same way either way so a toggle would be a no-op.
+      if (this.block.block_type === "code") {
+        const lang = (this.block.properties?.language || "").toLowerCase();
+        return ["mermaid", "csv", "tsv"].includes(lang);
+      }
+      // Text-typed blocks: the toggle lights up if the content contains
+      // an inline ```mermaid / ```csv / ```tsv fenced block. The
+      // formatter applies the toggle to every inline fence in the block
+      // together, so one block-level state covers however many fences
+      // the user pasted in.
+      const content = this.block.content || "";
+      return /```(mermaid|csv|tsv)\b[^\n`]*\n[\s\S]*?```/i.test(content);
     },
     canToggleAssetRender() {
       // The toggle applies to anything we render inline — images, plus

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -226,7 +226,7 @@ const BlockComponent = {
           .replace(/</g, "&lt;")
           .replace(/>/g, "&gt;")
           .replace(/"/g, "&quot;");
-        return `<div class="block-mermaid-wrapper"><div class="block-mermaid" data-mermaid-source="${attr}"></div></div>`;
+        return `<div class="block-mermaid-wrapper block-resizable"><div class="block-mermaid" data-mermaid-source="${attr}"></div><div class="block-resize-handle" aria-hidden="true"></div></div>`;
       }
       if (this.detectedAssetType === "markdown") {
         if (!window.marked || !window.DOMPurify) return "";
@@ -510,6 +510,63 @@ const BlockComponent = {
       // its targets aren't present.
       this.renderMermaidIfPresent();
       this.highlightCodeIfPresent();
+      this.applyResizableHandles();
+    },
+
+    applyResizableHandles() {
+      // Apply the persisted block-level width to every resizable
+      // wrapper inside this block, and wire up corner-handle drag.
+      // A block has a single properties.size today, so multiple
+      // resizables in one block share the same width — fine for the
+      // current shapes (one mermaid wrapper per code block, one image
+      // wrapper per asset block).
+      if (!this.$el || this.$el.nodeType !== 1) return;
+      const savedWidth = this.block.properties?.size?.width;
+      const wrappers = this.$el.querySelectorAll(".block-resizable");
+      wrappers.forEach((el) => {
+        if (savedWidth && !el.dataset.savedSizeApplied) {
+          el.style.width = `${savedWidth}px`;
+          el.dataset.savedSizeApplied = "true";
+        }
+      });
+      const handles = this.$el.querySelectorAll(
+        ".block-resize-handle:not([data-resize-bound])"
+      );
+      handles.forEach((handle) => {
+        handle.dataset.resizeBound = "true";
+        handle.addEventListener("mousedown", (event) =>
+          this.startResize(event, handle)
+        );
+      });
+    },
+
+    startResize(event, handle) {
+      // Drag the corner handle to set wrapper width; height follows
+      // from the SVG/img's `height: auto`, so the aspect ratio is
+      // preserved without doing any math here.
+      const wrapper = handle.closest(".block-resizable");
+      if (!wrapper) return;
+      event.preventDefault();
+      event.stopPropagation();
+      handle.classList.add("is-resizing");
+      const startX = event.clientX;
+      const startWidth = wrapper.getBoundingClientRect().width;
+      const onMove = (e) => {
+        const delta = e.clientX - startX;
+        // Floor at 120px so the handle can't drag the wrapper into a
+        // sliver that's hard to recover from.
+        const next = Math.max(120, Math.round(startWidth + delta));
+        wrapper.style.width = `${next}px`;
+      };
+      const onUp = () => {
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup", onUp);
+        handle.classList.remove("is-resizing");
+        const final = Math.round(wrapper.getBoundingClientRect().width);
+        this.setBlockProperties(this.block, { size: { width: final } });
+      };
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onUp);
     },
 
     renderMermaidIfPresent() {
@@ -1325,13 +1382,18 @@ const BlockComponent = {
           <span v-else>•</span>
         </div>
         <div v-if="hasAsset && !isEmbed" class="block-asset" @click.stop>
-          <img
+          <div
             v-if="assetIsImage && !isRenderedRaw"
-            :src="assetUrl"
-            :alt="assetDisplayName"
-            class="block-asset-image"
-            loading="lazy"
-          />
+            class="block-asset-image-wrapper block-resizable"
+          >
+            <img
+              :src="assetUrl"
+              :alt="assetDisplayName"
+              class="block-asset-image"
+              loading="lazy"
+            />
+            <div class="block-resize-handle" aria-hidden="true"></div>
+          </div>
           <div
             v-else-if="shouldRenderAsset && assetSource !== null"
             class="block-asset-rendered"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -355,6 +355,13 @@ const BlockComponent = {
     if (this.isEmbed) {
       this.loadWebArchive();
     }
+    this.renderMermaidIfPresent();
+  },
+  updated() {
+    // The block-content div uses v-html, so when the block's content
+    // changes (edits, type swaps) Vue replaces the inner DOM with a fresh
+    // mermaid placeholder. Re-run the mermaid renderer to pick those up.
+    this.renderMermaidIfPresent();
   },
   beforeUnmount() {
     // Clean up event listener
@@ -369,6 +376,19 @@ const BlockComponent = {
     );
   },
   methods: {
+    renderMermaidIfPresent() {
+      // Skip the work if neither the helper nor any placeholder are
+      // present. The helper takes care of one-shot mermaid initialization
+      // and idempotent rendering.
+      if (!window.brainspreadMermaid || !this.$el || this.$el.nodeType !== 1)
+        return;
+      if (!this.$el.querySelector || !this.$el.querySelector(".block-mermaid"))
+        return;
+      const appTheme =
+        document.documentElement.getAttribute("data-theme") || "dark";
+      window.brainspreadMermaid.renderIn(this.$el, appTheme);
+    },
+
     async loadWebArchive() {
       if (this.webArchiveLoading) return;
       this.webArchiveLoading = true;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -367,13 +367,14 @@ const BlockComponent = {
     if (this.isEmbed) {
       this.loadWebArchive();
     }
-    this.renderMermaidIfPresent();
+    this.applyContentRenderers();
   },
   updated() {
     // The block-content div uses v-html, so when the block's content
     // changes (edits, type swaps) Vue replaces the inner DOM with a fresh
-    // mermaid placeholder. Re-run the mermaid renderer to pick those up.
-    this.renderMermaidIfPresent();
+    // placeholder. Re-run the dynamic renderers so the new DOM picks up
+    // mermaid SVGs, syntax highlighting, etc.
+    this.applyContentRenderers();
   },
   beforeUnmount() {
     // Clean up event listener
@@ -388,6 +389,15 @@ const BlockComponent = {
     );
   },
   methods: {
+    applyContentRenderers() {
+      // Run after v-html replaces the block's display HTML so dynamic
+      // renderers (mermaid SVG, Prism syntax highlighting, etc.) can
+      // upgrade the static markup. Each renderer is no-op-cheap when
+      // its targets aren't present.
+      this.renderMermaidIfPresent();
+      this.highlightCodeIfPresent();
+    },
+
     renderMermaidIfPresent() {
       // Skip the work if neither the helper nor any placeholder are
       // present. The helper takes care of one-shot mermaid initialization
@@ -399,6 +409,25 @@ const BlockComponent = {
       const appTheme =
         document.documentElement.getAttribute("data-theme") || "dark";
       window.brainspreadMermaid.renderIn(this.$el, appTheme);
+    },
+
+    highlightCodeIfPresent() {
+      // Apply Prism syntax highlighting to any <code class="language-*">
+      // emitted by formatContentWithTags. The autoloader fetches the
+      // grammar for each language on first use; calling highlightElement
+      // again on an already-tokenized node is a cheap no-op-ish retokenize.
+      if (!window.Prism || !this.$el || this.$el.nodeType !== 1) return;
+      const codeEls = this.$el.querySelectorAll(
+        "pre.block-code > code[class*='language-']"
+      );
+      codeEls.forEach((el) => {
+        try {
+          window.Prism.highlightElement(el);
+        } catch (_) {
+          // Highlighting failures shouldn't take the block down; the
+          // un-highlighted code is still legible.
+        }
+      });
     },
 
     async loadWebArchive() {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -185,6 +185,7 @@ const BlockComponent = {
       if (name.endsWith(".csv")) return "csv";
       if (name.endsWith(".tsv")) return "tsv";
       if (name.endsWith(".mmd") || name.endsWith(".mermaid")) return "mermaid";
+      if (name.endsWith(".md") || name.endsWith(".markdown")) return "markdown";
       return null;
     },
     shouldRenderAsset() {
@@ -216,6 +217,19 @@ const BlockComponent = {
           .replace(/>/g, "&gt;")
           .replace(/"/g, "&quot;");
         return `<div class="block-mermaid-wrapper"><div class="block-mermaid" data-mermaid-source="${attr}"></div></div>`;
+      }
+      if (this.detectedAssetType === "markdown") {
+        if (!window.marked || !window.DOMPurify) return "";
+        // Per-call options (rather than marked.setOptions) so we don't
+        // mutate global state shared with the chat panel. gfm + breaks
+        // matches the chat panel's behavior, which is what users
+        // already expect for markdown rendering in this app.
+        const html = window.marked.parse(this.assetSource, {
+          gfm: true,
+          breaks: true,
+        });
+        const clean = window.DOMPurify.sanitize(html);
+        return `<div class="block-markdown">${clean}</div>`;
       }
       return "";
     },

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -144,6 +144,12 @@ const BlockComponent = {
       embedTagSuggestions: [],
       embedTagSelectedIndex: 0,
       embedTagSearchToken: 0,
+      // Asset-source rendering (csv/mmd/mermaid uploads). The bytes are
+      // fetched lazily on mount when the asset's filename matches a
+      // renderable extension; null until the fetch completes.
+      assetSource: null,
+      assetFetchError: null,
+      assetFetchInFlight: false,
     };
   },
   computed: {
@@ -158,8 +164,60 @@ const BlockComponent = {
       const lang = (this.block.properties?.language || "").toLowerCase();
       return ["mermaid", "csv", "tsv"].includes(lang);
     },
-    isCodeRenderedRaw() {
+    canToggleAssetRender() {
+      // Asset blocks with a renderable extension (csv, tsv, mmd,
+      // mermaid) get the same toggle so users can swap between the
+      // rendered table/diagram and the plain download chip.
+      return !!this.detectedAssetType;
+    },
+    canToggleRender() {
+      return this.canToggleCodeRender || this.canToggleAssetRender;
+    },
+    isRenderedRaw() {
       return this.block.properties?.render === "raw";
+    },
+    detectedAssetType() {
+      // Sniff a renderable type from the asset's original filename. Any
+      // extension we know how to render lights up; everything else
+      // continues to render as the default download chip.
+      if (!this.hasAsset || this.assetIsImage) return null;
+      const name = (this.block.asset.original_filename || "").toLowerCase();
+      if (name.endsWith(".csv")) return "csv";
+      if (name.endsWith(".tsv")) return "tsv";
+      if (name.endsWith(".mmd") || name.endsWith(".mermaid")) return "mermaid";
+      return null;
+    },
+    shouldRenderAsset() {
+      // Render the inline view unless the user explicitly toggled to
+      // raw. The fetch is a small text file so eager-loading is fine.
+      return this.canToggleAssetRender && !this.isRenderedRaw;
+    },
+    assetRenderHtml() {
+      // Compose the inline render HTML from the fetched bytes. Pure
+      // computed so the template's v-html stays in sync if the user
+      // toggles back to rendered after viewing raw.
+      if (!this.assetSource) return "";
+      if (
+        this.detectedAssetType === "csv" ||
+        this.detectedAssetType === "tsv"
+      ) {
+        if (!window.brainspreadCsv) return "";
+        const delim = this.detectedAssetType === "tsv" ? "\t" : ",";
+        const table = window.brainspreadCsv.renderCsvTable(
+          this.assetSource,
+          delim
+        );
+        return `<div class="block-csv-wrapper">${table}</div>`;
+      }
+      if (this.detectedAssetType === "mermaid") {
+        const attr = String(this.assetSource)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;");
+        return `<div class="block-mermaid-wrapper"><div class="block-mermaid" data-mermaid-source="${attr}"></div></div>`;
+      }
+      return "";
     },
     blockSelected() {
       return this.isBlockSelected(this.block.uuid);
@@ -382,6 +440,9 @@ const BlockComponent = {
     if (this.isEmbed) {
       this.loadWebArchive();
     }
+    if (this.shouldRenderAsset && this.assetSource === null) {
+      this.fetchAssetSource();
+    }
     this.applyContentRenderers();
   },
   updated() {
@@ -390,6 +451,12 @@ const BlockComponent = {
     // placeholder. Re-run the dynamic renderers so the new DOM picks up
     // mermaid SVGs, syntax highlighting, etc.
     this.applyContentRenderers();
+    // If the asset just became renderable (e.g. user toggled out of raw,
+    // or the asset itself just got attached) and we haven't fetched the
+    // bytes yet, kick that off.
+    if (this.shouldRenderAsset && this.assetSource === null) {
+      this.fetchAssetSource();
+    }
   },
   beforeUnmount() {
     // Clean up event listener
@@ -1096,8 +1163,31 @@ const BlockComponent = {
     },
 
     toggleCodeRender() {
-      const next = this.isCodeRenderedRaw ? "rendered" : "raw";
+      const next = this.isRenderedRaw ? "rendered" : "raw";
       this.setBlockProperties(this.block, { render: next });
+    },
+
+    async fetchAssetSource() {
+      // Fetch the asset bytes so the inline csv/mermaid renderer has
+      // text to work with. The serve endpoint is gated by the Django
+      // session cookie (see core.views.me); same-origin fetch sends it
+      // automatically.
+      if (this.assetFetchInFlight || !this.hasAsset) return;
+      this.assetFetchInFlight = true;
+      this.assetFetchError = null;
+      try {
+        const response = await fetch(this.assetUrl, {
+          credentials: "same-origin",
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        this.assetSource = await response.text();
+      } catch (err) {
+        this.assetFetchError = err && err.message ? err.message : String(err);
+      } finally {
+        this.assetFetchInFlight = false;
+      }
     },
 
     triggerAttachFilePicker() {
@@ -1210,6 +1300,19 @@ const BlockComponent = {
             class="block-asset-image"
             loading="lazy"
           />
+          <div
+            v-else-if="shouldRenderAsset && assetSource !== null"
+            class="block-asset-rendered"
+            v-html="assetRenderHtml"
+          ></div>
+          <div
+            v-else-if="shouldRenderAsset && assetFetchError"
+            class="block-mermaid-error"
+          >failed to load {{ assetDisplayName }}: {{ assetFetchError }}</div>
+          <div
+            v-else-if="shouldRenderAsset"
+            class="block-asset-loading"
+          >loading {{ assetDisplayName }}…</div>
           <a
             v-else
             :href="assetUrl"
@@ -1564,11 +1667,11 @@ const BlockComponent = {
           <span class="context-menu-icon">←</span>
           <span>outdent</span>
         </button>
-        <template v-if="canToggleCodeRender">
+        <template v-if="canToggleRender">
           <div class="context-menu-separator"></div>
           <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('toggleCodeRender')">
             <span class="context-menu-icon">⇄</span>
-            <span>{{ isCodeRenderedRaw ? 'show as rendered' : 'show as raw' }}</span>
+            <span>{{ isRenderedRaw ? 'show as rendered' : 'show as raw' }}</span>
           </button>
         </template>
         <div class="context-menu-separator"></div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -186,6 +186,9 @@ const BlockComponent = {
     isRenderedRaw() {
       return this.block.properties?.render === "raw";
     },
+    canResetSize() {
+      return !!this.block.properties?.size?.width;
+    },
     detectedAssetType() {
       // Sniff a renderable type from the asset's original filename. Any
       // extension we know how to render lights up; everything else
@@ -522,14 +525,22 @@ const BlockComponent = {
       // has either an image or a renderable text-shaped asset, never
       // both).
       if (!this.$el || this.$el.nodeType !== 1) return;
-      const savedWidth = this.block.properties?.size?.width;
+      // Bail mid-drag so we don't fight the in-progress resize by
+      // re-applying the old saved width on a reactive re-render.
+      if (this.$el.querySelector(".block-resize-handle.is-resizing")) return;
+      const savedWidth = this.block.properties?.size?.width || null;
+      const target = savedWidth ? String(savedWidth) : "";
       const wrappers = this.$el.querySelectorAll(".block-resizable");
       wrappers.forEach((el) => {
-        if (savedWidth && !el.dataset.savedSizeApplied) {
+        if (el.dataset.savedSizeApplied === target) return;
+        if (savedWidth) {
           el.style.width = `${savedWidth}px`;
           el.classList.add("has-saved-size");
-          el.dataset.savedSizeApplied = "true";
+        } else {
+          el.style.width = "";
+          el.classList.remove("has-saved-size");
         }
+        el.dataset.savedSizeApplied = target;
       });
       const handles = this.$el.querySelectorAll(
         ".block-resize-handle:not([data-resize-bound])"
@@ -1251,12 +1262,29 @@ const BlockComponent = {
         case "toggleCodeRender":
           this.toggleCodeRender();
           break;
+        case "resetSize":
+          this.resetSize();
+          break;
       }
     },
 
     toggleCodeRender() {
       const next = this.isRenderedRaw ? "rendered" : "raw";
       this.setBlockProperties(this.block, { render: next });
+    },
+
+    resetSize() {
+      // Clear the persisted size and the local DOM state so the
+      // wrappers fall back to their natural defaults (image at
+      // intrinsic size, mermaid at column width).
+      this.setBlockProperties(this.block, { size: null });
+      if (this.$el) {
+        this.$el.querySelectorAll(".block-resizable").forEach((el) => {
+          el.style.width = "";
+          el.classList.remove("has-saved-size");
+          el.dataset.savedSizeApplied = "";
+        });
+      }
     },
 
     async fetchAssetSource() {
@@ -1764,11 +1792,15 @@ const BlockComponent = {
           <span class="context-menu-icon">←</span>
           <span>outdent</span>
         </button>
-        <template v-if="canToggleRender">
+        <template v-if="canToggleRender || canResetSize">
           <div class="context-menu-separator"></div>
-          <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('toggleCodeRender')">
+          <button v-if="canToggleRender" class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('toggleCodeRender')">
             <span class="context-menu-icon">⇄</span>
             <span>{{ isRenderedRaw ? 'show as rendered' : 'show as raw' }}</span>
+          </button>
+          <button v-if="canResetSize" class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('resetSize')">
+            <span class="context-menu-icon">↺</span>
+            <span>reset size</span>
           </button>
         </template>
         <div class="context-menu-separator"></div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -518,14 +518,16 @@ const BlockComponent = {
       // wrapper inside this block, and wire up corner-handle drag.
       // A block has a single properties.size today, so multiple
       // resizables in one block share the same width — fine for the
-      // current shapes (one mermaid wrapper per code block, one image
-      // wrapper per asset block).
+      // current shapes (one mermaid wrapper per block; an asset block
+      // has either an image or a renderable text-shaped asset, never
+      // both).
       if (!this.$el || this.$el.nodeType !== 1) return;
       const savedWidth = this.block.properties?.size?.width;
       const wrappers = this.$el.querySelectorAll(".block-resizable");
       wrappers.forEach((el) => {
         if (savedWidth && !el.dataset.savedSizeApplied) {
           el.style.width = `${savedWidth}px`;
+          el.classList.add("has-saved-size");
           el.dataset.savedSizeApplied = "true";
         }
       });
@@ -562,6 +564,7 @@ const BlockComponent = {
         document.removeEventListener("mousemove", onMove);
         document.removeEventListener("mouseup", onUp);
         handle.classList.remove("is-resizing");
+        wrapper.classList.add("has-saved-size");
         const final = Math.round(wrapper.getBoundingClientRect().width);
         this.setBlockProperties(this.block, { size: { width: final } });
       };

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -1792,17 +1792,6 @@ const BlockComponent = {
           <span class="context-menu-icon">←</span>
           <span>outdent</span>
         </button>
-        <template v-if="canToggleRender || canResetSize">
-          <div class="context-menu-separator"></div>
-          <button v-if="canToggleRender" class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('toggleCodeRender')">
-            <span class="context-menu-icon">⇄</span>
-            <span>{{ isRenderedRaw ? 'show as rendered' : 'show as raw' }}</span>
-          </button>
-          <button v-if="canResetSize" class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('resetSize')">
-            <span class="context-menu-icon">↺</span>
-            <span>reset size</span>
-          </button>
-        </template>
         <div class="context-menu-separator"></div>
         <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('moveUp')">
           <span class="context-menu-icon">↑</span>
@@ -1830,6 +1819,17 @@ const BlockComponent = {
           <span class="context-menu-icon">▤</span>
           <span>attach file…</span>
         </button>
+        <template v-if="canToggleRender || canResetSize">
+          <div class="context-menu-separator"></div>
+          <button v-if="canToggleRender" class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('toggleCodeRender')">
+            <span class="context-menu-icon">⇄</span>
+            <span>{{ isRenderedRaw ? 'show as rendered' : 'show as raw' }}</span>
+          </button>
+          <button v-if="canResetSize" class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('resetSize')">
+            <span class="context-menu-icon">↺</span>
+            <span>reset size</span>
+          </button>
+        </template>
         <div class="context-menu-separator"></div>
         <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('schedule')">
           <span class="context-menu-icon"><svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"><rect x="2" y="3" width="12" height="11" rx="1"/><line x1="2" y1="6.5" x2="14" y2="6.5"/><line x1="5.5" y1="1.5" x2="5.5" y2="4.5"/><line x1="10.5" y1="1.5" x2="10.5" y2="4.5"/></g></svg></span>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -165,10 +165,12 @@ const BlockComponent = {
       return ["mermaid", "csv", "tsv"].includes(lang);
     },
     canToggleAssetRender() {
-      // Asset blocks with a renderable extension (csv, tsv, mmd,
-      // mermaid) get the same toggle so users can swap between the
-      // rendered table/diagram and the plain download chip.
-      return !!this.detectedAssetType;
+      // The toggle applies to anything we render inline — images, plus
+      // the text-shaped types in detectedAssetType. Rule of thumb: if
+      // the asset block has a non-chip default render, expose a way
+      // back to the chip view.
+      if (!this.hasAsset || this.isEmbed) return false;
+      return this.assetIsImage || !!this.detectedAssetType;
     },
     canToggleRender() {
       return this.canToggleCodeRender || this.canToggleAssetRender;
@@ -454,7 +456,11 @@ const BlockComponent = {
     if (this.isEmbed) {
       this.loadWebArchive();
     }
-    if (this.shouldRenderAsset && this.assetSource === null) {
+    if (
+      this.shouldRenderAsset &&
+      this.detectedAssetType &&
+      this.assetSource === null
+    ) {
       this.fetchAssetSource();
     }
     this.applyContentRenderers();
@@ -468,7 +474,11 @@ const BlockComponent = {
     // If the asset just became renderable (e.g. user toggled out of raw,
     // or the asset itself just got attached) and we haven't fetched the
     // bytes yet, kick that off.
-    if (this.shouldRenderAsset && this.assetSource === null) {
+    if (
+      this.shouldRenderAsset &&
+      this.detectedAssetType &&
+      this.assetSource === null
+    ) {
       this.fetchAssetSource();
     }
   },
@@ -1308,7 +1318,7 @@ const BlockComponent = {
         </div>
         <div v-if="hasAsset && !isEmbed" class="block-asset" @click.stop>
           <img
-            v-if="assetIsImage"
+            v-if="assetIsImage && !isRenderedRaw"
             :src="assetUrl"
             :alt="assetDisplayName"
             class="block-asset-image"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -29,6 +29,10 @@ const BlockComponent = {
       type: Function,
       required: true,
     },
+    setBlockProperties: {
+      type: Function,
+      default: () => () => {},
+    },
     formatContentWithTags: {
       type: Function,
       required: true,
@@ -145,6 +149,17 @@ const BlockComponent = {
   computed: {
     blockInContext() {
       return this.isBlockInContext(this.block.uuid);
+    },
+    canToggleCodeRender() {
+      // Only code blocks whose language has a specialized renderer can
+      // toggle between rendered and raw views. Plain code (python, js,
+      // …) always renders the same way, so the toggle would be a no-op.
+      if (this.block.block_type !== "code") return false;
+      const lang = (this.block.properties?.language || "").toLowerCase();
+      return ["mermaid", "csv", "tsv"].includes(lang);
+    },
+    isCodeRenderedRaw() {
+      return this.block.properties?.render === "raw";
     },
     blockSelected() {
       return this.isBlockSelected(this.block.uuid);
@@ -1074,7 +1089,15 @@ const BlockComponent = {
         case "attachFile":
           this.triggerAttachFilePicker();
           break;
+        case "toggleCodeRender":
+          this.toggleCodeRender();
+          break;
       }
+    },
+
+    toggleCodeRender() {
+      const next = this.isCodeRenderedRaw ? "rendered" : "raw";
+      this.setBlockProperties(this.block, { render: next });
     },
 
     triggerAttachFilePicker() {
@@ -1541,6 +1564,13 @@ const BlockComponent = {
           <span class="context-menu-icon">←</span>
           <span>outdent</span>
         </button>
+        <template v-if="canToggleCodeRender">
+          <div class="context-menu-separator"></div>
+          <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('toggleCodeRender')">
+            <span class="context-menu-icon">⇄</span>
+            <span>{{ isCodeRenderedRaw ? 'show as rendered' : 'show as raw' }}</span>
+          </button>
+        </template>
         <div class="context-menu-separator"></div>
         <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('moveUp')">
           <span class="context-menu-icon">↑</span>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/LeftNav.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/LeftNav.js
@@ -20,13 +20,28 @@ window.LeftNav = {
 
   data() {
     const isMobile = typeof window !== "undefined" && window.innerWidth <= 768;
+    // Persist the open/closed pref so a refresh doesn't blow away the
+    // user's choice. First visit (no saved value) still defaults to
+    // open on desktop, closed on mobile.
+    let isOpen = !isMobile;
+    try {
+      const saved =
+        typeof window !== "undefined" && window.localStorage
+          ? window.localStorage.getItem("brainspread.leftNavOpen")
+          : null;
+      if (saved === "1") isOpen = true;
+      else if (saved === "0") isOpen = false;
+    } catch (_) {
+      // localStorage can throw in private mode / disabled-cookie setups.
+      // Fall back to the viewport default.
+    }
     return {
       historicalData: null,
       loading: false,
       error: null,
       daysBack: 30,
       limit: 25,
-      isOpen: !isMobile,
+      isOpen,
       width: 320,
       isResizing: false,
       minWidth: 240,
@@ -95,6 +110,17 @@ window.LeftNav = {
 
     toggleSidebar() {
       this.isOpen = !this.isOpen;
+      try {
+        if (typeof window !== "undefined" && window.localStorage) {
+          window.localStorage.setItem(
+            "brainspread.leftNavOpen",
+            this.isOpen ? "1" : "0"
+          );
+        }
+      } catch (_) {
+        // localStorage can throw in private mode; the toggle still
+        // works for the current session, just won't persist.
+      }
     },
 
     toggleRecent() {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -1009,7 +1009,13 @@ const Page = {
           return `<div class="block-mermaid-wrapper">${langBadge}<div class="block-mermaid" data-mermaid-source="${attrEscaped}"></div></div>`;
         }
         const escaped = escapeHtml(source);
-        return `<div class="block-code-wrapper">${langBadge}<pre class="block-code"><code>${escaped}</code></pre></div>`;
+        // Tag <code> with a Prism language class so the autoloader can
+        // pick up the right grammar after mount. The autoloader fetches
+        // each language file lazily on first use, so unused languages
+        // cost nothing at app boot.
+        const safeLang = lang ? lang.toLowerCase().replace(/[^\w-]/g, "") : "";
+        const langClass = safeLang ? ` class="language-${safeLang}"` : "";
+        return `<div class="block-code-wrapper">${langBadge}<pre class="block-code"><code${langClass}>${escaped}</code></pre></div>`;
       };
 
       // Code-typed blocks render their entire content as a single fenced

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -992,26 +992,29 @@ const Page = {
     formatContentWithTags(content, blockType = null, properties = null) {
       if (!content) return "";
 
-      // Code blocks render as <pre><code> with content escaped and no other
-      // markdown formatting applied. Mermaid is a special case: the source
-      // is stashed on a placeholder element which BlockComponent renders
-      // to SVG via the mermaid library after mount.
-      if (blockType === "code") {
-        const escapeHtml = (s) =>
-          s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-        const lang = properties?.language || "";
+      const escapeHtml = (s) =>
+        s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+      // Render a fenced code block (or a mermaid placeholder when the
+      // language is "mermaid"). Shared between the block-type=code path
+      // and inline ```fences``` inside text-typed blocks.
+      const renderCodeBlock = (source, lang) => {
         const langBadge = lang
           ? `<span class="block-code-lang">${escapeHtml(lang)}</span>`
           : "";
-        if (lang.toLowerCase() === "mermaid") {
-          // Encode the source via attribute escaping. Quotes are the only
-          // characters that need extra handling beyond the standard set
-          // since the value sits inside a double-quoted attribute.
-          const attrEscaped = escapeHtml(content).replace(/"/g, "&quot;");
+        if (lang && lang.toLowerCase() === "mermaid") {
+          const attrEscaped = escapeHtml(source).replace(/"/g, "&quot;");
           return `<div class="block-mermaid-wrapper">${langBadge}<div class="block-mermaid" data-mermaid-source="${attrEscaped}"></div></div>`;
         }
-        const escaped = escapeHtml(content);
+        const escaped = escapeHtml(source);
         return `<div class="block-code-wrapper">${langBadge}<pre class="block-code"><code>${escaped}</code></pre></div>`;
+      };
+
+      // Code-typed blocks render their entire content as a single fenced
+      // block with no other markdown formatting applied.
+      if (blockType === "code") {
+        const lang = properties?.language || "";
+        return renderCodeBlock(content, lang);
       }
 
       let formatted = content;
@@ -1026,6 +1029,24 @@ const Page = {
           ""
         );
       }
+
+      // Extract triple-backtick fenced code blocks BEFORE the single-
+      // backtick span regex below; otherwise the leading ``` gets eaten as
+      // an inline code span and the remaining backticks render as stray
+      // text. The placeholder survives the rest of the markdown
+      // transforms and is restored at the end.
+      const fenceSegments = [];
+      formatted = formatted.replace(
+        /```([^\n`]*)\n([\s\S]*?)```/g,
+        (_match, lang, code) => {
+          const idx = fenceSegments.length;
+          // Drop the trailing newline before the closing fence so the
+          // rendered <pre> doesn't carry an extra blank line.
+          const trimmedCode = code.replace(/\n$/, "");
+          fenceSegments.push({ lang: lang.trim(), code: trimmedCode });
+          return `\x00FENCE${idx}\x00`;
+        }
+      );
 
       // Extract backtick code spans first to protect them from other formatting
       const codeSegments = [];
@@ -1146,6 +1167,14 @@ const Page = {
       // doesn't get re-matched by the hashtag regex).
       escapedChars.forEach((char, idx) => {
         formatted = formatted.split(`\x00ESC${idx}\x00`).join(char);
+      });
+
+      // Restore fenced code blocks last so their inner content was never
+      // run through any of the markdown transforms above.
+      fenceSegments.forEach((seg, idx) => {
+        formatted = formatted
+          .split(`\x00FENCE${idx}\x00`)
+          .join(renderCodeBlock(seg.code, seg.lang));
       });
 
       return formatted;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -997,23 +997,38 @@ const Page = {
       const escapeHtml = (s) =>
         s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
-      // Render a fenced code block (or a mermaid placeholder when the
-      // language is "mermaid"). Shared between the block-type=code path
-      // and inline ```fences``` inside text-typed blocks.
+      // Render a fenced code block. Recognized languages (mermaid, csv,
+      // tsv) get specialized rendering; everything else falls through to
+      // <pre><code> tagged for Prism syntax highlighting.
       const renderCodeBlock = (source, lang) => {
+        const langLower = lang ? lang.toLowerCase() : "";
         const langBadge = lang
           ? `<span class="block-code-lang">${escapeHtml(lang)}</span>`
           : "";
-        if (lang && lang.toLowerCase() === "mermaid") {
+        if (langLower === "mermaid") {
           const attrEscaped = escapeHtml(source).replace(/"/g, "&quot;");
           return `<div class="block-mermaid-wrapper">${langBadge}<div class="block-mermaid" data-mermaid-source="${attrEscaped}"></div></div>`;
+        }
+        if (
+          (langLower === "csv" || langLower === "tsv") &&
+          window.brainspreadCsv
+        ) {
+          const tableHtml = window.brainspreadCsv.renderCsvTable(
+            source,
+            langLower === "tsv" ? "\t" : ","
+          );
+          if (tableHtml) {
+            return `<div class="block-csv-wrapper">${langBadge}${tableHtml}</div>`;
+          }
+          // Empty/invalid CSV — fall through to the plain code rendering
+          // below so the user still sees their source.
         }
         const escaped = escapeHtml(source);
         // Tag <code> with a Prism language class so the autoloader can
         // pick up the right grammar after mount. The autoloader fetches
         // each language file lazily on first use, so unused languages
         // cost nothing at app boot.
-        const safeLang = lang ? lang.toLowerCase().replace(/[^\w-]/g, "") : "";
+        const safeLang = langLower.replace(/[^\w-]/g, "");
         const langClass = safeLang ? ` class="language-${safeLang}"` : "";
         return `<div class="block-code-wrapper">${langBadge}<pre class="block-code"><code${langClass}>${escaped}</code></pre></div>`;
       };

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -1702,8 +1702,9 @@ const Page = {
         }
 
         if (fenceMatch) {
-          // Opening fence: only intercept if we've started processing a list
-          if (!sawFirstNonEmpty) return [];
+          // Opening fence — accept this as the start of a list-style paste
+          // even when no bullet has been seen yet, so a bare ```lang
+          // fenced block (e.g. ```mermaid) round-trips into a code block.
           const leading = fenceMatch[1];
           codeFenceOpen = true;
           codeFenceIndentStr = leading;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -387,8 +387,14 @@ const Page = {
     async setBlockProperties(block, partial) {
       // Shallow-merge `partial` into the block's existing properties
       // (so toggling one flag doesn't drop the others) and persist.
-      // Used by the context-menu render toggle for code blocks.
+      // Pass a key with `null` to clear it — useful for "reset size"
+      // and similar opt-outs.
       const merged = { ...(block.properties || {}), ...partial };
+      Object.keys(merged).forEach((key) => {
+        if (merged[key] === null || merged[key] === undefined) {
+          delete merged[key];
+        }
+      });
       try {
         const result = await window.apiService.updateBlock(block.uuid, {
           properties: merged,

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -384,6 +384,25 @@ const Page = {
       }
     },
 
+    async setBlockProperties(block, partial) {
+      // Shallow-merge `partial` into the block's existing properties
+      // (so toggling one flag doesn't drop the others) and persist.
+      // Used by the context-menu render toggle for code blocks.
+      const merged = { ...(block.properties || {}), ...partial };
+      try {
+        const result = await window.apiService.updateBlock(block.uuid, {
+          properties: merged,
+        });
+        if (result.success) {
+          block.properties = merged;
+        } else {
+          console.error("failed to update block properties:", result.errors);
+        }
+      } catch (error) {
+        console.error("failed to update block properties:", error);
+      }
+    },
+
     async updateBlock(block, newContent, skipReload = false) {
       try {
         const result = await window.apiService.updateBlock(block.uuid, {
@@ -999,17 +1018,20 @@ const Page = {
 
       // Render a fenced code block. Recognized languages (mermaid, csv,
       // tsv) get specialized rendering; everything else falls through to
-      // <pre><code> tagged for Prism syntax highlighting.
-      const renderCodeBlock = (source, lang) => {
+      // <pre><code> tagged for Prism syntax highlighting. `forceRaw`
+      // suppresses the specialized renderers so the toggle in the block
+      // menu can fall back to the plain code view.
+      const renderCodeBlock = (source, lang, forceRaw = false) => {
         const langLower = lang ? lang.toLowerCase() : "";
         const langBadge = lang
           ? `<span class="block-code-lang">${escapeHtml(lang)}</span>`
           : "";
-        if (langLower === "mermaid") {
+        if (!forceRaw && langLower === "mermaid") {
           const attrEscaped = escapeHtml(source).replace(/"/g, "&quot;");
           return `<div class="block-mermaid-wrapper">${langBadge}<div class="block-mermaid" data-mermaid-source="${attrEscaped}"></div></div>`;
         }
         if (
+          !forceRaw &&
           (langLower === "csv" || langLower === "tsv") &&
           window.brainspreadCsv
         ) {
@@ -1037,7 +1059,8 @@ const Page = {
       // block with no other markdown formatting applied.
       if (blockType === "code") {
         const lang = properties?.language || "";
-        return renderCodeBlock(content, lang);
+        const forceRaw = properties?.render === "raw";
+        return renderCodeBlock(content, lang, forceRaw);
       }
 
       let formatted = content;
@@ -2894,6 +2917,7 @@ const Page = {
                 :stopEditing="stopEditing"
                 :deleteBlock="deleteBlock"
                 :toggleBlockTodo="toggleBlockTodo"
+                :setBlockProperties="setBlockProperties"
                 :formatContentWithTags="formatContentWithTags"
                 :isBlockInContext="isBlockInContext"
                 :isBlockSelected="isBlockSelected"
@@ -2931,6 +2955,7 @@ const Page = {
               :stopEditing="stopEditing"
               :deleteBlock="deleteBlock"
               :toggleBlockTodo="toggleBlockTodo"
+              :setBlockProperties="setBlockProperties"
               :formatContentWithTags="formatContentWithTags"
               :isBlockInContext="isBlockInContext"
               :isBlockSelected="isBlockSelected"
@@ -2979,6 +3004,7 @@ const Page = {
                 :stopEditing="stopEditing"
                 :deleteBlock="deleteBlock"
                 :toggleBlockTodo="toggleBlockTodo"
+                :setBlockProperties="setBlockProperties"
                 :formatContentWithTags="formatContentWithTags"
                 :isBlockInContext="isBlockInContext"
                 :isBlockSelected="isBlockSelected"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -1020,15 +1020,29 @@ const Page = {
       // tsv) get specialized rendering; everything else falls through to
       // <pre><code> tagged for Prism syntax highlighting. `forceRaw`
       // suppresses the specialized renderers so the toggle in the block
-      // menu can fall back to the plain code view.
-      const renderCodeBlock = (source, lang, forceRaw = false) => {
+      // menu can fall back to the plain code view. `resizable` adds a
+      // corner drag-handle on the mermaid wrapper — only meaningful for
+      // code-typed blocks where the block-level properties.size has
+      // somewhere to land.
+      const renderCodeBlock = (
+        source,
+        lang,
+        forceRaw = false,
+        resizable = false
+      ) => {
         const langLower = lang ? lang.toLowerCase() : "";
         const langBadge = lang
           ? `<span class="block-code-lang">${escapeHtml(lang)}</span>`
           : "";
         if (!forceRaw && langLower === "mermaid") {
           const attrEscaped = escapeHtml(source).replace(/"/g, "&quot;");
-          return `<div class="block-mermaid-wrapper">${langBadge}<div class="block-mermaid" data-mermaid-source="${attrEscaped}"></div></div>`;
+          const wrapperClass = resizable
+            ? "block-mermaid-wrapper block-resizable"
+            : "block-mermaid-wrapper";
+          const handle = resizable
+            ? '<div class="block-resize-handle" aria-hidden="true"></div>'
+            : "";
+          return `<div class="${wrapperClass}">${langBadge}<div class="block-mermaid" data-mermaid-source="${attrEscaped}"></div>${handle}</div>`;
         }
         if (
           !forceRaw &&
@@ -1056,11 +1070,13 @@ const Page = {
       };
 
       // Code-typed blocks render their entire content as a single fenced
-      // block with no other markdown formatting applied.
+      // block with no other markdown formatting applied. The wrapper is
+      // resizable (mermaid only) since the block-level properties.size
+      // has somewhere to land.
       if (blockType === "code") {
         const lang = properties?.language || "";
         const forceRaw = properties?.render === "raw";
-        return renderCodeBlock(content, lang, forceRaw);
+        return renderCodeBlock(content, lang, forceRaw, true);
       }
 
       let formatted = content;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -968,15 +968,24 @@ const Page = {
       if (!content) return "";
 
       // Code blocks render as <pre><code> with content escaped and no other
-      // markdown formatting applied.
+      // markdown formatting applied. Mermaid is a special case: the source
+      // is stashed on a placeholder element which BlockComponent renders
+      // to SVG via the mermaid library after mount.
       if (blockType === "code") {
         const escapeHtml = (s) =>
           s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-        const escaped = escapeHtml(content);
         const lang = properties?.language || "";
         const langBadge = lang
           ? `<span class="block-code-lang">${escapeHtml(lang)}</span>`
           : "";
+        if (lang.toLowerCase() === "mermaid") {
+          // Encode the source via attribute escaping. Quotes are the only
+          // characters that need extra handling beyond the standard set
+          // since the value sits inside a double-quoted attribute.
+          const attrEscaped = escapeHtml(content).replace(/"/g, "&quot;");
+          return `<div class="block-mermaid-wrapper">${langBadge}<div class="block-mermaid" data-mermaid-source="${attrEscaped}"></div></div>`;
+        }
+        const escaped = escapeHtml(content);
         return `<div class="block-code-wrapper">${langBadge}<pre class="block-code"><code>${escaped}</code></pre></div>`;
       }
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -1216,11 +1216,16 @@ const Page = {
       });
 
       // Restore fenced code blocks last so their inner content was never
-      // run through any of the markdown transforms above.
+      // run through any of the markdown transforms above. The block's
+      // properties.render flag forces every inline fence in the block to
+      // its raw view together — that's the granularity the context-menu
+      // toggle operates at, since one block can hold several fences and
+      // toggling them individually would need per-fence UI.
+      const inlineForceRaw = properties?.render === "raw";
       fenceSegments.forEach((seg, idx) => {
         formatted = formatted
           .split(`\x00FENCE${idx}\x00`)
-          .join(renderCodeBlock(seg.code, seg.lang));
+          .join(renderCodeBlock(seg.code, seg.lang, inlineForceRaw));
       });
 
       return formatted;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -431,6 +431,12 @@ const Page = {
 
       if (!confirmed) return;
 
+      // Mark the block as being deleted before we hit the API so any
+      // blur-triggered stopEditing -> updateBlock that races with the
+      // delete becomes a no-op. The blur can fire when the confirm()
+      // dialog steals focus, or when loadPage() rerenders the tree.
+      this.deletingBlocks.add(block.uuid);
+
       try {
         const result = await window.apiService.deleteBlock(block.uuid);
         if (result.success) {
@@ -439,13 +445,16 @@ const Page = {
       } catch (error) {
         console.error("failed to delete block:", error);
         this.error = "failed to delete block";
+      } finally {
+        // Hold the guard briefly so any in-flight blur handlers that
+        // queued after the delete still see the block as "deleting".
+        setTimeout(() => {
+          this.deletingBlocks.delete(block.uuid);
+        }, 100);
       }
     },
 
     async deleteEmptyBlock(block) {
-      // Mark block as being deleted to prevent save conflicts
-      this.deletingBlocks.add(block.uuid);
-
       // Find the previous block to focus after deletion
       const previousBlock = this.findPreviousBlock(block);
 
@@ -473,13 +482,6 @@ const Page = {
         }
       } catch (error) {
         console.error("Failed to delete empty block:", error);
-        // Remove from deleting set on error
-        this.deletingBlocks.delete(block.uuid);
-      } finally {
-        // Clean up tracking after a delay to ensure blur events have processed
-        setTimeout(() => {
-          this.deletingBlocks.delete(block.uuid);
-        }, 100);
       }
     },
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -1236,12 +1236,14 @@ const Page = {
       // properties.render flag forces every inline fence in the block to
       // its raw view together — that's the granularity the context-menu
       // toggle operates at, since one block can hold several fences and
-      // toggling them individually would need per-fence UI.
+      // toggling them individually would need per-fence UI. Same story
+      // for resize: every inline mermaid fence in the block shares the
+      // block-level properties.size.
       const inlineForceRaw = properties?.render === "raw";
       fenceSegments.forEach((seg, idx) => {
         formatted = formatted
           .split(`\x00FENCE${idx}\x00`)
-          .join(renderCodeBlock(seg.code, seg.lang, inlineForceRaw));
+          .join(renderCodeBlock(seg.code, seg.lang, inlineForceRaw, true));
       });
 
       return formatted;

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/csv.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/csv.js
@@ -1,0 +1,108 @@
+// CSV parsing for the block renderer. Handles RFC 4180 basics:
+//   - fields separated by `delimiter` (defaults to comma)
+//   - records separated by LF or CRLF
+//   - fields containing the delimiter, a newline, or a double quote
+//     must be wrapped in double quotes
+//   - an embedded double quote inside a quoted field is escaped as ""
+//
+// Stays under 100 lines so it can live alongside the rest of the
+// vanilla-JS service files without a build step.
+
+(function () {
+  function parseCsv(text, delimiter) {
+    const sep = delimiter || ",";
+    const rows = [];
+    let row = [];
+    let field = "";
+    let inQuotes = false;
+    let i = 0;
+    const n = text.length;
+    while (i < n) {
+      const c = text[i];
+      if (inQuotes) {
+        if (c === '"') {
+          if (text[i + 1] === '"') {
+            field += '"';
+            i += 2;
+            continue;
+          }
+          inQuotes = false;
+          i++;
+          continue;
+        }
+        field += c;
+        i++;
+        continue;
+      }
+      if (c === '"') {
+        inQuotes = true;
+        i++;
+        continue;
+      }
+      if (c === sep) {
+        row.push(field);
+        field = "";
+        i++;
+        continue;
+      }
+      if (c === "\r") {
+        if (text[i + 1] === "\n") i++;
+        row.push(field);
+        field = "";
+        rows.push(row);
+        row = [];
+        i++;
+        continue;
+      }
+      if (c === "\n") {
+        row.push(field);
+        field = "";
+        rows.push(row);
+        row = [];
+        i++;
+        continue;
+      }
+      field += c;
+      i++;
+    }
+    if (field !== "" || row.length > 0) {
+      row.push(field);
+      rows.push(row);
+    }
+    return rows;
+  }
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+
+  // Render parsed CSV rows as a <table> string. The first row is
+  // treated as the header — that matches the most common authoring
+  // convention and is the only sensible default; users who don't want
+  // a header can toggle the block to raw.
+  function renderCsvTable(text, delimiter) {
+    const rows = parseCsv(text, delimiter);
+    if (rows.length === 0) return "";
+    const [header, ...body] = rows;
+    const headHtml = `<thead><tr>${header
+      .map((c) => `<th>${escapeHtml(c)}</th>`)
+      .join("")}</tr></thead>`;
+    const bodyHtml = body.length
+      ? `<tbody>${body
+          .map(
+            (r) =>
+              `<tr>${r.map((c) => `<td>${escapeHtml(c)}</td>`).join("")}</tr>`
+          )
+          .join("")}</tbody>`
+      : "";
+    return `<div class="block-csv-scroll"><table class="block-csv">${headHtml}${bodyHtml}</table></div>`;
+  }
+
+  window.brainspreadCsv = {
+    parseCsv,
+    renderCsvTable,
+  };
+})();

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/mermaid.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/mermaid.js
@@ -1,0 +1,102 @@
+// Mermaid diagram integration for the knowledge app.
+//
+// Code blocks with language "mermaid" are rendered to an inline SVG via
+// the global `mermaid` library loaded from CDN. The block formatter in
+// Page.js emits a placeholder element with the source stashed in a
+// data attribute; this helper finds those placeholders inside a DOM
+// subtree and replaces them with the rendered SVG.
+
+(function () {
+  let initialized = false;
+  let currentMermaidTheme = null;
+
+  // Map the app's user-facing themes to mermaid's built-in themes. Mermaid
+  // ships with `default`, `dark`, `forest`, and `neutral`. Anything that
+  // isn't obviously light gets the dark mermaid theme so contrast stays
+  // readable on dark backgrounds.
+  function mermaidThemeFor(appTheme) {
+    if (appTheme === "light") return "default";
+    if (appTheme === "forest") return "forest";
+    return "dark";
+  }
+
+  function ensureInitialized(appTheme) {
+    if (!window.mermaid) return false;
+    const theme = mermaidThemeFor(appTheme);
+    if (initialized && theme === currentMermaidTheme) return true;
+    window.mermaid.initialize({
+      startOnLoad: false,
+      theme,
+      // strict mode disables HTML in labels and click events, which keeps
+      // user-authored diagrams from injecting markup into the page.
+      securityLevel: "strict",
+      fontFamily: 'system-ui, -apple-system, "Segoe UI", sans-serif',
+    });
+    initialized = true;
+    currentMermaidTheme = theme;
+    return true;
+  }
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+
+  async function renderOne(el) {
+    const source = el.dataset.mermaidSource || "";
+    if (!source.trim()) {
+      el.dataset.mermaidRendered = "true";
+      return;
+    }
+    const id = `mermaid-${Math.random().toString(36).slice(2, 11)}`;
+    try {
+      const { svg } = await window.mermaid.render(id, source);
+      el.innerHTML = svg;
+      el.dataset.mermaidRendered = "true";
+    } catch (err) {
+      const msg = err && err.message ? err.message : String(err);
+      el.innerHTML = `<div class="block-mermaid-error">mermaid error: ${escapeHtml(
+        msg
+      )}</div>`;
+      el.dataset.mermaidRendered = "error";
+    }
+  }
+
+  // Render any mermaid placeholders inside `rootEl` that haven't been
+  // processed yet. Safe to call repeatedly — already-rendered diagrams
+  // are skipped via the `data-mermaid-rendered` marker. Block components
+  // are recursive, so a parent's `$el` overlaps its children's; the
+  // "pending" marker is set synchronously to keep two concurrent calls
+  // from rendering the same element twice.
+  async function renderIn(rootEl, appTheme) {
+    if (!rootEl || !ensureInitialized(appTheme)) return;
+    const els = rootEl.querySelectorAll(
+      ".block-mermaid:not([data-mermaid-rendered])"
+    );
+    for (const el of els) {
+      el.dataset.mermaidRendered = "pending";
+      await renderOne(el);
+    }
+  }
+
+  // Re-render every mermaid diagram on the page. Used after a theme
+  // change so existing SVGs pick up the new color palette.
+  async function rerenderAll(appTheme) {
+    if (!window.mermaid) return;
+    initialized = false; // force re-initialize with new theme
+    if (!ensureInitialized(appTheme)) return;
+    const els = document.querySelectorAll(".block-mermaid");
+    for (const el of els) {
+      el.removeAttribute("data-mermaid-rendered");
+      el.innerHTML = "";
+      await renderOne(el);
+    }
+  }
+
+  window.brainspreadMermaid = {
+    renderIn,
+    rerenderAll,
+  };
+})();

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/mermaid.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/mermaid.js
@@ -10,13 +10,17 @@
   let initialized = false;
   let currentMermaidTheme = null;
 
-  // Map the app's user-facing themes to mermaid's built-in themes. Mermaid
-  // ships with `default`, `dark`, `forest`, and `neutral`. Anything that
-  // isn't obviously light gets the dark mermaid theme so contrast stays
-  // readable on dark backgrounds.
+  // Map the app's user-facing themes to mermaid's built-in themes.
+  // Mermaid ships with `default` (dark-on-light), `dark`
+  // (light-on-dark), `forest`, and `neutral`. Pick the variant whose
+  // foreground contrasts with the app theme's background — picking the
+  // wrong one leaves the diagram lines almost invisible (e.g. earthy's
+  // cream background under mermaid's dark theme).
+  const LIGHT_BG_THEMES = new Set(["light", "earthy"]);
+
   function mermaidThemeFor(appTheme) {
-    if (appTheme === "light") return "default";
     if (appTheme === "forest") return "forest";
+    if (LIGHT_BG_THEMES.has(appTheme)) return "default";
     return "dark";
   }
 

--- a/packages/django-app/app/knowledge/templates/knowledge/base.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/base.html
@@ -30,6 +30,7 @@
     <!-- API Service -->
     <script src="{% static 'knowledge/js/services/api.js' %}?v={{ STATIC_VERSION }}"></script>
     <script src="{% static 'knowledge/js/services/mermaid.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/services/csv.js' %}?v={{ STATIC_VERSION }}"></script>
 
     <!-- Vue Components -->
     <script src="{% static 'knowledge/js/components/BlockComponent.js' %}?v={{ STATIC_VERSION }}"></script>

--- a/packages/django-app/app/knowledge/templates/knowledge/base.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/base.html
@@ -21,11 +21,15 @@
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-core.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 
+    <!-- Mermaid diagram rendering -->
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+
     <!-- Prism CSS Theme -->
     <link href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
     <!-- API Service -->
     <script src="{% static 'knowledge/js/services/api.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/services/mermaid.js' %}?v={{ STATIC_VERSION }}"></script>
 
     <!-- Vue Components -->
     <script src="{% static 'knowledge/js/components/BlockComponent.js' %}?v={{ STATIC_VERSION }}"></script>


### PR DESCRIPTION
Closes #74

## Summary
Started as mermaid diagram rendering for fenced code blocks; grew into a small dynamic-renderer pipeline shared by both fenced code blocks and uploaded text-shaped assets, plus a handful of fixes that came up while testing it.

## Code-block / fenced-block rendering
- **Mermaid**: ` ```mermaid ` blocks render as inline SVG via the mermaid library (loaded from CDN, initialized in strict mode so user-authored diagrams can't inject markup). App-theme → mermaid-theme mapping (light → `default`, forest → `forest`, others → `dark`); diagrams re-render automatically on theme change so colors stay in sync.
- **PrismJS syntax highlighting**: Prism was already loaded but unused in the main app. Code blocks with a language now emit `<code class="language-{lang}">` and Prism's autoloader fetches each grammar lazily on first use — "all languages" costs nothing at boot.
- **CSV / TSV → `<table>`**: small RFC 4180 parser in `services/csv.js`. The first row is treated as the header. Falls back to raw code rendering for empty/unparseable input.
- **Triple-backtick fences inside text blocks**: extracted before the inline-code regex so the leading ` ``` ` no longer gets eaten by single-backtick handling. Inline mermaid/csv fences pick up the same renderers as code-typed blocks.
- **Bare fenced-code paste**: the list-paste handler used to bail when a paste's first non-empty line was a fence. Now a fence-led paste also activates the parser and lands as a proper `code` block — which is the only path that the mermaid/csv/etc renderers hook into.

## Asset-upload rendering
- **`.mmd` / `.mermaid` / `.md` / `.markdown`**: form normalizes browser-sent `application/octet-stream` to the right `text/*` MIME so the upload passes the existing whitelist; tests cover both paths.
- **Inline render of asset bytes**: asset blocks whose original filename matches a known extension fetch the bytes after mount and render inline:
  - `.csv` / `.tsv` → `<table>`
  - `.mmd` / `.mermaid` → mermaid SVG (via the existing placeholder + lifecycle)
  - `.md` / `.markdown` → HTML via `marked.parse(text, { gfm, breaks })` → `DOMPurify.sanitize(...)`
- Fetch is same-origin so the Django session cookie carries the auth.

## Show-as-raw toggle
- Code blocks (mermaid/csv/tsv) and asset blocks (csv/mmd/markdown) gain a "show as raw / show as rendered" entry in the context menu.
- Stored as `properties.render = "raw" | "rendered"` so the choice persists across reloads.
- Plain code blocks (python, js, …) don't show the toggle since the render is the same either way.

## Bug fixes that came along for the ride
- **Auth on asset images** (`/me/` session refresh): API tokens never expired but Django's session cookie did at the 2-week default. `<img src="/api/assets/.../">` can only authenticate via the cookie, so images would silently 401 until the user logged out and back in. `/me/` (which the frontend hits on every app boot) now re-issues the session cookie when the caller authed via token without a live session, so images stay authenticated as long as the app gets opened at least once every two weeks.
- **Save-after-delete race on the menu-driven delete**: `deleteBlock` didn't add the block to `deletingBlocks`, so a blur-triggered `stopEditing → updateBlock` (fired when the `confirm()` dialog steals focus and again when `loadPage()` rerenders) hit the deleted UUID and surfaced as 4xx/5xx in the network log. Hoisted the guard out of `deleteEmptyBlock` so both delete paths suppress the racing update.
- **Left nav state persists** across refreshes via `localStorage`. First-visit defaults are unchanged (open on desktop, closed on mobile).

## Test plan
- [x] `just test` (covers added asset-upload tests for `.mmd` / `.mermaid` / `.md` / `.markdown` and the `/me/` session-refresh test)
- [x] paste a ` ```mermaid ` fenced block → renders as SVG
- [x] paste a ` ```python ` block → highlighted by Prism
- [x] paste a ` ```csv ` block → renders as a table
- [x] right-click any of the above → "show as raw" flips to source view; flipping back doesn't re-fetch
- [x] upload a `.csv`, `.md`, and `.mmd` file → each renders inline; the menu toggle still works
- [ ] switch theme → existing mermaid diagrams re-render with the new palette
- [ ] close the left nav, refresh → it stays closed
- [ ] delete a block via the context menu → no follow-up 4xx update on the deleted UUID

https://claude.ai/code/session_01HH96ydLzpe5AE1hppQ15iC