### PR TITLE
Add favorites feature to left navigation sidebar

### DIFF
--- a/packages/django-app/app/knowledge/commands/__init__.py
+++ b/packages/django-app/app/knowledge/commands/__init__.py
@@ -4,6 +4,7 @@ from .create_block_command import CreateBlockCommand
 from .create_page_command import CreatePageCommand
 from .delete_block_command import DeleteBlockCommand
 from .delete_page_command import DeletePageCommand
+from .get_favorited_pages_command import GetFavoritedPagesCommand
 from .get_graph_data_command import GetGraphDataCommand
 from .get_historical_data_command import GetHistoricalDataCommand
 from .get_page_with_blocks_command import GetPageWithBlocksCommand
@@ -16,6 +17,7 @@ from .schedule_block_command import ScheduleBlockCommand
 from .search_pages_command import SearchPagesCommand
 from .send_due_reminders_command import SendDueRemindersCommand
 from .set_block_type_command import SetBlockTypeCommand
+from .set_page_favorited_command import SetPageFavoritedCommand
 from .share_page_command import SharePageCommand
 from .sync_block_tags_command import SyncBlockTagsCommand
 from .toggle_block_todo_command import ToggleBlockTodoCommand

--- a/packages/django-app/app/knowledge/commands/get_favorited_pages_command.py
+++ b/packages/django-app/app/knowledge/commands/get_favorited_pages_command.py
@@ -1,0 +1,19 @@
+from typing import List
+
+from common.commands.abstract_base_command import AbstractBaseCommand
+
+from ..forms.get_favorited_pages_form import GetFavoritedPagesForm
+from ..models import Page
+
+
+class GetFavoritedPagesCommand(AbstractBaseCommand):
+    """Return the user's favorited pages, ordered by title."""
+
+    def __init__(self, form: GetFavoritedPagesForm) -> None:
+        self.form = form
+
+    def execute(self) -> List[Page]:
+        super().execute()
+
+        user = self.form.cleaned_data["user"]
+        return list(Page.objects.filter(user=user, favorited=True).order_by("title"))

--- a/packages/django-app/app/knowledge/commands/get_favorited_pages_command.py
+++ b/packages/django-app/app/knowledge/commands/get_favorited_pages_command.py
@@ -4,6 +4,7 @@ from common.commands.abstract_base_command import AbstractBaseCommand
 
 from ..forms.get_favorited_pages_form import GetFavoritedPagesForm
 from ..models import Page
+from ..repositories import PageRepository
 
 
 class GetFavoritedPagesCommand(AbstractBaseCommand):
@@ -16,4 +17,4 @@ class GetFavoritedPagesCommand(AbstractBaseCommand):
         super().execute()
 
         user = self.form.cleaned_data["user"]
-        return list(Page.objects.filter(user=user, favorited=True).order_by("title"))
+        return list(PageRepository.get_favorited(user))

--- a/packages/django-app/app/knowledge/commands/set_page_favorited_command.py
+++ b/packages/django-app/app/knowledge/commands/set_page_favorited_command.py
@@ -1,0 +1,21 @@
+from common.commands.abstract_base_command import AbstractBaseCommand
+
+from ..forms.set_page_favorited_form import SetPageFavoritedForm
+from ..models import Page
+
+
+class SetPageFavoritedCommand(AbstractBaseCommand):
+    """Star or unstar a page so it appears in the left-nav Favorites section."""
+
+    def __init__(self, form: SetPageFavoritedForm) -> None:
+        self.form = form
+
+    def execute(self) -> Page:
+        super().execute()
+
+        page = self.form.cleaned_data["page"]
+        favorited = bool(self.form.cleaned_data.get("favorited"))
+
+        page.favorited = favorited
+        page.save(update_fields=["favorited", "modified_at"])
+        return page

--- a/packages/django-app/app/knowledge/forms/__init__.py
+++ b/packages/django-app/app/knowledge/forms/__init__.py
@@ -4,6 +4,7 @@ from .create_block_form import CreateBlockForm
 from .create_page_form import CreatePageForm
 from .delete_block_form import DeleteBlockForm
 from .delete_page_form import DeletePageForm
+from .get_favorited_pages_form import GetFavoritedPagesForm
 from .get_graph_data_form import GetGraphDataForm
 from .get_historical_data_form import GetHistoricalDataForm
 from .get_page_with_blocks_form import GetPageWithBlocksForm
@@ -16,6 +17,7 @@ from .schedule_block_form import ScheduleBlockForm
 from .search_pages_form import SearchPagesForm
 from .send_due_reminders_form import SendDueRemindersForm
 from .set_block_type_form import SetBlockTypeForm
+from .set_page_favorited_form import SetPageFavoritedForm
 from .share_page_form import SharePageForm
 from .sync_block_tags_form import SyncBlockTagsForm
 from .toggle_block_todo_form import ToggleBlockTodoForm

--- a/packages/django-app/app/knowledge/forms/get_favorited_pages_form.py
+++ b/packages/django-app/app/knowledge/forms/get_favorited_pages_form.py
@@ -1,0 +1,16 @@
+from django import forms
+from django.core.exceptions import ValidationError
+
+from common.forms import BaseForm
+from core.models import User
+from core.repositories import UserRepository
+
+
+class GetFavoritedPagesForm(BaseForm):
+    user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
+
+    def clean_user(self) -> User:
+        user = self.cleaned_data.get("user")
+        if not user:
+            raise ValidationError("User is required")
+        return user

--- a/packages/django-app/app/knowledge/forms/set_page_favorited_form.py
+++ b/packages/django-app/app/knowledge/forms/set_page_favorited_form.py
@@ -1,0 +1,30 @@
+from django import forms
+from django.core.exceptions import ValidationError
+
+from common.forms import BaseForm, UUIDModelChoiceField
+from core.models import User
+from core.repositories import UserRepository
+
+from ..models import Page
+from ..repositories import PageRepository
+
+
+class SetPageFavoritedForm(BaseForm):
+    user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
+    page = UUIDModelChoiceField(queryset=PageRepository.get_queryset(), required=True)
+    favorited = forms.BooleanField(required=False)
+
+    def clean_page(self) -> Page:
+        page = self.cleaned_data.get("page")
+        user = self.cleaned_data.get("user")
+
+        if page and user and page.user != user:
+            raise ValidationError("Page not found")
+
+        return page
+
+    def clean_user(self) -> User:
+        user = self.cleaned_data.get("user")
+        if not user:
+            raise ValidationError("User is required")
+        return user

--- a/packages/django-app/app/knowledge/migrations/0026_page_favorited.py
+++ b/packages/django-app/app/knowledge/migrations/0026_page_favorited.py
@@ -1,0 +1,21 @@
+# Generated for issue #48: favorite pages
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("knowledge", "0025_page_sharing"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="page",
+            name="favorited",
+            field=models.BooleanField(
+                default=False,
+                help_text="Whether the user has starred this page",
+            ),
+        ),
+    ]

--- a/packages/django-app/app/knowledge/models/page.py
+++ b/packages/django-app/app/knowledge/models/page.py
@@ -75,6 +75,13 @@ class Page(UUIDModelMixin, CRUDTimestampsMixin):
         help_text="Unguessable token used in public share URLs",
     )
 
+    # User-curated "starred" flag. Pinned pages render in the left-nav
+    # Favorites section so the user can jump to their working set without
+    # searching. Unrelated to is_published / share_mode.
+    favorited = models.BooleanField(
+        default=False, help_text="Whether the user has starred this page"
+    )
+
     class Meta:
         db_table = "pages"
         unique_together = [("user", "slug")]
@@ -126,6 +133,7 @@ class Page(UUIDModelMixin, CRUDTimestampsMixin):
             "recent_blocks": None,  # fill these in later
             "share_mode": self.share_mode,
             "share_token": self.share_token,
+            "favorited": self.favorited,
         }
 
 
@@ -144,6 +152,7 @@ class PageData(TypedDict):
     recent_blocks: Optional[List[BlockData]]
     share_mode: str
     share_token: Optional[str]
+    favorited: bool
 
 
 class PagesData(TypedDict):

--- a/packages/django-app/app/knowledge/repositories/page_repository.py
+++ b/packages/django-app/app/knowledge/repositories/page_repository.py
@@ -148,6 +148,11 @@ class PageRepository(BaseRepository):
         )
 
     @classmethod
+    def get_favorited(cls, user) -> QuerySet:
+        """Get the user's starred pages, ordered by title for the sidebar."""
+        return cls.get_queryset().filter(user=user, favorited=True).order_by("title")
+
+    @classmethod
     def get_tag_page(cls, tag_name: str, user) -> Optional[Page]:
         """Get tag page by tag name"""
         try:

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4561,12 +4561,12 @@ a.sidebar-item:visited {
 }
 
 /* Hidden by default so it doesn't add chrome to every title row.
-   Reveal on hover/focus of the title row, on focus of the button
-   itself (keyboard nav), or whenever the page is favorited — a
-   filled ★ then advertises the state at a glance. */
+   Reveal on hover of the title row, on keyboard focus of the button
+   (`:focus-visible` skips mouse focus so a click doesn't pin it
+   visible after the cursor leaves), or whenever the page is
+   favorited — the filled ★ then advertises the state at a glance. */
 .page-header-flex-left:hover .page-favorite-toggle,
 .title-left:hover .page-favorite-toggle,
-.page-favorite-toggle:focus,
 .page-favorite-toggle:focus-visible,
 .page-favorite-toggle.is-favorited {
   opacity: 1;
@@ -4574,10 +4574,6 @@ a.sidebar-item:visited {
 
 .page-favorite-toggle:hover {
   color: var(--text-primary);
-}
-
-.page-favorite-toggle.is-favorited {
-  color: var(--context-color);
 }
 
 .page-title-text {

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4560,14 +4560,15 @@ a.sidebar-item:visited {
     color 0.15s ease;
 }
 
-/* Reveal on hover/focus of the surrounding title row, or whenever the
-   button itself has focus, so keyboard users can still reach it. The
-   star intentionally stays hollow + hover-only even when favorited;
-   the left-nav Favorites list and the page menu carry the state. */
+/* Hidden by default so it doesn't add chrome to every title row.
+   Reveal on hover/focus of the title row, on focus of the button
+   itself (keyboard nav), or whenever the page is favorited — a
+   filled ★ then advertises the state at a glance. */
 .page-header-flex-left:hover .page-favorite-toggle,
 .title-left:hover .page-favorite-toggle,
 .page-favorite-toggle:focus,
-.page-favorite-toggle:focus-visible {
+.page-favorite-toggle:focus-visible,
+.page-favorite-toggle.is-favorited {
   opacity: 1;
 }
 
@@ -4660,6 +4661,10 @@ a.sidebar-item:visited {
 
 .page-header-flex-left {
   flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
 }
 
 .page-title-text,

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4572,7 +4572,7 @@ a.sidebar-item:visited {
   opacity: 1;
 }
 
-.page-favorite-toggle:hover {
+.page-favorite-toggle.is-favorited {
   color: var(--text-primary);
 }
 

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -2380,6 +2380,35 @@ kbd {
   transform: rotate(90deg);
 }
 
+.leftnav-section-count {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-weight: normal;
+  font-size: 0.7rem;
+}
+
+.leftnav-favorites-body {
+  display: flex;
+  flex-direction: column;
+  padding: 0.1rem 0 0.4rem;
+}
+
+.leftnav-favorites-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.leftnav-favorite-item .leftnav-icon {
+  color: var(--text-muted);
+}
+
+.leftnav-empty {
+  padding: 0.4rem 0.6rem 0.5rem;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  font-style: italic;
+}
+
 .leftnav-recent {
   flex: 1;
   min-height: 0;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4552,12 +4552,10 @@ a.sidebar-item:visited {
   padding: 0.15rem 0.3rem;
   font-size: 1.3rem;
   line-height: 1;
-  color: var(--text-muted);
+  color: var(--text-primary);
   cursor: pointer;
   opacity: 0;
-  transition:
-    opacity 0.15s ease,
-    color 0.15s ease;
+  transition: opacity 0.15s ease;
 }
 
 /* Hidden by default so it doesn't add chrome to every title row.
@@ -4570,10 +4568,6 @@ a.sidebar-item:visited {
 .page-favorite-toggle:focus-visible,
 .page-favorite-toggle.is-favorited {
   opacity: 1;
-}
-
-.page-favorite-toggle.is-favorited {
-  color: var(--text-primary);
 }
 
 .page-title-text {

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4546,6 +4546,39 @@ a.sidebar-item:visited {
   flex: 1;
 }
 
+.page-favorite-toggle {
+  background: transparent;
+  border: none;
+  padding: 0.15rem 0.3rem;
+  font-size: 1.3rem;
+  line-height: 1;
+  color: var(--text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 0.15s ease,
+    color 0.15s ease;
+}
+
+/* Reveal on hover/focus of the surrounding title row, or whenever the
+   button itself has focus, so keyboard users can still reach it. The
+   star intentionally stays hollow + hover-only even when favorited;
+   the left-nav Favorites list and the page menu carry the state. */
+.page-header-flex-left:hover .page-favorite-toggle,
+.title-left:hover .page-favorite-toggle,
+.page-favorite-toggle:focus,
+.page-favorite-toggle:focus-visible {
+  opacity: 1;
+}
+
+.page-favorite-toggle:hover {
+  color: var(--text-primary);
+}
+
+.page-favorite-toggle.is-favorited {
+  color: var(--context-color);
+}
+
 .page-title-text {
   font-size: 2rem;
   font-weight: bold;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/LeftNav.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/LeftNav.js
@@ -35,6 +35,16 @@ window.LeftNav = {
       // localStorage can throw in private mode / disabled-cookie setups.
       // Fall back to the viewport default.
     }
+    let favoritesExpanded = true;
+    try {
+      const savedFavExpanded =
+        typeof window !== "undefined" && window.localStorage
+          ? window.localStorage.getItem("brainspread.leftNavFavoritesExpanded")
+          : null;
+      if (savedFavExpanded === "0") favoritesExpanded = false;
+    } catch (_) {
+      // ignore localStorage failures
+    }
     return {
       historicalData: null,
       loading: false,
@@ -47,6 +57,10 @@ window.LeftNav = {
       minWidth: 240,
       maxWidth: 800,
       recentExpanded: true,
+      favorites: [],
+      favoritesLoading: false,
+      favoritesError: null,
+      favoritesExpanded,
     };
   },
 
@@ -71,11 +85,22 @@ window.LeftNav = {
 
   mounted() {
     this.loadHistoricalData();
+    this.loadFavorites();
     this.setupResizeListener();
+    // The page header dispatches this when a user stars/unstars the
+    // current page so the Favorites list refreshes without a reload.
+    this.handleFavoritesChanged = () => this.loadFavorites();
+    document.addEventListener("favorites:changed", this.handleFavoritesChanged);
   },
 
   beforeUnmount() {
     this.removeResizeListener();
+    if (this.handleFavoritesChanged) {
+      document.removeEventListener(
+        "favorites:changed",
+        this.handleFavoritesChanged
+      );
+    }
   },
 
   watch: {},
@@ -125,6 +150,39 @@ window.LeftNav = {
 
     toggleRecent() {
       this.recentExpanded = !this.recentExpanded;
+    },
+
+    toggleFavorites() {
+      this.favoritesExpanded = !this.favoritesExpanded;
+      try {
+        if (typeof window !== "undefined" && window.localStorage) {
+          window.localStorage.setItem(
+            "brainspread.leftNavFavoritesExpanded",
+            this.favoritesExpanded ? "1" : "0"
+          );
+        }
+      } catch (_) {
+        // localStorage can throw in private mode; toggle still works for
+        // the current session.
+      }
+    },
+
+    async loadFavorites() {
+      this.favoritesLoading = true;
+      this.favoritesError = null;
+      try {
+        const result = await window.apiService.getFavoritedPages();
+        if (result.success) {
+          this.favorites = result.data?.pages || [];
+        } else {
+          this.favoritesError = "failed to load favorites";
+        }
+      } catch (error) {
+        console.error("error loading favorites:", error);
+        this.favoritesError = error.message || "failed to load favorites";
+      } finally {
+        this.favoritesLoading = false;
+      }
     },
 
     formatDate(dateString) {
@@ -605,6 +663,46 @@ window.LeftNav = {
               <span class="leftnav-label">graph</span>
             </a>
           </nav>
+
+          <!-- Favorites (collapsible) -->
+          <section class="leftnav-section leftnav-favorites" aria-label="Favorites">
+            <button
+              type="button"
+              class="leftnav-section-toggle"
+              @click="toggleFavorites"
+              :aria-expanded="favoritesExpanded"
+            >
+              <span class="leftnav-chevron" :class="{ open: favoritesExpanded }" aria-hidden="true">▸</span>
+              <span>favorites</span>
+              <span v-if="favorites.length" class="leftnav-section-count">{{ favorites.length }}</span>
+            </button>
+
+            <div v-if="favoritesExpanded" class="leftnav-favorites-body">
+              <div v-if="favoritesLoading" class="sidebar-loading">
+                Loading...
+              </div>
+              <div v-else-if="favoritesError" class="sidebar-error">
+                {{ favoritesError }}
+              </div>
+              <div v-else-if="!favorites.length" class="leftnav-empty">
+                No favorites yet. Star a page from its menu.
+              </div>
+              <div v-else class="leftnav-favorites-list">
+                <a
+                  v-for="page in favorites"
+                  :key="page.uuid"
+                  :href="pageUrl(page.slug)"
+                  class="leftnav-item leftnav-favorite-item"
+                  @click="handleNavClick($event, page.slug)"
+                  @auxclick="handleNavClick($event, page.slug)"
+                  :title="'Open ' + page.title"
+                >
+                  <span class="leftnav-icon" aria-hidden="true">★</span>
+                  <span class="leftnav-label">{{ formatPageTitle(page) }}</span>
+                </a>
+              </div>
+            </div>
+          </section>
 
           <!-- Recent (collapsible) -->
           <section class="leftnav-section leftnav-recent" aria-label="Recent">

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -2918,6 +2918,14 @@ const Page = {
         <div class="page-header whiteboard-page-header">
           <div class="page-title-container page-header-flex">
             <div class="page-header-flex-left">
+              <button
+                type="button"
+                class="page-favorite-toggle"
+                :class="{ 'is-favorited': isFavorited }"
+                @click="toggleFavorited"
+                :title="isFavorited ? 'Remove from favorites' : 'Add to favorites'"
+                :aria-pressed="isFavorited"
+              >☆</button>
               <div v-if="!isEditingTitle" class="page-title-display">
                 <h1 class="page-title-text" tabindex="0" role="button" aria-label="Edit page title" @click="startEditingTitle" @keydown.enter.prevent="startEditingTitle" @keydown.space.prevent="startEditingTitle">{{ page.title || 'Untitled Whiteboard' }}</h1>
               </div>
@@ -2968,6 +2976,14 @@ const Page = {
                   class="date-picker"
                   title="Navigate to date"
                 />
+                <button
+                  type="button"
+                  class="page-favorite-toggle"
+                  :class="{ 'is-favorited': isFavorited }"
+                  @click="toggleFavorited"
+                  :title="isFavorited ? 'Remove from favorites' : 'Add to favorites'"
+                  :aria-pressed="isFavorited"
+                >☆</button>
               </div>
               <div class="header-controls">
                 <div class="context-menu-container">
@@ -2998,6 +3014,14 @@ const Page = {
             <!-- Regular Page Title (Editable) -->
             <div v-else class="page-title-container page-header-flex">
               <div class="page-header-flex-left">
+                <button
+                  type="button"
+                  class="page-favorite-toggle"
+                  :class="{ 'is-favorited': isFavorited }"
+                  @click="toggleFavorited"
+                  :title="isFavorited ? 'Remove from favorites' : 'Add to favorites'"
+                  :aria-pressed="isFavorited"
+                >☆</button>
                 <div v-if="!isEditingTitle" class="page-title-display">
                   <h1 class="page-title-text" tabindex="0" role="button" aria-label="Edit page title" @click="startEditingTitle" @keydown.enter.prevent="startEditingTitle" @keydown.space.prevent="startEditingTitle">{{ page.title || 'Untitled Page' }}</h1>
                 </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -118,6 +118,10 @@ const Page = {
       return this.shareMode !== "private" && !!this.page?.share_token;
     },
 
+    isFavorited() {
+      return !!this.page?.favorited;
+    },
+
     shareUrl() {
       if (!this.page?.share_token) return "";
       return `${window.location.origin}/knowledge/share/${this.page.share_token}/`;
@@ -1573,6 +1577,29 @@ const Page = {
       this.closePageMenu();
     },
 
+    async toggleFavorited() {
+      if (!this.page) return;
+      const next = !this.isFavorited;
+      try {
+        const result = await window.apiService.setPageFavorited(
+          this.page.uuid,
+          next
+        );
+        if (result.success && result.data) {
+          this.page = { ...this.page, ...result.data };
+          // The left-nav Favorites list listens for this and refetches.
+          document.dispatchEvent(new CustomEvent("favorites:changed"));
+        } else {
+          this.$parent?.addToast?.("failed to update favorite", "error");
+        }
+      } catch (error) {
+        console.error("failed to toggle favorite:", error);
+        this.$parent?.addToast?.("failed to update favorite", "error");
+      } finally {
+        this.closePageMenu();
+      }
+    },
+
     closeShareModal() {
       this.shareModalOpen = false;
       this.shareSavingMode = null;
@@ -2913,6 +2940,10 @@ const Page = {
                 <button @click="togglePageMenu" class="btn btn-outline context-menu-btn" title="Whiteboard options" :aria-expanded="showPageMenu" aria-haspopup="menu">⋮</button>
                 <div v-if="showPageMenu" class="context-menu" @click.stop @keydown="handlePageMenuKeydown" role="menu">
                   <button @click="startEditingTitle" class="context-menu-item" role="menuitem">edit title</button>
+                  <button @click="toggleFavorited" class="context-menu-item" role="menuitem">
+                    <span class="context-menu-icon">★</span>
+                    <span>{{ isFavorited ? 'unfavorite' : 'favorite' }}</span>
+                  </button>
                   <button @click="deletePage" class="context-menu-item context-menu-danger" role="menuitem">delete whiteboard</button>
                 </div>
               </div>
@@ -2950,6 +2981,10 @@ const Page = {
                     <button @click="enterSelectionMode" class="context-menu-item" role="menuitem">
                       <span class="context-menu-icon">◉</span>
                       <span>select multiple</span>
+                    </button>
+                    <button @click="toggleFavorited" class="context-menu-item" role="menuitem">
+                      <span class="context-menu-icon">★</span>
+                      <span>{{ isFavorited ? 'unfavorite' : 'favorite' }}</span>
                     </button>
                     <button @click="deletePage" class="context-menu-item context-menu-danger" role="menuitem">
                        <span class="context-menu-icon">×</span>
@@ -2995,6 +3030,10 @@ const Page = {
                     <button @click="enterSelectionMode" class="context-menu-item" role="menuitem">
                       <span class="context-menu-icon">◉</span>
                       <span>select multiple</span>
+                    </button>
+                    <button @click="toggleFavorited" class="context-menu-item" role="menuitem">
+                      <span class="context-menu-icon">★</span>
+                      <span>{{ isFavorited ? 'unfavorite' : 'favorite' }}</span>
                     </button>
                     <button @click="openShareModal" class="context-menu-item" role="menuitem">
                       <span class="context-menu-icon">→</span>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -2925,7 +2925,7 @@ const Page = {
                 @click="toggleFavorited"
                 :title="isFavorited ? 'Remove from favorites' : 'Add to favorites'"
                 :aria-pressed="isFavorited"
-              >☆</button>
+              >{{ isFavorited ? '★' : '☆' }}</button>
               <div v-if="!isEditingTitle" class="page-title-display">
                 <h1 class="page-title-text" tabindex="0" role="button" aria-label="Edit page title" @click="startEditingTitle" @keydown.enter.prevent="startEditingTitle" @keydown.space.prevent="startEditingTitle">{{ page.title || 'Untitled Whiteboard' }}</h1>
               </div>
@@ -2983,7 +2983,7 @@ const Page = {
                   @click="toggleFavorited"
                   :title="isFavorited ? 'Remove from favorites' : 'Add to favorites'"
                   :aria-pressed="isFavorited"
-                >☆</button>
+                >{{ isFavorited ? '★' : '☆' }}</button>
               </div>
               <div class="header-controls">
                 <div class="context-menu-container">
@@ -3021,7 +3021,7 @@ const Page = {
                   @click="toggleFavorited"
                   :title="isFavorited ? 'Remove from favorites' : 'Add to favorites'"
                   :aria-pressed="isFavorited"
-                >☆</button>
+                >{{ isFavorited ? '★' : '☆' }}</button>
                 <div v-if="!isEditingTitle" class="page-title-display">
                   <h1 class="page-title-text" tabindex="0" role="button" aria-label="Edit page title" @click="startEditingTitle" @keydown.enter.prevent="startEditingTitle" @keydown.space.prevent="startEditingTitle">{{ page.title || 'Untitled Page' }}</h1>
                 </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -144,6 +144,17 @@ class ApiService {
     });
   }
 
+  async setPageFavorited(pageUuid, favorited) {
+    return await this.request("/knowledge/api/pages/favorite/", {
+      method: "POST",
+      body: JSON.stringify({ page: pageUuid, favorited: !!favorited }),
+    });
+  }
+
+  async getFavoritedPages() {
+    return await this.request("/knowledge/api/pages/favorites/");
+  }
+
   async getPages(publishedOnly = true, limit = 10, offset = 0) {
     return await this.request(
       `/knowledge/api/pages/list/?published_only=${publishedOnly}&limit=${limit}&offset=${offset}`

--- a/packages/django-app/app/knowledge/test/commands/test_get_favorited_pages_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_get_favorited_pages_command.py
@@ -1,0 +1,48 @@
+from django.test import TestCase
+
+from knowledge.commands import GetFavoritedPagesCommand
+from knowledge.forms import GetFavoritedPagesForm
+
+from ..helpers import PageFactory, UserFactory
+
+
+class TestGetFavoritedPagesCommand(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.other_user = UserFactory()
+
+        cls.fav_b = PageFactory(user=cls.user, title="Beta", favorited=True)
+        cls.fav_a = PageFactory(user=cls.user, title="Alpha", favorited=True)
+        cls.unfav = PageFactory(user=cls.user, title="Gamma", favorited=False)
+        # Another user's favorite must never leak into the response.
+        cls.other_fav = PageFactory(
+            user=cls.other_user, title="Stranger", favorited=True
+        )
+
+    def _run(self, user):
+        form = GetFavoritedPagesForm({"user": user.id})
+        self.assertTrue(form.is_valid(), form.errors)
+        return GetFavoritedPagesCommand(form).execute()
+
+    def test_should_return_only_users_favorites_sorted_by_title(self):
+        pages = self._run(self.user)
+        self.assertEqual(
+            [str(p.uuid) for p in pages],
+            [str(self.fav_a.uuid), str(self.fav_b.uuid)],
+        )
+
+    def test_should_exclude_unfavorited_pages(self):
+        pages = self._run(self.user)
+        slugs = {p.slug for p in pages}
+        self.assertNotIn(self.unfav.slug, slugs)
+
+    def test_should_not_leak_across_users(self):
+        pages = self._run(self.other_user)
+        self.assertEqual([str(p.uuid) for p in pages], [str(self.other_fav.uuid)])
+
+    def test_should_return_empty_list_when_none_favorited(self):
+        empty_user = UserFactory()
+        PageFactory(user=empty_user, title="Plain", favorited=False)
+        pages = self._run(empty_user)
+        self.assertEqual(pages, [])

--- a/packages/django-app/app/knowledge/test/commands/test_set_page_favorited_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_set_page_favorited_command.py
@@ -1,0 +1,54 @@
+from django.test import TestCase
+
+from knowledge.commands import SetPageFavoritedCommand
+from knowledge.forms import SetPageFavoritedForm
+
+from ..helpers import PageFactory, UserFactory
+
+
+class TestSetPageFavoritedCommand(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.page = PageFactory(user=cls.user, title="My Notes")
+
+    def _set(self, favorited: bool):
+        form = SetPageFavoritedForm(
+            {
+                "user": self.user.id,
+                "page": self.page.uuid,
+                "favorited": favorited,
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        return SetPageFavoritedCommand(form).execute()
+
+    def test_should_default_to_unfavorited(self):
+        # Sanity check on the model default — favoriting must be opt-in.
+        self.assertFalse(self.page.favorited)
+
+    def test_should_set_favorited_true(self):
+        page = self._set(True)
+        self.assertTrue(page.favorited)
+        page.refresh_from_db()
+        self.assertTrue(page.favorited)
+
+    def test_should_clear_favorited(self):
+        self._set(True)
+        page = self._set(False)
+        self.assertFalse(page.favorited)
+        page.refresh_from_db()
+        self.assertFalse(page.favorited)
+
+    def test_should_reject_other_users_page(self):
+        other_user = UserFactory()
+        other_page = PageFactory(user=other_user, title="Their Notes")
+        form = SetPageFavoritedForm(
+            {
+                "user": self.user.id,
+                "page": other_page.uuid,
+                "favorited": True,
+            }
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("page", form.errors)

--- a/packages/django-app/app/knowledge/urls.py
+++ b/packages/django-app/app/knowledge/urls.py
@@ -51,6 +51,12 @@ urlpatterns = [
     path("api/pages/", views.create_page, name="create_page"),
     path("api/pages/update/", views.update_page, name="update_page"),
     path("api/pages/share/", views.share_page, name="share_page"),
+    path("api/pages/favorite/", views.set_page_favorited, name="set_page_favorited"),
+    path(
+        "api/pages/favorites/",
+        views.get_favorited_pages,
+        name="get_favorited_pages",
+    ),
     path("api/pages/delete/", views.delete_page, name="delete_page"),
     path("api/pages/list/", views.get_pages, name="list_pages"),
     path("api/pages/search/", views.search_pages, name="search_pages"),

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -17,6 +17,7 @@ from knowledge.commands import (
     CreatePageCommand,
     DeleteBlockCommand,
     DeletePageCommand,
+    GetFavoritedPagesCommand,
     GetGraphDataCommand,
     GetHistoricalDataCommand,
     GetPageWithBlocksCommand,
@@ -27,6 +28,7 @@ from knowledge.commands import (
     ReorderBlocksCommand,
     ScheduleBlockCommand,
     SearchPagesCommand,
+    SetPageFavoritedCommand,
     SharePageCommand,
     ToggleBlockTodoCommand,
     UpdateBlockCommand,
@@ -46,6 +48,7 @@ from knowledge.forms import (
     CreatePageForm,
     DeleteBlockForm,
     DeletePageForm,
+    GetFavoritedPagesForm,
     GetGraphDataForm,
     GetHistoricalDataForm,
     GetPageWithBlocksForm,
@@ -56,6 +59,7 @@ from knowledge.forms import (
     ReorderBlocksForm,
     ScheduleBlockForm,
     SearchPagesForm,
+    SetPageFavoritedForm,
     SharePageForm,
     ToggleBlockTodoForm,
     UpdateBlockForm,
@@ -529,6 +533,88 @@ def share_page(request):
 
     except Exception as e:
         response: PageResponse = {
+            "success": False,
+            "data": None,
+            "errors": {"non_field_errors": [str(e)]},
+        }
+        return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def set_page_favorited(request):
+    """Star or unstar a page for the Favorites section in the left nav."""
+    try:
+        data = request.data.copy()
+        data["user"] = request.user.id
+        form = SetPageFavoritedForm(data)
+
+        if form.is_valid():
+            command = SetPageFavoritedCommand(form)
+            page = command.execute()
+
+            response: PageResponse = {
+                "success": True,
+                "data": page.to_dict(),
+                "errors": None,
+            }
+            return Response(response)
+
+        response: PageResponse = {
+            "success": False,
+            "data": None,
+            "errors": form.errors,
+        }
+        return Response(response, status=status.HTTP_400_BAD_REQUEST)
+
+    except ValidationError as e:
+        return Response(
+            {"success": False, "errors": {"non_field_errors": [str(e)]}},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    except Exception as e:
+        response: PageResponse = {
+            "success": False,
+            "data": None,
+            "errors": {"non_field_errors": [str(e)]},
+        }
+        return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def get_favorited_pages(request):
+    """Return the user's starred pages for the Favorites left-nav section."""
+    try:
+        form = GetFavoritedPagesForm({"user": request.user.id})
+
+        if form.is_valid():
+            command = GetFavoritedPagesCommand(form)
+            pages = command.execute()
+
+            pages_data: PagesData = {
+                "pages": [page.to_dict() for page in pages],
+                "total_count": len(pages),
+                "has_more": False,
+            }
+
+            response: PagesResponse = {
+                "success": True,
+                "data": pages_data,
+                "errors": None,
+            }
+            return Response(response)
+
+        response: PagesResponse = {
+            "success": False,
+            "data": None,
+            "errors": form.errors,
+        }
+        return Response(response, status=status.HTTP_400_BAD_REQUEST)
+
+    except Exception as e:
+        response: PagesResponse = {
             "success": False,
             "data": None,
             "errors": {"non_field_errors": [str(e)]},


### PR DESCRIPTION
## Summary
This PR adds a "Favorites" section to the left navigation sidebar, allowing users to star/unstar pages and quickly access their most-used pages without searching.

## Key Changes

**Backend (Django)**
- Added `favorited` boolean field to the `Page` model to track user-starred pages
- Created `SetPageFavoritedCommand` and `GetFavoritedPagesCommand` to handle favorite operations
- Created corresponding forms (`SetPageFavoritedForm`, `GetFavoritedPagesForm`) with proper validation
- Added two new API endpoints:
  - `POST /api/pages/favorite/` - Star/unstar a page
  - `GET /api/pages/favorites/` - Retrieve user's favorited pages (sorted by title)
- Added database migration to add the `favorited` field
- Updated `Page.to_dict()` to include the `favorited` flag in API responses

**Frontend (Vue.js)**
- Enhanced `LeftNav` component with a collapsible "Favorites" section that:
  - Displays count of favorited pages
  - Persists expanded/collapsed state to localStorage
  - Shows loading, error, and empty states
  - Loads favorites on mount and listens for `favorites:changed` events
- Enhanced `Page` component with:
  - `toggleFavorited()` method to star/unstar the current page
  - `isFavorited()` computed property
  - Star/favorite menu items in all three context menus (whiteboard header, block menu, etc.)
  - Dispatches `favorites:changed` event after successful favorite toggle
- Updated API service with `setPageFavorited()` and `getFavoritedPages()` methods

**Styling**
- Added CSS for the favorites section including:
  - Section count badge styling
  - Favorites list container and item styling
  - Empty state message styling
  - Star icon styling

**Testing**
- Added comprehensive test suites for both commands:
  - `TestSetPageFavoritedCommand` - Tests favoriting/unfavoriting and permission validation
  - `TestGetFavoritedPagesCommand` - Tests filtering, sorting, and user isolation

## Implementation Details
- Favorites are user-specific and properly isolated (users cannot favorite other users' pages)
- The favorites list is sorted alphabetically by page title
- Expanded/collapsed state persists across sessions using localStorage with fallback for private browsing
- The feature uses event-driven updates so the left nav refreshes when a page is favorited from the page menu
- All API endpoints require authentication

https://claude.ai/code/session_01Jo3nqefAYuNgChFPneNSpK