### PR TITLE
tldraw upload via assets + emit visible-blocks-changed for ctx picker

### DIFF
--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -253,6 +253,13 @@ const Page = {
           this.referencedBlocks = result.data.referenced_blocks || [];
           this.overdueBlocks = result.data.overdue_blocks || [];
           this.$emit("page-loaded", this.page);
+          // Flatten the block tree for consumers (e.g. ChatPanel's
+          // ctx picker) that want a single list of every block on
+          // the page, not just the root level.
+          this.$emit(
+            "visible-blocks-changed",
+            this.flattenBlockTree(this.directBlocks)
+          );
         } else {
           this.error = "failed to load page";
         }
@@ -286,6 +293,24 @@ const Page = {
 
         return block;
       });
+    },
+
+    flattenBlockTree(blocks) {
+      // Pre-order walk: root first, then its descendants, then the
+      // next sibling. ChatPanel's ctx picker uses this list so users
+      // can attach a deeply-nested block to context without first
+      // expanding it on the page.
+      const out = [];
+      const walk = (items) => {
+        for (const block of items || []) {
+          out.push(block);
+          if (block.children && block.children.length) {
+            walk(block.children);
+          }
+        }
+      };
+      walk(blocks);
+      return out;
     },
 
     async createBlock(

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Whiteboard.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Whiteboard.js
@@ -114,8 +114,39 @@ const Whiteboard = {
       this._reactRoot.render(
         React.createElement(Tldraw, {
           onMount: this.onTldrawMount,
+          // Route paste/drop image uploads through our /api/assets/
+          // endpoint so the bytes live in the Asset table (with
+          // sha256 dedupe + per-user owner check) instead of being
+          // serialized as a base64 data URL inside the snapshot
+          // JSON. Without this every pasted image bloats
+          // Page.whiteboard_snapshot.
+          assets: this.buildAssetStore(),
         })
       );
+    },
+
+    buildAssetStore() {
+      // tldraw v3 AssetStore: { upload, resolve, [remove] }.
+      // - upload(asset, file): persist the bytes, return { src }.
+      //   tldraw pre-generates an `asset` object with type +
+      //   placeholder src; we ignore it and just upload the file.
+      // - resolve(asset): return the URL tldraw should render. With
+      //   our `src` already stored, this is just identity.
+      const apiService = window.apiService;
+      return {
+        upload: async (asset, file) => {
+          // Older tldraw signatures swapped the order; handle both.
+          const f = file instanceof File ? file : asset;
+          const res = await apiService.uploadAsset(f, {
+            assetType: "whiteboard_asset",
+          });
+          if (!res?.success || !res?.data?.uuid) {
+            throw new Error("Whiteboard asset upload failed");
+          }
+          return { src: apiService.assetServeUrl(res.data.uuid) };
+        },
+        resolve: async (asset) => asset?.props?.src || null,
+      };
     },
 
     onTldrawMount(editor) {

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -629,15 +629,50 @@ class ApiService {
       body: form,
       credentials: "include",
     });
-    const data = await response.json();
+
+    // The server always returns JSON on the happy path; non-JSON
+    // responses come from nginx / Django debug pages when something
+    // intercepted the request before Django could format an error
+    // (most commonly: nginx client_max_body_size truncating a large
+    // phone-camera JPEG into a 413). Try JSON first, fall back to a
+    // status-aware message so users don't see "Unexpected token '<'".
+    const contentType = response.headers.get("Content-Type") || "";
+    const looksJson = contentType.includes("application/json");
+    let data = null;
+    if (looksJson) {
+      try {
+        data = await response.json();
+      } catch (_) {
+        data = null;
+      }
+    }
+
     if (!response.ok) {
-      const msg =
-        data?.errors?.file?.[0] ||
-        data?.errors?.non_field_errors?.[0] ||
-        "Upload failed";
-      throw new Error(msg);
+      const fromJson =
+        data?.errors?.file?.[0] || data?.errors?.non_field_errors?.[0];
+      throw new Error(fromJson || this._uploadStatusMessage(response.status));
+    }
+
+    if (!data) {
+      // 200 OK but the body wasn't JSON - shouldn't happen with our
+      // own view, but cover it defensively rather than crashing.
+      throw new Error(
+        "Upload succeeded but the server returned an unexpected response"
+      );
     }
     return data;
+  }
+
+  _uploadStatusMessage(status) {
+    if (status === 401) return "Not signed in. Try logging out and back in.";
+    if (status === 403)
+      return "Upload rejected by the server (CSRF or permission issue).";
+    if (status === 413)
+      return "File too large for the server. Try a smaller image, or ask the admin to raise the upload limit.";
+    if (status === 415) return "Unsupported file type.";
+    if (status >= 500)
+      return `Upload failed (${status}). The server hit an error - check the logs.`;
+    return `Upload failed (${status}).`;
   }
 
   // URL the browser hits to render an asset's bytes. The endpoint


### PR DESCRIPTION
## Summary

Two follow-on fixes after PR #93:

- **Wire tldraw uploads through `/api/assets/`.** New paste / drop image uploads inside a whiteboard now persist into the `Asset` table (`asset_type=whiteboard_asset`) with sha256 dedupe + per-user owner check, and the snapshot JSON only stores the serve URL — base64 bloat in `Page.whiteboard_snapshot` stops growing on every paste. No backfill: prod has no real whiteboards and existing base64-snapshot blocks keep rendering.
- **Actually fire `visible-blocks-changed` from Page on load.** The event was declared in `emits` but never emitted, so `app.js`'s `visibleBlocks` stayed `[]` and the chat panel's `ctx` block-picker always said "No blocks on this page yet" even when the page had blocks. Page now emits a flattened pre-order walk of the block tree after loadPage so the picker can show every block, including nested ones, without the user expanding them first.

## Test plan

- [ ] `just prepush` (no new tests — both fixes are wiring; manual verification covers them).
- [ ] On staging, open a whiteboard page, paste an image onto the canvas. Confirm:
  - The image renders.
  - `/admin/assets/asset/` lists a new `whiteboard_asset` row.
  - The page's `whiteboard_snapshot` contains a `/api/assets/<uuid>/` URL rather than `data:image/...;base64,…`.
- [ ] On any non-whiteboard page with at least one block, click the chat panel's `ctx` button. Confirm the popover lists each block, including nested ones, and that toggling rows adds / removes them from chat context.

https://claude.ai/code/session_017AwqGoJXZNWNT2gEREZjDK

---
_Generated by [Claude Code](https://claude.ai/code/session_017AwqGoJXZNWNT2gEREZjDK)_