### PR TITLE
Add scheduling and block management tools to AI chat

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -86,6 +86,7 @@ jobs:
             just staging-up
             sleep 5
             just staging-migrate
+            just staging-populate-ai-models
             just staging-create-superuser
             just staging-seed
 

--- a/packages/django-app/app/ai_chat/tests/test_scheduling_tool_executor.py
+++ b/packages/django-app/app/ai_chat/tests/test_scheduling_tool_executor.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from ai_chat.tools.notes_tool_executor import (
     NotesToolExecutor,
     _parse_relative_date,
+    _resolve_reminder_time,
 )
 from ai_chat.tools.notes_tools import (
     NOTES_READ_TOOL_NAMES,
@@ -397,3 +398,106 @@ class ListReadToolsTestCase(TestCase):
             {"start_date": "2026-06-15", "end_date": "2026-06-01"},
         )
         self.assertIn("error", result)
+
+
+class GetCurrentTimeToolTestCase(TestCase):
+    def test_returns_user_local_now(self):
+        user = UserFactory(email="now@example.com", timezone="America/New_York")
+        ex = NotesToolExecutor(user)
+
+        result = ex.execute("get_current_time", {})
+
+        self.assertEqual(result["timezone"], "America/New_York")
+        # Sanity-check that the response is a real ISO timestamp matching
+        # America/New_York (the offset string varies by DST so just check
+        # a tz suffix is present).
+        self.assertIn("T", result["now"])
+        self.assertRegex(result["time"], r"^\d{2}:\d{2}$")
+        self.assertRegex(result["date"], r"^\d{4}-\d{2}-\d{2}$")
+        self.assertIn(
+            result["weekday"],
+            {
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday",
+                "Sunday",
+            },
+        )
+
+    def test_falls_back_to_utc_for_unset_tz(self):
+        user = UserFactory(email="no-tz@example.com", timezone="")
+        ex = NotesToolExecutor(user)
+
+        result = ex.execute("get_current_time", {})
+
+        self.assertEqual(result["timezone"], "UTC")
+
+
+class ResolveReminderTimeTestCase(TestCase):
+    def setUp(self):
+        self.user = UserFactory(email="rt@example.com", timezone="UTC")
+
+    def test_empty_returns_none_pair(self):
+        self.assertEqual(_resolve_reminder_time(None, self.user), (None, None))
+        self.assertEqual(_resolve_reminder_time("", self.user), (None, None))
+
+    def test_wallclock_passes_through(self):
+        d, t = _resolve_reminder_time("09:30", self.user)
+        self.assertIsNone(d)
+        self.assertEqual(t, "09:30")
+
+    def test_relative_minutes_returns_now_plus_offset(self):
+        d, t = _resolve_reminder_time("+5m", self.user)
+        # Date should be today (in UTC for this user); time should be
+        # within a minute of now+5m.
+        now_utc = timezone.now()
+        expected = now_utc + timedelta(minutes=5)
+        self.assertEqual(d, expected.date())
+        # Allow a 1-minute drift since clock advances during the test.
+        actual = datetime.strptime(t, "%H:%M").replace(
+            year=expected.year, month=expected.month, day=expected.day
+        )
+        actual = pytz.UTC.localize(actual)
+        diff = abs((actual - expected.replace(second=0, microsecond=0)).total_seconds())
+        self.assertLess(diff, 90)
+
+    def test_relative_hours(self):
+        d, _ = _resolve_reminder_time("+2h", self.user)
+        expected = (timezone.now() + timedelta(hours=2)).date()
+        self.assertEqual(d, expected)
+
+    def test_garbage_raises(self):
+        with self.assertRaises(ValueError):
+            _resolve_reminder_time("not a time", self.user)
+
+
+class ScheduleBlockRelativeTimeTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(email="rel-time@example.com", timezone="UTC")
+        cls.page = PageFactory(user=cls.user)
+
+    def test_relative_minute_offset_creates_reminder_at_now_plus_n(self):
+        block = BlockFactory(user=self.user, page=self.page, content="leave soon")
+        ex = NotesToolExecutor(self.user, allow_writes=True)
+        before = timezone.now()
+
+        result = ex.execute(
+            "schedule_block",
+            {
+                "block_uuid": str(block.uuid),
+                "scheduled_for": "today",
+                "reminder_time": "+3m",
+            },
+        )
+
+        self.assertTrue(result.get("scheduled"))
+        reminder = Reminder.objects.get(block=block)
+        # The reminder fires within ~3m of when we called the tool
+        # (allow a generous bound for slow CI).
+        delta = (reminder.fire_at - before).total_seconds()
+        self.assertGreater(delta, 60)
+        self.assertLess(delta, 240)

--- a/packages/django-app/app/ai_chat/tests/test_scheduling_tool_executor.py
+++ b/packages/django-app/app/ai_chat/tests/test_scheduling_tool_executor.py
@@ -1,0 +1,399 @@
+from datetime import date, datetime, time, timedelta
+
+import pytz
+from django.test import TestCase
+from django.utils import timezone
+
+from ai_chat.tools.notes_tool_executor import (
+    NotesToolExecutor,
+    _parse_relative_date,
+)
+from ai_chat.tools.notes_tools import (
+    NOTES_READ_TOOL_NAMES,
+    NOTES_WRITE_TOOL_NAMES,
+)
+from core.test.helpers import UserFactory
+from knowledge.models import Reminder
+from knowledge.test.helpers import BlockFactory, PageFactory
+
+
+class ParseRelativeDateTestCase(TestCase):
+    def setUp(self):
+        self.today = date(2026, 5, 1)
+
+    def test_iso_passthrough(self):
+        self.assertEqual(
+            _parse_relative_date("2026-04-30", self.today), date(2026, 4, 30)
+        )
+
+    def test_today_keyword(self):
+        self.assertEqual(_parse_relative_date("today", self.today), self.today)
+
+    def test_tomorrow_keyword(self):
+        self.assertEqual(_parse_relative_date("tomorrow", self.today), date(2026, 5, 2))
+
+    def test_yesterday_keyword(self):
+        self.assertEqual(
+            _parse_relative_date("yesterday", self.today), date(2026, 4, 30)
+        )
+
+    def test_positive_day_offset(self):
+        self.assertEqual(_parse_relative_date("+3d", self.today), date(2026, 5, 4))
+
+    def test_negative_day_offset(self):
+        self.assertEqual(_parse_relative_date("-2d", self.today), date(2026, 4, 29))
+
+    def test_week_offset(self):
+        self.assertEqual(_parse_relative_date("+1w", self.today), date(2026, 5, 8))
+
+    def test_empty_returns_none(self):
+        self.assertIsNone(_parse_relative_date("", self.today))
+        self.assertIsNone(_parse_relative_date(None, self.today))
+
+    def test_garbage_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_relative_date("not a date", self.today)
+
+
+class SchedulingToolDiscoveryTestCase(TestCase):
+    def test_new_tool_names_registered(self):
+        # Read tools (no approval gate).
+        for name in (
+            "list_overdue_blocks",
+            "list_pending_reminders",
+            "list_scheduled_blocks",
+        ):
+            self.assertIn(name, NOTES_READ_TOOL_NAMES)
+            self.assertNotIn(name, NOTES_WRITE_TOOL_NAMES)
+
+        # Write tools (gated behind approval).
+        for name in (
+            "schedule_block",
+            "clear_schedule",
+            "set_block_type",
+            "move_block_to_daily",
+        ):
+            self.assertIn(name, NOTES_WRITE_TOOL_NAMES)
+            self.assertNotIn(name, NOTES_READ_TOOL_NAMES)
+
+    def test_writes_require_approval_by_default(self):
+        user = UserFactory(email="approval@example.com")
+        ex = NotesToolExecutor(user, allow_writes=True)
+        for name in (
+            "schedule_block",
+            "clear_schedule",
+            "set_block_type",
+            "move_block_to_daily",
+        ):
+            self.assertTrue(ex.requires_approval(name), name)
+
+    def test_auto_approve_skips_gate(self):
+        user = UserFactory(email="auto-approve@example.com")
+        ex = NotesToolExecutor(user, allow_writes=True, auto_approve_writes=True)
+        for name in (
+            "schedule_block",
+            "clear_schedule",
+            "set_block_type",
+            "move_block_to_daily",
+        ):
+            self.assertFalse(ex.requires_approval(name), name)
+
+    def test_reads_known_without_writes(self):
+        user = UserFactory(email="reads@example.com")
+        ex = NotesToolExecutor(user, allow_writes=False)
+        for name in (
+            "list_overdue_blocks",
+            "list_pending_reminders",
+            "list_scheduled_blocks",
+        ):
+            self.assertTrue(ex.is_known(name), name)
+            self.assertFalse(ex.requires_approval(name), name)
+
+
+class ScheduleBlockToolTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(email="sched@example.com", timezone="America/New_York")
+        cls.other_user = UserFactory(email="sched-other@example.com")
+        cls.page = PageFactory(user=cls.user, title="Inbox", slug="inbox")
+        cls.block = BlockFactory(
+            user=cls.user, page=cls.page, content="ship feature", block_type="todo"
+        )
+
+    def test_sets_scheduled_for(self):
+        ex = NotesToolExecutor(self.user, allow_writes=True)
+
+        result = ex.execute(
+            "schedule_block",
+            {"block_uuid": str(self.block.uuid), "scheduled_for": "2026-06-15"},
+        )
+
+        self.assertTrue(result.get("scheduled"))
+        self.assertEqual(result["block"]["scheduled_for"], "2026-06-15")
+        self.block.refresh_from_db()
+        self.assertEqual(self.block.scheduled_for, date(2026, 6, 15))
+
+    def test_creates_reminder_when_time_provided(self):
+        ex = NotesToolExecutor(self.user, allow_writes=True)
+
+        result = ex.execute(
+            "schedule_block",
+            {
+                "block_uuid": str(self.block.uuid),
+                "scheduled_for": "2026-06-15",
+                "reminder_time": "09:30",
+            },
+        )
+
+        self.assertTrue(result.get("scheduled"))
+        reminders = Reminder.objects.filter(block=self.block)
+        self.assertEqual(reminders.count(), 1)
+        # User is in America/New_York; 09:30 local on 2026-06-15.
+        expected = (
+            pytz.timezone("America/New_York")
+            .localize(datetime.combine(date(2026, 6, 15), time(9, 30)))
+            .astimezone(pytz.UTC)
+        )
+        self.assertEqual(reminders.first().fire_at, expected)
+
+    def test_resolves_relative_dates(self):
+        ex = NotesToolExecutor(self.user, allow_writes=True)
+
+        result = ex.execute(
+            "schedule_block",
+            {"block_uuid": str(self.block.uuid), "scheduled_for": "tomorrow"},
+        )
+
+        self.assertTrue(result.get("scheduled"))
+        self.block.refresh_from_db()
+        # Tomorrow in user's timezone — assert it's exactly one day after
+        # today_for_user, which is what the tool uses.
+        from core.helpers import today_for_user
+
+        self.assertEqual(
+            self.block.scheduled_for, today_for_user(self.user) + timedelta(days=1)
+        )
+
+    def test_rejects_other_users_block(self):
+        ex = NotesToolExecutor(self.other_user, allow_writes=True)
+
+        result = ex.execute(
+            "schedule_block",
+            {"block_uuid": str(self.block.uuid), "scheduled_for": "2026-06-15"},
+        )
+
+        self.assertIn("error", result)
+        self.block.refresh_from_db()
+        self.assertIsNone(self.block.scheduled_for)
+
+    def test_rejects_garbage_date(self):
+        ex = NotesToolExecutor(self.user, allow_writes=True)
+
+        result = ex.execute(
+            "schedule_block",
+            {"block_uuid": str(self.block.uuid), "scheduled_for": "next thursday"},
+        )
+
+        self.assertIn("error", result)
+
+
+class ClearScheduleToolTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(email="clear@example.com")
+        cls.page = PageFactory(user=cls.user)
+
+    def test_clears_schedule_and_pending_reminder(self):
+        block = BlockFactory(
+            user=self.user, page=self.page, scheduled_for=date(2026, 5, 30)
+        )
+        Reminder.objects.create(
+            block=block, fire_at=timezone.now() + timedelta(hours=1)
+        )
+        ex = NotesToolExecutor(self.user, allow_writes=True)
+
+        result = ex.execute("clear_schedule", {"block_uuid": str(block.uuid)})
+
+        self.assertTrue(result.get("cleared"))
+        block.refresh_from_db()
+        self.assertIsNone(block.scheduled_for)
+        self.assertEqual(
+            Reminder.objects.filter(block=block, sent_at__isnull=True).count(), 0
+        )
+
+
+class SetBlockTypeToolTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(email="type@example.com")
+        cls.page = PageFactory(user=cls.user)
+
+    def test_marks_todo_done_and_sets_completed_at(self):
+        block = BlockFactory(
+            user=self.user, page=self.page, content="TODO ship it", block_type="todo"
+        )
+        ex = NotesToolExecutor(self.user, allow_writes=True)
+
+        result = ex.execute(
+            "set_block_type",
+            {"block_uuid": str(block.uuid), "block_type": "done"},
+        )
+
+        self.assertTrue(result.get("updated"))
+        block.refresh_from_db()
+        self.assertEqual(block.block_type, "done")
+        self.assertIsNotNone(block.completed_at)
+        # Prefix swap happens in SetBlockTypeCommand.
+        self.assertTrue(block.content.lower().startswith("done"))
+
+    def test_rejects_invalid_block_type(self):
+        block = BlockFactory(user=self.user, page=self.page, block_type="todo")
+        ex = NotesToolExecutor(self.user, allow_writes=True)
+
+        result = ex.execute(
+            "set_block_type",
+            {"block_uuid": str(block.uuid), "block_type": "not-a-type"},
+        )
+
+        self.assertIn("error", result)
+        block.refresh_from_db()
+        self.assertEqual(block.block_type, "todo")
+
+
+class MoveBlockToDailyToolTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(email="move-daily@example.com")
+        cls.page = PageFactory(user=cls.user, title="Project", slug="project")
+
+    def test_moves_block_to_daily(self):
+        block = BlockFactory(user=self.user, page=self.page, content="meeting prep")
+        ex = NotesToolExecutor(self.user, allow_writes=True)
+
+        result = ex.execute(
+            "move_block_to_daily",
+            {"block_uuid": str(block.uuid), "target_date": "2026-06-15"},
+        )
+
+        self.assertTrue(result.get("moved"))
+        self.assertEqual(result["target_page"]["page_type"], "daily")
+        # The source page must show up in affected_page_uuids so the
+        # frontend can refresh whichever page the user has open.
+        self.assertIn(str(self.page.uuid), result["affected_page_uuids"])
+        block.refresh_from_db()
+        self.assertEqual(block.page.date, date(2026, 6, 15))
+
+    def test_default_target_is_today(self):
+        from core.helpers import today_for_user
+
+        block = BlockFactory(user=self.user, page=self.page, content="urgent")
+        ex = NotesToolExecutor(self.user, allow_writes=True)
+
+        result = ex.execute("move_block_to_daily", {"block_uuid": str(block.uuid)})
+
+        self.assertTrue(result.get("moved"))
+        block.refresh_from_db()
+        self.assertEqual(block.page.date, today_for_user(self.user))
+
+
+class ListReadToolsTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(email="list@example.com")
+        cls.other_user = UserFactory(email="list-other@example.com")
+        cls.page = PageFactory(user=cls.user, title="Project", slug="project")
+        cls.other_page = PageFactory(user=cls.other_user, title="Other", slug="other")
+
+    def test_list_overdue_blocks_filters_by_user_and_today(self):
+        from core.helpers import today_for_user
+
+        today = today_for_user(self.user)
+        BlockFactory(
+            user=self.user,
+            page=self.page,
+            content="overdue todo",
+            block_type="todo",
+            scheduled_for=today - timedelta(days=2),
+        )
+        BlockFactory(
+            user=self.user,
+            page=self.page,
+            content="future todo",
+            block_type="todo",
+            scheduled_for=today + timedelta(days=2),
+        )
+        # Other user's overdue must NOT leak through.
+        BlockFactory(
+            user=self.other_user,
+            page=self.other_page,
+            content="someone else overdue",
+            block_type="todo",
+            scheduled_for=today - timedelta(days=2),
+        )
+        ex = NotesToolExecutor(self.user)
+
+        result = ex.execute("list_overdue_blocks", {})
+
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["results"][0]["content"], "overdue todo")
+        self.assertEqual(result["results"][0]["page_title"], "Project")
+
+    def test_list_pending_reminders_excludes_sent(self):
+        block = BlockFactory(user=self.user, page=self.page, content="ping me")
+        pending = Reminder.objects.create(
+            block=block, fire_at=timezone.now() + timedelta(hours=2)
+        )
+        Reminder.objects.create(
+            block=block,
+            fire_at=timezone.now() - timedelta(hours=1),
+            sent_at=timezone.now(),
+            status=Reminder.STATUS_SENT,
+        )
+        # Other user's reminder must not leak.
+        other_block = BlockFactory(user=self.other_user, page=self.other_page)
+        Reminder.objects.create(
+            block=other_block, fire_at=timezone.now() + timedelta(hours=3)
+        )
+        ex = NotesToolExecutor(self.user)
+
+        result = ex.execute("list_pending_reminders", {})
+
+        self.assertEqual(result["count"], 1)
+        entry = result["results"][0]
+        self.assertEqual(entry["uuid"], str(pending.uuid))
+        self.assertEqual(entry["block_content"], "ping me")
+        self.assertEqual(entry["page_title"], "Project")
+
+    def test_list_scheduled_blocks_returns_range(self):
+        from core.helpers import today_for_user
+
+        today = today_for_user(self.user)
+        in_range = BlockFactory(
+            user=self.user,
+            page=self.page,
+            content="in range",
+            scheduled_for=today + timedelta(days=3),
+        )
+        BlockFactory(
+            user=self.user,
+            page=self.page,
+            content="too far",
+            scheduled_for=today + timedelta(days=60),
+        )
+        ex = NotesToolExecutor(self.user)
+
+        result = ex.execute(
+            "list_scheduled_blocks",
+            {"start_date": "today", "end_date": "+30d"},
+        )
+
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["results"][0]["block_uuid"], str(in_range.uuid))
+
+    def test_list_scheduled_blocks_rejects_inverted_range(self):
+        ex = NotesToolExecutor(self.user)
+        result = ex.execute(
+            "list_scheduled_blocks",
+            {"start_date": "2026-06-15", "end_date": "2026-06-01"},
+        )
+        self.assertIn("error", result)

--- a/packages/django-app/app/ai_chat/tools/notes_tool_executor.py
+++ b/packages/django-app/app/ai_chat/tools/notes_tool_executor.py
@@ -3,21 +3,32 @@
 Keeps the `get_tool_result` surface small and JSON-serialisable so the
 provider service can feed it straight back as a `tool_result` block.
 
-Write tools (create_block / edit_block / move_blocks) never run without
+Write tools (create_block / edit_block / move_blocks / schedule_block /
+clear_schedule / set_block_type / move_block_to_daily) never run without
 explicit user approval — the service pauses and the execution happens
 out-of-band during resume. See ai_chat.commands.resume_approval_command.
 """
 
 import logging
-from typing import Any, Dict, List
+import re
+from datetime import date, timedelta
+from typing import Any, Dict, List, Optional
 
+from core.helpers import today_for_user
 from core.models import User
 from knowledge.commands.create_block_command import CreateBlockCommand
 from knowledge.commands.create_page_command import CreatePageCommand
+from knowledge.commands.move_block_to_daily_command import MoveBlockToDailyCommand
+from knowledge.commands.schedule_block_command import ScheduleBlockCommand
+from knowledge.commands.set_block_type_command import SetBlockTypeCommand
 from knowledge.commands.update_block_command import UpdateBlockCommand
 from knowledge.forms.create_block_form import CreateBlockForm
 from knowledge.forms.create_page_form import CreatePageForm
+from knowledge.forms.move_block_to_daily_form import MoveBlockToDailyForm
+from knowledge.forms.schedule_block_form import ScheduleBlockForm
+from knowledge.forms.set_block_type_form import SetBlockTypeForm
 from knowledge.forms.update_block_form import UpdateBlockForm
+from knowledge.models import Reminder
 from knowledge.repositories.block_repository import BlockRepository
 from knowledge.repositories.page_repository import PageRepository
 
@@ -30,6 +41,11 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_SEARCH_LIMIT = 10
 MAX_SEARCH_LIMIT = 25
+DEFAULT_LIST_LIMIT = 25
+MAX_LIST_LIMIT = 100
+DEFAULT_SCHEDULE_RANGE_LIMIT = 50
+MAX_SCHEDULE_RANGE_LIMIT = 200
+SCHEDULE_RANGE_DEFAULT_DAYS = 30
 
 
 class NotesToolExecutor:
@@ -71,6 +87,12 @@ class NotesToolExecutor:
                 return self._get_page_by_title(args)
             if name == "get_block_by_id":
                 return self._get_block_by_id(args)
+            if name == "list_overdue_blocks":
+                return self._list_overdue_blocks(args)
+            if name == "list_pending_reminders":
+                return self._list_pending_reminders(args)
+            if name == "list_scheduled_blocks":
+                return self._list_scheduled_blocks(args)
             if name == "create_page":
                 return self._create_page(args)
             if name == "create_block":
@@ -81,6 +103,14 @@ class NotesToolExecutor:
                 return self._move_blocks(args)
             if name == "reorder_blocks":
                 return self._reorder_blocks(args)
+            if name == "schedule_block":
+                return self._schedule_block(args)
+            if name == "clear_schedule":
+                return self._clear_schedule(args)
+            if name == "set_block_type":
+                return self._set_block_type(args)
+            if name == "move_block_to_daily":
+                return self._move_block_to_daily(args)
             return {"error": f"Unknown tool: {name}"}
         except Exception as e:
             logger.exception("Notes tool %s failed", name)
@@ -427,6 +457,288 @@ class NotesToolExecutor:
             "target_page_uuid": str(target_page.uuid),
             "affected_page_uuids": sorted(affected),
         }
+
+    def _list_overdue_blocks(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        limit = _coerce_limit(
+            args.get("limit"), default=DEFAULT_LIST_LIMIT, max_value=MAX_LIST_LIMIT
+        )
+        today = today_for_user(self.user)
+        blocks = list(BlockRepository.get_overdue_blocks(self.user, today)[:limit])
+        return {
+            "today": today.isoformat(),
+            "count": len(blocks),
+            "results": [_summarize_block(b) for b in blocks],
+        }
+
+    def _list_pending_reminders(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        limit = _coerce_limit(
+            args.get("limit"), default=DEFAULT_LIST_LIMIT, max_value=MAX_LIST_LIMIT
+        )
+        reminders = list(
+            Reminder.objects.filter(
+                block__user=self.user,
+                sent_at__isnull=True,
+                status=Reminder.STATUS_PENDING,
+            )
+            .select_related("block", "block__page")
+            .order_by("fire_at")[:limit]
+        )
+        results = []
+        for reminder in reminders:
+            entry = reminder.to_dict()
+            block = reminder.block
+            entry["block_content"] = block.content
+            entry["block_type"] = block.block_type
+            entry["page_title"] = block.page.title if block.page else None
+            entry["page_uuid"] = str(block.page.uuid) if block.page else None
+            results.append(entry)
+        return {"count": len(results), "results": results}
+
+    def _list_scheduled_blocks(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        today = today_for_user(self.user)
+        try:
+            start_date = _parse_relative_date(args.get("start_date"), today) or today
+        except ValueError as e:
+            return {"error": f"start_date: {e}"}
+        try:
+            end_date = _parse_relative_date(args.get("end_date"), today)
+        except ValueError as e:
+            return {"error": f"end_date: {e}"}
+        if end_date is None:
+            end_date = start_date + timedelta(days=SCHEDULE_RANGE_DEFAULT_DAYS)
+        if end_date < start_date:
+            return {"error": "end_date must be on or after start_date"}
+
+        limit = _coerce_limit(
+            args.get("limit"),
+            default=DEFAULT_SCHEDULE_RANGE_LIMIT,
+            max_value=MAX_SCHEDULE_RANGE_LIMIT,
+        )
+        blocks = list(
+            BlockRepository.get_queryset()
+            .filter(
+                user=self.user,
+                scheduled_for__gte=start_date,
+                scheduled_for__lte=end_date,
+            )
+            .select_related("page")
+            .prefetch_related("reminders")
+            .order_by("scheduled_for", "order")[:limit]
+        )
+        return {
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+            "count": len(blocks),
+            "results": [_summarize_block(b) for b in blocks],
+        }
+
+    def _schedule_block(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        block_uuid = (args.get("block_uuid") or "").strip()
+        if not block_uuid:
+            return {"error": "block_uuid is required"}
+        block = BlockRepository.get_by_uuid(block_uuid, user=self.user)
+        if not block:
+            return {"error": f"No block found with uuid {block_uuid}"}
+
+        today = today_for_user(self.user)
+        try:
+            scheduled_for = _parse_relative_date(args.get("scheduled_for"), today)
+        except ValueError as e:
+            return {"error": f"scheduled_for: {e}"}
+        if scheduled_for is None:
+            return {
+                "error": (
+                    "scheduled_for is required (use clear_schedule to unschedule)"
+                )
+            }
+
+        try:
+            reminder_date = _parse_relative_date(args.get("reminder_date"), today)
+        except ValueError as e:
+            return {"error": f"reminder_date: {e}"}
+
+        form_data: Dict[str, Any] = {
+            "user": self.user.id,
+            "block": block.uuid,
+            "scheduled_for": scheduled_for.isoformat(),
+        }
+        if reminder_date is not None:
+            form_data["reminder_date"] = reminder_date.isoformat()
+        reminder_time = (args.get("reminder_time") or "").strip()
+        if reminder_time:
+            form_data["reminder_time"] = reminder_time
+
+        form = ScheduleBlockForm(form_data)
+        if not form.is_valid():
+            return {"error": _first_form_error(form)}
+        updated = ScheduleBlockCommand(form).execute()
+        return {
+            "scheduled": True,
+            "block": updated.to_dict(include_page_context=True),
+            "affected_page_uuids": ([str(updated.page.uuid)] if updated.page else []),
+        }
+
+    def _clear_schedule(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        block_uuid = (args.get("block_uuid") or "").strip()
+        if not block_uuid:
+            return {"error": "block_uuid is required"}
+        block = BlockRepository.get_by_uuid(block_uuid, user=self.user)
+        if not block:
+            return {"error": f"No block found with uuid {block_uuid}"}
+
+        # ScheduleBlockForm treats a missing scheduled_for as "clear" (the
+        # field is required=False; cleaned_data["scheduled_for"] is None).
+        form = ScheduleBlockForm(
+            {
+                "user": self.user.id,
+                "block": block.uuid,
+            }
+        )
+        if not form.is_valid():
+            return {"error": _first_form_error(form)}
+        updated = ScheduleBlockCommand(form).execute()
+        return {
+            "cleared": True,
+            "block": updated.to_dict(include_page_context=True),
+            "affected_page_uuids": ([str(updated.page.uuid)] if updated.page else []),
+        }
+
+    def _set_block_type(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        block_uuid = (args.get("block_uuid") or "").strip()
+        block_type = (args.get("block_type") or "").strip()
+        if not block_uuid:
+            return {"error": "block_uuid is required"}
+        if not block_type:
+            return {"error": "block_type is required"}
+        block = BlockRepository.get_by_uuid(block_uuid, user=self.user)
+        if not block:
+            return {"error": f"No block found with uuid {block_uuid}"}
+
+        form = SetBlockTypeForm(
+            {
+                "user": self.user.id,
+                "block": block.uuid,
+                "block_type": block_type,
+            }
+        )
+        if not form.is_valid():
+            return {"error": _first_form_error(form)}
+        updated = SetBlockTypeCommand(form).execute()
+        return {
+            "updated": True,
+            "block": updated.to_dict(include_page_context=True),
+            "affected_page_uuids": ([str(updated.page.uuid)] if updated.page else []),
+        }
+
+    def _move_block_to_daily(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        block_uuid = (args.get("block_uuid") or "").strip()
+        if not block_uuid:
+            return {"error": "block_uuid is required"}
+        block = BlockRepository.get_by_uuid(block_uuid, user=self.user)
+        if not block:
+            return {"error": f"No block found with uuid {block_uuid}"}
+
+        today = today_for_user(self.user)
+        try:
+            target_date = _parse_relative_date(args.get("target_date"), today)
+        except ValueError as e:
+            return {"error": f"target_date: {e}"}
+
+        # Capture source page so the chat surface can refresh both ends
+        # after the move (the command itself doesn't return the source).
+        source_page_uuid = str(block.page.uuid) if block.page else None
+
+        form_data: Dict[str, Any] = {
+            "user": self.user.id,
+            "block": block.uuid,
+        }
+        if target_date is not None:
+            form_data["target_date"] = target_date.isoformat()
+
+        form = MoveBlockToDailyForm(form_data)
+        if not form.is_valid():
+            return {"error": _first_form_error(form)}
+        result = MoveBlockToDailyCommand(form).execute()
+
+        target_page_uuid = result["target_page"]["uuid"]
+        affected = {target_page_uuid}
+        if source_page_uuid:
+            affected.add(source_page_uuid)
+        return {
+            "moved": result["moved"],
+            "message": result["message"],
+            "block": result["block"],
+            "target_page": result["target_page"],
+            "affected_page_uuids": sorted(affected),
+        }
+
+
+_RELATIVE_OFFSET_RE = re.compile(r"^([+-])(\d+)([dw])$")
+
+
+def _parse_relative_date(value: Any, today: date) -> Optional[date]:
+    """Parse a date input that accepts ISO YYYY-MM-DD or simple relative
+    tokens ('today', 'tomorrow', 'yesterday', '+Nd', '-Nd', '+Nw', '-Nw').
+
+    Returns None when the input is empty / missing. Raises ValueError on
+    unrecognised formats so the caller can surface a helpful error.
+    """
+    if value is None:
+        return None
+    if isinstance(value, date):
+        return value
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    if text == "today":
+        return today
+    if text == "tomorrow":
+        return today + timedelta(days=1)
+    if text == "yesterday":
+        return today - timedelta(days=1)
+    match = _RELATIVE_OFFSET_RE.match(text)
+    if match:
+        sign, num, unit = match.groups()
+        amount = int(num) * (1 if sign == "+" else -1)
+        days = amount if unit == "d" else amount * 7
+        return today + timedelta(days=days)
+    try:
+        return date.fromisoformat(text)
+    except ValueError as e:
+        raise ValueError(
+            f"expected ISO YYYY-MM-DD or 'today'/'tomorrow'/'+Nd', got '{value}'"
+        ) from e
+
+
+def _coerce_limit(value: Any, *, default: int, max_value: int) -> int:
+    if value is None:
+        return default
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(1, min(n, max_value))
+
+
+def _summarize_block(block) -> Dict[str, Any]:
+    """Compact block summary for list_* tools — small enough to keep many
+    in a tool result, rich enough for the chat surface to render."""
+    return {
+        "block_uuid": str(block.uuid),
+        "content": block.content,
+        "block_type": block.block_type,
+        "scheduled_for": (
+            block.scheduled_for.isoformat() if block.scheduled_for else None
+        ),
+        "completed_at": (
+            block.completed_at.isoformat() if block.completed_at else None
+        ),
+        "page_uuid": str(block.page.uuid) if block.page else None,
+        "page_title": block.page.title if block.page else None,
+        "page_slug": block.page.slug if block.page else None,
+        "pending_reminder_date": block._pending_reminder_local_date(),
+        "pending_reminder_time": block._pending_reminder_local_time(),
+    }
 
 
 def _first_form_error(form) -> str:

--- a/packages/django-app/app/ai_chat/tools/notes_tool_executor.py
+++ b/packages/django-app/app/ai_chat/tools/notes_tool_executor.py
@@ -11,8 +11,11 @@ out-of-band during resume. See ai_chat.commands.resume_approval_command.
 
 import logging
 import re
-from datetime import date, timedelta
-from typing import Any, Dict, List, Optional
+from datetime import date, time, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytz
+from django.utils import timezone
 
 from core.helpers import today_for_user
 from core.models import User
@@ -87,6 +90,8 @@ class NotesToolExecutor:
                 return self._get_page_by_title(args)
             if name == "get_block_by_id":
                 return self._get_block_by_id(args)
+            if name == "get_current_time":
+                return self._get_current_time(args)
             if name == "list_overdue_blocks":
                 return self._list_overdue_blocks(args)
             if name == "list_pending_reminders":
@@ -205,6 +210,22 @@ class NotesToolExecutor:
                 }
                 for child in children
             ],
+        }
+
+    def _get_current_time(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        tz_name = self.user.timezone or "UTC"
+        try:
+            tz = pytz.timezone(tz_name)
+        except pytz.UnknownTimeZoneError:
+            tz = pytz.UTC
+            tz_name = "UTC"
+        now_local = timezone.now().astimezone(tz)
+        return {
+            "now": now_local.isoformat(),
+            "date": now_local.date().isoformat(),
+            "time": now_local.strftime("%H:%M"),
+            "weekday": now_local.strftime("%A"),
+            "timezone": tz_name,
         }
 
     def _create_page(self, args: Dict[str, Any]) -> Dict[str, Any]:
@@ -557,6 +578,18 @@ class NotesToolExecutor:
         except ValueError as e:
             return {"error": f"reminder_date: {e}"}
 
+        # Resolve reminder_time. A relative offset ("+3m", "+2h") wins
+        # over reminder_date — if the offset crosses midnight the date
+        # rolls forward with it.
+        try:
+            resolved_date, resolved_time = _resolve_reminder_time(
+                args.get("reminder_time"), self.user
+            )
+        except ValueError as e:
+            return {"error": f"reminder_time: {e}"}
+        if resolved_date is not None:
+            reminder_date = resolved_date
+
         form_data: Dict[str, Any] = {
             "user": self.user.id,
             "block": block.uuid,
@@ -564,9 +597,8 @@ class NotesToolExecutor:
         }
         if reminder_date is not None:
             form_data["reminder_date"] = reminder_date.isoformat()
-        reminder_time = (args.get("reminder_time") or "").strip()
-        if reminder_time:
-            form_data["reminder_time"] = reminder_time
+        if resolved_time:
+            form_data["reminder_time"] = resolved_time
 
         form = ScheduleBlockForm(form_data)
         if not form.is_valid():
@@ -674,6 +706,50 @@ class NotesToolExecutor:
 
 
 _RELATIVE_OFFSET_RE = re.compile(r"^([+-])(\d+)([dw])$")
+_RELATIVE_TIME_OFFSET_RE = re.compile(r"^([+-])(\d+)([mh])$")
+
+
+def _resolve_reminder_time(
+    value: Any, user: User
+) -> Tuple[Optional[date], Optional[str]]:
+    """Resolve a `reminder_time` arg into (date_override, 'HH:MM' or None).
+
+    - Empty / None    -> (None, None) — caller should leave reminder unset.
+    - 'HH:MM'         -> (None, 'HH:MM') — let the form parse it; the
+                          caller's reminder_date / scheduled_for fallback
+                          decides which day it fires on.
+    - '+Nm' / '+Nh'   -> (target_date, 'HH:MM') in the user's tz, computed
+                          from now() + offset. The date is returned so the
+                          caller can roll reminder_date forward when the
+                          offset crosses midnight.
+    """
+    if value is None:
+        return (None, None)
+    text = str(value).strip().lower()
+    if not text:
+        return (None, None)
+
+    match = _RELATIVE_TIME_OFFSET_RE.match(text)
+    if match:
+        sign, num, unit = match.groups()
+        amount = int(num) * (1 if sign == "+" else -1)
+        delta = timedelta(minutes=amount) if unit == "m" else timedelta(hours=amount)
+        try:
+            tz = pytz.timezone(user.timezone or "UTC")
+        except pytz.UnknownTimeZoneError:
+            tz = pytz.UTC
+        target = timezone.now().astimezone(tz) + delta
+        return (target.date(), target.strftime("%H:%M"))
+
+    # Wall-clock — accept HH:MM or HH:MM:SS so we error early on garbage.
+    # We return the original string; the form's TimeField parses it.
+    try:
+        time.fromisoformat(text)
+    except ValueError as e:
+        raise ValueError(
+            f"expected HH:MM or '+Nm' / '+Nh' offset, got '{value}'"
+        ) from e
+    return (None, text)
 
 
 def _parse_relative_date(value: Any, today: date) -> Optional[date]:

--- a/packages/django-app/app/ai_chat/tools/notes_tools.py
+++ b/packages/django-app/app/ai_chat/tools/notes_tools.py
@@ -6,6 +6,11 @@ we run the Django query, and return the result as a tool_result.
 Tools are split into `NOTES_READ_TOOLS` (safe, always-on when the user grants
 the notes-tools scope) and `NOTES_WRITE_TOOLS` (guarded — every call must be
 approved by the user via the PendingToolApproval flow before execution).
+
+Scheduling/movement/completion tools live alongside the notes tools so they
+flow through the same PendingToolApproval gate; they wrap the existing
+ScheduleBlockCommand / SetBlockTypeCommand / MoveBlockToDailyCommand. See
+issue #82.
 """
 
 from typing import Any, Dict, List
@@ -70,6 +75,82 @@ NOTES_READ_TOOLS: List[Dict[str, Any]] = [
                 },
             },
             "required": ["block_uuid"],
+        },
+    },
+    {
+        "name": "list_overdue_blocks",
+        "description": (
+            "List the user's overdue scheduled blocks: blocks whose"
+            " scheduled_for is before today (in the user's timezone) and"
+            " whose block_type is still todo / doing / later. Same predicate"
+            " that drives the daily-page overdue section. Returns block"
+            " uuid, content, page title, scheduled_for, block_type."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum rows to return (default 25, max 100).",
+                    "minimum": 1,
+                    "maximum": 100,
+                },
+            },
+        },
+    },
+    {
+        "name": "list_pending_reminders",
+        "description": (
+            "List reminders that haven't fired yet, oldest first. Each row"
+            " includes the reminder fire_at timestamp (UTC), channel, and"
+            " the parent block's uuid + content + page title."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum rows to return (default 25, max 100).",
+                    "minimum": 1,
+                    "maximum": 100,
+                },
+            },
+        },
+    },
+    {
+        "name": "list_scheduled_blocks",
+        "description": (
+            "List blocks with a scheduled_for date in the given inclusive"
+            " range. Defaults: start_date = today (user tz), end_date ="
+            " start_date + 30 days. Useful for 'what's coming up this week'"
+            " questions. Dates accept ISO YYYY-MM-DD or 'today' / 'tomorrow'"
+            " / '+Nd' offsets."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "start_date": {
+                    "type": "string",
+                    "description": (
+                        "Inclusive lower bound. ISO YYYY-MM-DD, or 'today',"
+                        " 'tomorrow', 'yesterday', '+Nd' / '-Nd'. Default:"
+                        " today in the user's timezone."
+                    ),
+                },
+                "end_date": {
+                    "type": "string",
+                    "description": (
+                        "Inclusive upper bound. Same format as start_date."
+                        " Default: start_date + 30 days."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum rows to return (default 50, max 200).",
+                    "minimum": 1,
+                    "maximum": 200,
+                },
+            },
         },
     },
 ]
@@ -236,6 +317,130 @@ NOTES_WRITE_TOOLS: List[Dict[str, Any]] = [
                 },
             },
             "required": ["block_uuids", "target_page_uuid"],
+        },
+    },
+    {
+        "name": "schedule_block",
+        "description": (
+            "Set a block's due date (scheduled_for), optionally creating a"
+            " reminder. The block surfaces on the daily page for that date"
+            " and shows up in the overdue section after it passes. Re-"
+            "calling on the same block replaces any pending reminder; sent"
+            " reminders stay as history. Pass an absolute ISO date or one of"
+            " 'today' / 'tomorrow' / 'yesterday' / '+Nd' / '-Nd'. Reminder"
+            " time is HH:MM 24-hour in the user's timezone. Use"
+            " clear_schedule to unschedule a block. Every call pauses for"
+            " explicit user approval before execution."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "block_uuid": {
+                    "type": "string",
+                    "description": "UUID of the block to schedule.",
+                },
+                "scheduled_for": {
+                    "type": "string",
+                    "description": (
+                        "Due date. ISO YYYY-MM-DD, or 'today' / 'tomorrow'"
+                        " / 'yesterday' / '+Nd' / '-Nd'."
+                    ),
+                },
+                "reminder_date": {
+                    "type": "string",
+                    "description": (
+                        "Optional date for the reminder ping. Same format as"
+                        " scheduled_for. Defaults to scheduled_for (i.e."
+                        " 'remind me the day of'). Only used if"
+                        " reminder_time is also set."
+                    ),
+                },
+                "reminder_time": {
+                    "type": "string",
+                    "description": (
+                        "Optional HH:MM 24-hour wall-clock time in the"
+                        " user's timezone. Required to actually create a"
+                        " reminder; without it the block is scheduled but"
+                        " no ping fires."
+                    ),
+                },
+            },
+            "required": ["block_uuid", "scheduled_for"],
+        },
+    },
+    {
+        "name": "clear_schedule",
+        "description": (
+            "Remove a block's due date and delete its pending reminder."
+            " Sent reminders stay as history. Every call pauses for"
+            " explicit user approval before execution."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "block_uuid": {
+                    "type": "string",
+                    "description": "UUID of the block to unschedule.",
+                },
+            },
+            "required": ["block_uuid"],
+        },
+    },
+    {
+        "name": "set_block_type",
+        "description": (
+            "Change a block's type (todo / doing / done / later / wontdo /"
+            " bullet / heading / quote / code). Maintains completed_at on"
+            " transitions into / out of done|wontdo and swaps the leading"
+            " content prefix (TODO -> DONE etc). Use this to mark a todo"
+            " as done from chat. Every call pauses for explicit user"
+            " approval before execution."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "block_uuid": {
+                    "type": "string",
+                    "description": "UUID of the block to update.",
+                },
+                "block_type": {
+                    "type": "string",
+                    "description": (
+                        "New type. Allowed: bullet, todo, doing, done,"
+                        " later, wontdo, heading, quote, code, divider."
+                    ),
+                },
+            },
+            "required": ["block_uuid", "block_type"],
+        },
+    },
+    {
+        "name": "move_block_to_daily",
+        "description": (
+            "Move a block (and its descendants) to a daily page. Defaults to"
+            " today's daily in the user's timezone — useful for 'move that"
+            " to today' / 'shove this onto tomorrow's daily' intents. The"
+            " daily page is auto-created if it doesn't exist. The block"
+            " becomes a root-level block on the target. Every call pauses"
+            " for explicit user approval before execution."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "block_uuid": {
+                    "type": "string",
+                    "description": "UUID of the block to move.",
+                },
+                "target_date": {
+                    "type": "string",
+                    "description": (
+                        "Optional target date. ISO YYYY-MM-DD or 'today' /"
+                        " 'tomorrow' / 'yesterday' / '+Nd' / '-Nd'. Default:"
+                        " today in the user's timezone."
+                    ),
+                },
+            },
+            "required": ["block_uuid"],
         },
     },
 ]

--- a/packages/django-app/app/ai_chat/tools/notes_tools.py
+++ b/packages/django-app/app/ai_chat/tools/notes_tools.py
@@ -78,6 +78,21 @@ NOTES_READ_TOOLS: List[Dict[str, Any]] = [
         },
     },
     {
+        "name": "get_current_time",
+        "description": (
+            "Return the current date + time in the user's timezone. Call"
+            " this before scheduling a block / reminder when the user says"
+            " something time-relative ('in 5 minutes', 'this afternoon')"
+            " and you don't already know the exact local time. Returns"
+            " ISO-8601 'now', plus separate date / time / weekday / timezone"
+            " fields for convenience."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+        },
+    },
+    {
         "name": "list_overdue_blocks",
         "description": (
             "List the user's overdue scheduled blocks: blocks whose"
@@ -359,9 +374,12 @@ NOTES_WRITE_TOOLS: List[Dict[str, Any]] = [
                     "type": "string",
                     "description": (
                         "Optional HH:MM 24-hour wall-clock time in the"
-                        " user's timezone. Required to actually create a"
-                        " reminder; without it the block is scheduled but"
-                        " no ping fires."
+                        " user's timezone, OR a relative offset from now:"
+                        " '+Nm' / '+Nh' (e.g. '+3m', '+2h'). Required to"
+                        " actually create a reminder; without it the block"
+                        " is scheduled but no ping fires. Relative offsets"
+                        " override reminder_date if the offset crosses"
+                        " midnight."
                     ),
                 },
             },

--- a/packages/django-app/justfile
+++ b/packages/django-app/justfile
@@ -250,6 +250,9 @@ staging-down:
 staging-migrate:
   docker compose run --rm -w /code/app web python manage.py migrate
 
+staging-populate-ai-models:
+  docker compose run --rm -w /code/app web python manage.py populate_ai_providers_and_models
+
 staging-create-superuser:
   docker compose run --rm \
     -e DJANGO_SUPERUSER_EMAIL \


### PR DESCRIPTION
## Summary
Extends the AI chat notes tools with scheduling, reminder, and block management capabilities. Users can now schedule blocks for specific dates, set reminders, change block types, move blocks to daily pages, and query their scheduled/overdue items through the chat interface.

## Key Changes

- **New read-only tools** for querying scheduled work:
  - `list_overdue_blocks`: Returns blocks past their scheduled date
  - `list_pending_reminders`: Returns upcoming reminders, oldest first
  - `list_scheduled_blocks`: Returns blocks within a date range with flexible date parsing

- **New write tools** (gated behind user approval):
  - `schedule_block`: Set a block's due date and optionally create a reminder with time
  - `clear_schedule`: Remove a block's due date and pending reminder
  - `set_block_type`: Change block type (todo/doing/done/later/wontdo/etc) with prefix swapping
  - `move_block_to_daily`: Move a block to a daily page (defaults to today)

- **Date parsing utility** (`_parse_relative_date`):
  - Supports ISO YYYY-MM-DD format
  - Relative keywords: 'today', 'tomorrow', 'yesterday'
  - Offset syntax: '+Nd', '-Nd' (days), '+Nw', '-Nw' (weeks)
  - Returns None for empty input, raises ValueError for invalid formats

- **Helper utilities**:
  - `_coerce_limit`: Safely parse and bound limit parameters
  - `_summarize_block`: Compact block representation for list results

- **Comprehensive test coverage** (399 lines):
  - Date parsing edge cases and formats
  - Tool discovery and approval gating
  - Schedule/clear/type-change/move operations with user isolation
  - List tools with filtering, pagination, and date range validation

## Implementation Details

- All write tools integrate with existing commands (ScheduleBlockCommand, SetBlockTypeCommand, MoveBlockToDailyCommand) via their forms
- User timezone awareness throughout (via `today_for_user` helper)
- Proper user isolation: blocks/reminders from other users are never accessible
- Reminders created with timezone-aware UTC timestamps
- Affected page UUIDs returned so chat UI can refresh both source and target pages
- Default limits and ranges prevent excessive data transfer (e.g., 30-day default for scheduled blocks)

https://claude.ai/code/session_01T5aEre2aGJditBXm27Eiwa

Resolves https://github.com/steezeburger/brainspread/issues/82