### PR TITLE
Add public page sharing (closes #90)

### DIFF
--- a/packages/django-app/app/knowledge/static/knowledge/css/public_page.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/public_page.css
@@ -205,6 +205,36 @@ body {
   font-style: italic;
 }
 
+.public-references {
+  margin-top: 32px;
+  padding-top: 18px;
+  border-top: 1px solid #e1e4e8;
+}
+
+.public-references-title {
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b7280;
+}
+
+.public-reference {
+  padding-left: 0;
+}
+
+.public-reference::before {
+  content: "";
+}
+
+.public-reference-source {
+  font-size: 12px;
+  color: #6b7280;
+  margin-bottom: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
 .public-page-footer {
   margin-top: 48px;
   padding-top: 16px;
@@ -266,5 +296,12 @@ body {
   }
   .public-block-type-quote {
     border-left-color: #30363d;
+  }
+  .public-references {
+    border-top-color: #30363d;
+  }
+  .public-references-title,
+  .public-reference-source {
+    color: #8b949e;
   }
 }

--- a/packages/django-app/app/knowledge/templates/knowledge/public_page.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/public_page.html
@@ -23,8 +23,33 @@
         <ul class="public-block-list">
           {% include 'knowledge/_public_block_list.html' with blocks=blocks %}
         </ul>
-      {% else %}
+      {% elif not references %}
         <p class="public-page-empty">This page has no content yet.</p>
+      {% endif %}
+
+      {% if references %}
+        <section class="public-references">
+          <h2 class="public-references-title">linked references</h2>
+          <ul class="public-block-list public-references-list">
+            {% for ref in references %}
+              <li class="public-block public-block-type-{{ ref.block_type }} public-reference">
+                <div class="public-reference-source">
+                  {% if ref.source_page_type == 'daily' and ref.source_page_date %}
+                    {{ ref.source_page_date }}
+                  {% else %}
+                    {{ ref.source_page_title }}
+                  {% endif %}
+                </div>
+                {% if ref.asset_is_image and ref.asset_url %}
+                  <img class="public-block-image" src="{{ ref.asset_url }}" alt="" loading="lazy" />
+                {% elif ref.content_type == 'image' and ref.media_url %}
+                  <img class="public-block-image" src="{{ ref.media_url }}" alt="" loading="lazy" />
+                {% endif %}
+                <div class="public-block-content" data-md="{{ ref.content }}">{{ ref.content }}</div>
+              </li>
+            {% endfor %}
+          </ul>
+        </section>
       {% endif %}
 
       <footer class="public-page-footer">

--- a/packages/django-app/app/knowledge/test/views/test_share_page_api.py
+++ b/packages/django-app/app/knowledge/test/views/test_share_page_api.py
@@ -99,6 +99,66 @@ class PublicPageViewTestCase(TestCase):
         # specific recipient, not for search engines.
         self.assertIn("noindex", body)
 
+    def test_public_view_includes_linked_references(self):
+        # Topic / tag-style pages live on tagged blocks scattered across
+        # daily notes. Sharing the topic page should surface those
+        # references — without them a #food-log share would be empty.
+        from datetime import date
+
+        self.page.share_token = "tag-share-token"
+        self.page.share_mode = "link"
+        self.page.save()
+
+        daily = PageFactory(
+            user=self.user,
+            title="2026-04-30",
+            slug="2026-04-30",
+            page_type="daily",
+            date=date(2026, 4, 30),
+        )
+        tagged_block = BlockFactory(
+            user=self.user,
+            page=daily,
+            content="ate spaghetti #food-log",
+            order=0,
+        )
+        tagged_block.pages.add(self.page)
+
+        client = Client()
+        response = client.get(f"/knowledge/share/{self.page.share_token}/")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode("utf-8")
+        self.assertIn("ate spaghetti", body)
+        self.assertIn("linked references", body)
+        # Source-page label uses the daily's date, not its raw title.
+        self.assertIn("2026-04-30", body)
+
+    def test_public_view_excludes_blocks_tagged_with_other_pages(self):
+        # A block tagged only with a different page must not leak just
+        # because both pages belong to the same user.
+        self.page.share_token = "scope-token"
+        self.page.share_mode = "link"
+        self.page.save()
+
+        unrelated_topic = PageFactory(
+            user=self.user, title="Other Topic", slug="other-topic"
+        )
+        other_block = BlockFactory(
+            user=self.user,
+            page=PageFactory(user=self.user, title="diary", slug="diary"),
+            content="secret diary entry",
+            order=0,
+        )
+        other_block.pages.add(unrelated_topic)
+
+        client = Client()
+        response = client.get(f"/knowledge/share/{self.page.share_token}/")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode("utf-8")
+        self.assertNotIn("secret diary entry", body)
+
 
 class PublicAssetViewTestCase(TestCase):
     @classmethod
@@ -184,6 +244,43 @@ class PublicAssetViewTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b"fake-inline-bytes")
+
+    def test_serves_asset_attached_to_a_tagged_block(self):
+        # An image on a daily-note block tagged with the shared page must
+        # load — otherwise sharing a topic page with image references is
+        # broken.
+        tagged_asset = Asset.objects.create(
+            user=self.owner,
+            file_type=Asset.FILE_TYPE_IMAGE,
+            asset_type=Asset.ASSET_TYPE_BLOCK_ATTACHMENT,
+            file=SimpleUploadedFile(
+                "tagged.png", b"tagged-bytes", content_type="image/png"
+            ),
+            original_filename="tagged.png",
+            mime_type="image/png",
+            byte_size=len(b"tagged-bytes"),
+        )
+        daily = PageFactory(
+            user=self.owner,
+            title="2026-04-29",
+            slug="2026-04-29",
+            page_type="daily",
+        )
+        tagged_block = BlockFactory(
+            user=self.owner,
+            page=daily,
+            content="dinner",
+            asset=tagged_asset,
+            order=0,
+        )
+        tagged_block.pages.add(self.page)
+
+        client = Client()
+        response = client.get(
+            f"/knowledge/share/{self.page.share_token}/asset/{tagged_asset.uuid}/"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"tagged-bytes")
 
     def test_404s_for_unrelated_asset_even_when_owned_by_same_user(self):
         # Same user owns this asset, but it's only referenced by a private

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -199,6 +199,37 @@ def _serialize_block_tree(block, share_token: str) -> dict:
     }
 
 
+def _serialize_referenced_block(block, share_token: str) -> dict:
+    """Flat dict for a block that lives on another page but is tagged with
+    the shared page. Carries source-page context so the template can
+    label "from <daily date> / <page title>" without exposing a working
+    link to the source page.
+
+    Renders flat (no children) to match how the editor surfaces linked
+    references — the recipient sees the same scope of content the owner
+    sees in their own "Linked References" section.
+    """
+    asset_uuid = str(block.asset.uuid) if block.asset_id else None
+    asset_file_type = block.asset.file_type if block.asset_id else None
+    source = block.page
+    return {
+        "uuid": str(block.uuid),
+        "content": _rewrite_asset_urls(block.content, share_token),
+        "block_type": block.block_type,
+        "content_type": block.content_type,
+        "media_url": block.media_url,
+        "asset_url": (
+            _public_asset_url(share_token, asset_uuid) if asset_uuid else None
+        ),
+        "asset_is_image": asset_file_type == "image",
+        "source_page_title": source.title if source else "",
+        "source_page_type": source.page_type if source else "",
+        "source_page_date": (
+            source.date.isoformat() if source and source.date else None
+        ),
+    }
+
+
 def public_page(request, share_token: str):
     """Public, no-auth read-only view of a shared page. Resolves the
     share_token to a Page only if its current share_mode is "link" —
@@ -216,6 +247,17 @@ def public_page(request, share_token: str):
         _serialize_block_tree(b, share_token)
         for b in BlockRepository.get_root_blocks(page)
     ]
+    # Linked references — blocks elsewhere that tag this page (e.g. daily
+    # notes that mention #food-log). For a topic / tag-style page these
+    # ARE the content, so the share view would be empty without them.
+    referenced_blocks = (
+        page.tagged_blocks.exclude(page=page)
+        .select_related("user", "page", "asset")
+        .order_by("-page__date", "-modified_at", "order")
+    )
+    references = [
+        _serialize_referenced_block(b, share_token) for b in referenced_blocks
+    ]
 
     response = render(
         request,
@@ -223,6 +265,7 @@ def public_page(request, share_token: str):
         {
             "page": page,
             "blocks": blocks,
+            "references": references,
             "owner_email": page.user.email,
         },
     )
@@ -256,14 +299,20 @@ def public_asset(request, share_token: str, asset_uuid: str):
     except (Asset.DoesNotExist, ValueError, ValidationError):
         raise Http404("Shared asset not found")
 
-    # FK reference is the cheap, exact match. If a future code path embeds
-    # asset URLs inside block content without setting the FK, extend this
-    # check to also scan block.content for the uuid.
-    referenced_via_fk = page.blocks.filter(asset=asset).exists()
-    referenced_in_content = page.blocks.filter(
-        content__contains=f"/api/assets/{asset_uuid}/"
-    ).exists()
-    if not (referenced_via_fk or referenced_in_content):
+    # An asset is considered "shared" if any block visible on the public
+    # page uses it. That includes both blocks living on the page itself
+    # (page.blocks) and blocks tagged with the page (page.tagged_blocks)
+    # — the public render shows both, so both must be able to load images.
+    inline_marker = f"/api/assets/{asset_uuid}/"
+    direct_match = (
+        page.blocks.filter(asset=asset).exists()
+        or page.blocks.filter(content__contains=inline_marker).exists()
+    )
+    tagged_match = (
+        page.tagged_blocks.filter(asset=asset).exists()
+        or page.tagged_blocks.filter(content__contains=inline_marker).exists()
+    )
+    if not (direct_match or tagged_match):
         raise Http404("Shared asset not found")
 
     if not asset.file:


### PR DESCRIPTION
## Summary

- Adds Google Docs-style page sharing: pages stay private by default; the owner can flip a regular page to "anyone with the link" via a share modal in the page ⋮ menu. Shared pages are reachable at `/knowledge/share/<token>/` as a server-rendered, read-only HTML view (no auth, no editor JS).
- Share token is generated lazily and stays stable across mode toggles, so an existing link keeps working when the owner re-shares after a private detour. Switching back to private 404s the URL immediately.
- Image assets on the shared page load through a token-scoped sibling endpoint at `/knowledge/share/<token>/asset/<uuid>/` that resolves only when (a) the token is currently shared and (b) the asset is referenced by a block on that page (FK or `/api/assets/<uuid>/` in markdown). The existing `/api/assets/<uuid>/` stays auth-required.
- For tag/topic pages like `food-log` whose content lives in tagged blocks, the public view also surfaces "linked references" — blocks across the user's daily notes that tag the shared page. Source pages are labelled (date for daily notes, title otherwise) but not linked.

## Test plan

- [x] `just test` — 442 tests pass (22 new across share command/view tests)
- [x] Ruff / black / prettier / Django system check / `makemigrations --check` all clean
- [ ] Manual: share a regular page, open the link in incognito, verify content + images load
- [ ] Manual: share a tag-style page (e.g. food-log), confirm tagged blocks from dailies show under "linked references"
- [ ] Manual: revoke (private), confirm the URL 404s immediately
- [ ] Manual: re-share, confirm the same link works again
- [ ] Manual: confirm `/api/assets/<uuid>/` still requires auth (unchanged)
- [ ] Manual: dark-mode share modal — link is readable; copy button works in HTTP and HTTPS contexts

Closes #90.

https://claude.ai/code/session_01BvSwurWucTo1wBu2ALnVeM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvSwurWucTo1wBu2ALnVeM)_