### PR TITLE
Add structured output (JSON schema) support across AI services

### DIFF
--- a/packages/django-app/app/ai_chat/commands/send_message_command.py
+++ b/packages/django-app/app/ai_chat/commands/send_message_command.py
@@ -85,6 +85,7 @@ class SendMessageCommand(AbstractBaseCommand):
                 "auto_approve_notes_writes"
             )
             enable_web_search = self.form.cleaned_data.get("enable_web_search", True)
+            response_format = self.form.cleaned_data.get("response_format")
             tools, tool_executor = SendMessageCommand._build_tools(
                 provider_name,
                 user,
@@ -99,6 +100,7 @@ class SendMessageCommand(AbstractBaseCommand):
                 tools,
                 system=BRAINSPREAD_SYSTEM_PROMPT,
                 tool_executor=tool_executor,
+                response_format=response_format,
             )
 
             ai_model = AIModelRepository.get_by_name(model)

--- a/packages/django-app/app/ai_chat/commands/stream_send_message_command.py
+++ b/packages/django-app/app/ai_chat/commands/stream_send_message_command.py
@@ -119,6 +119,7 @@ class StreamSendMessageCommand(AbstractBaseCommand):
                 "auto_approve_notes_writes"
             )
             enable_web_search = self.form.cleaned_data.get("enable_web_search", True)
+            response_format = self.form.cleaned_data.get("response_format")
             tools, tool_executor = SendMessageCommand._build_tools(
                 provider_name,
                 user,
@@ -144,6 +145,7 @@ class StreamSendMessageCommand(AbstractBaseCommand):
                 tools,
                 system=BRAINSPREAD_SYSTEM_PROMPT,
                 tool_executor=tool_executor,
+                response_format=response_format,
             ):
                 etype = event.get("type")
                 if etype == "text":

--- a/packages/django-app/app/ai_chat/forms.py
+++ b/packages/django-app/app/ai_chat/forms.py
@@ -39,6 +39,10 @@ class SendMessageForm(BaseForm):
     # NullBooleanField so we can distinguish "omitted" (legacy clients that
     # never send this flag expect web search on) from an explicit false.
     enable_web_search = forms.NullBooleanField(required=False)
+    # Opt-in JSON-schema structured output. When set, the assistant text is
+    # constrained to JSON validating the supplied schema. Each provider has
+    # its own wire shape; services translate from the unified dict below.
+    response_format = forms.JSONField(required=False)
 
     def clean_user(self) -> User:
         user = self.cleaned_data.get("user")
@@ -102,6 +106,43 @@ class SendMessageForm(BaseForm):
     def clean_enable_web_search(self) -> bool:
         value = self.cleaned_data.get("enable_web_search")
         return True if value is None else bool(value)
+
+    def clean_response_format(self) -> Optional[Dict]:
+        """Validate and normalize a structured-output request.
+
+        The unified shape is:
+            {
+              "type": "json_schema",       # required
+              "schema": {...JSON Schema},  # required, non-empty object
+              "name": "string",            # optional, defaults applied
+              "strict": bool               # optional (OpenAI-only)
+            }
+        Each service translates this to its native parameter on the wire.
+        """
+        value = self.cleaned_data.get("response_format")
+        if value in (None, "", {}, []):
+            return None
+        if not isinstance(value, dict):
+            raise ValidationError("response_format must be an object")
+        fmt_type = value.get("type")
+        if fmt_type != "json_schema":
+            raise ValidationError("response_format.type must be 'json_schema'")
+        schema = value.get("schema")
+        if not isinstance(schema, dict) or not schema:
+            raise ValidationError(
+                "response_format.schema must be a non-empty JSON Schema object"
+            )
+        name = value.get("name")
+        if name is not None and not isinstance(name, str):
+            raise ValidationError("response_format.name must be a string")
+        normalized: Dict = {
+            "type": fmt_type,
+            "schema": schema,
+            "name": name or "structured_response",
+        }
+        if "strict" in value:
+            normalized["strict"] = bool(value.get("strict"))
+        return normalized
 
     def clean_context_blocks(self) -> List[Dict]:
         context_blocks = self.cleaned_data.get("context_blocks")

--- a/packages/django-app/app/ai_chat/services/anthropic_service.py
+++ b/packages/django-app/app/ai_chat/services/anthropic_service.py
@@ -140,10 +140,11 @@ class AnthropicService(BaseAIService):
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
         tool_executor: Optional[ToolExecutor] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> AIServiceResult:
         try:
             self.validate_messages(messages)
-            kwargs = self._build_kwargs(messages, tools, system)
+            kwargs = self._build_kwargs(messages, tools, system, response_format)
 
             text_parts: List[str] = []
             thinking_parts: List[str] = []
@@ -350,10 +351,11 @@ class AnthropicService(BaseAIService):
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
         tool_executor: Optional[ToolExecutor] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Iterator[Dict[str, Any]]:
         try:
             self.validate_messages(messages)
-            kwargs = self._build_kwargs(messages, tools, system)
+            kwargs = self._build_kwargs(messages, tools, system, response_format)
 
             content_parts: List[str] = []
             thinking_parts: List[str] = []
@@ -576,6 +578,7 @@ class AnthropicService(BaseAIService):
         messages: List[Dict[str, Any]],
         tools: Optional[List[Dict[str, Any]]],
         system: Optional[str],
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         anthropic_messages: List[Dict[str, Any]] = []
         embedded_system: Optional[str] = None
@@ -644,8 +647,19 @@ class AnthropicService(BaseAIService):
                     "type": "enabled",
                     "budget_tokens": ENABLED_THINKING_BUDGET_TOKENS,
                 }
+        output_config: Dict[str, Any] = {}
         if self._supports_effort():
-            kwargs["output_config"] = {"effort": "high"}
+            output_config["effort"] = "high"
+        if response_format and response_format.get("type") == "json_schema":
+            # Anthropic's structured output: nest the JSON schema under
+            # output_config.format. The `name`/`strict` fields from the
+            # unified shape are OpenAI-only; Anthropic just needs the schema.
+            output_config["format"] = {
+                "type": "json_schema",
+                "schema": response_format["schema"],
+            }
+        if output_config:
+            kwargs["output_config"] = output_config
         return kwargs
 
     @staticmethod

--- a/packages/django-app/app/ai_chat/services/base_ai_service.py
+++ b/packages/django-app/app/ai_chat/services/base_ai_service.py
@@ -92,6 +92,7 @@ class BaseAIService(ABC):
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
         tool_executor: Optional[ToolExecutor] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> AIServiceResult:
         """
         Send messages to AI service and return the response.
@@ -103,6 +104,11 @@ class BaseAIService(ABC):
                 system slot should mark it with cache_control where possible.
             tool_executor: Optional callback that runs client-side tools and
                 returns results so the service can complete the tool-use loop.
+            response_format: Optional unified structured-output spec
+                (`{type: "json_schema", schema, name, strict?}`). When set,
+                each provider switches to its native JSON-schema mode and
+                `AIServiceResult.content` contains a JSON string the caller
+                can parse.
 
         Returns:
             AIServiceResult: Structured result containing the assistant text,
@@ -119,6 +125,7 @@ class BaseAIService(ABC):
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
         tool_executor: Optional[ToolExecutor] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Iterator[Dict[str, Any]]:
         """
         Stream the assistant response as incremental events.
@@ -134,7 +141,11 @@ class BaseAIService(ABC):
         Subclasses should override for true streaming.
         """
         result = self.send_message(
-            messages, tools, system=system, tool_executor=tool_executor
+            messages,
+            tools,
+            system=system,
+            tool_executor=tool_executor,
+            response_format=response_format,
         )
         if result.content:
             yield {"type": "text", "delta": result.content}

--- a/packages/django-app/app/ai_chat/services/google_service.py
+++ b/packages/django-app/app/ai_chat/services/google_service.py
@@ -35,6 +35,7 @@ class GoogleService(BaseAIService):
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
         tool_executor: Optional[ToolExecutor] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> AIServiceResult:
         try:
             self.validate_messages(messages)
@@ -51,11 +52,15 @@ class GoogleService(BaseAIService):
                 tool_config = self._convert_tools_to_google_format(tools)
 
             formatted_messages = self._build_google_payload(working_messages)
+            generation_config = self._build_generation_config(response_format)
+            extra_kwargs: Dict[str, Any] = {}
+            if generation_config is not None:
+                extra_kwargs["generation_config"] = generation_config
 
             if tool_config:
                 try:
                     response = self.client.generate_content(
-                        formatted_messages, tools=tool_config
+                        formatted_messages, tools=tool_config, **extra_kwargs
                     )
                 except google_exceptions.GoogleAPIError as e:
                     if (
@@ -65,16 +70,22 @@ class GoogleService(BaseAIService):
                         logger.warning(
                             f"Google Search Grounding not supported, falling back to regular generation: {e}"
                         )
-                        response = self.client.generate_content(formatted_messages)
+                        response = self.client.generate_content(
+                            formatted_messages, **extra_kwargs
+                        )
                     else:
                         raise e
                 except Exception as e:
                     logger.warning(
                         f"Google Search tool failed, falling back to regular generation: {e}"
                     )
-                    response = self.client.generate_content(formatted_messages)
+                    response = self.client.generate_content(
+                        formatted_messages, **extra_kwargs
+                    )
             else:
-                response = self.client.generate_content(formatted_messages)
+                response = self.client.generate_content(
+                    formatted_messages, **extra_kwargs
+                )
 
             if not response.text:
                 raise GoogleServiceError("Empty response from Google AI")
@@ -97,6 +108,7 @@ class GoogleService(BaseAIService):
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
         tool_executor: Optional[ToolExecutor] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Iterator[Dict[str, Any]]:
         try:
             self.validate_messages(messages)
@@ -112,16 +124,24 @@ class GoogleService(BaseAIService):
             # multiple round-trips, so fall back in either case.
             if tools or tool_executor is not None:
                 yield from super().stream_message(
-                    messages, tools, system=system, tool_executor=tool_executor
+                    messages,
+                    tools,
+                    system=system,
+                    tool_executor=tool_executor,
+                    response_format=response_format,
                 )
                 return
 
             formatted_messages = self._build_google_payload(working_messages)
+            generation_config = self._build_generation_config(response_format)
+            extra_kwargs: Dict[str, Any] = {"stream": True}
+            if generation_config is not None:
+                extra_kwargs["generation_config"] = generation_config
 
             content_parts: List[str] = []
             last_chunk: Any = None
 
-            stream = self.client.generate_content(formatted_messages, stream=True)
+            stream = self.client.generate_content(formatted_messages, **extra_kwargs)
             for chunk in stream:
                 last_chunk = chunk
                 text = getattr(chunk, "text", None)
@@ -189,6 +209,24 @@ class GoogleService(BaseAIService):
             for img in msg.get("images") or []:
                 parts.append({"mime_type": img["mime_type"], "data": img["data"]})
         return parts
+
+    @staticmethod
+    def _build_generation_config(
+        response_format: Optional[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        """Translate the unified structured-output spec into Gemini's
+        `generation_config`.
+
+        Gemini constrains output to JSON when both `response_mime_type` and
+        `response_schema` are set. Returns None when no structured output was
+        requested so the existing free-text behavior is unchanged.
+        """
+        if not response_format or response_format.get("type") != "json_schema":
+            return None
+        return {
+            "response_mime_type": "application/json",
+            "response_schema": response_format["schema"],
+        }
 
     def _convert_tools_to_google_format(
         self, tools: List[Dict[str, Any]]

--- a/packages/django-app/app/ai_chat/services/openai_service.py
+++ b/packages/django-app/app/ai_chat/services/openai_service.py
@@ -37,6 +37,7 @@ class OpenAIService(BaseAIService):
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
         tool_executor: Optional[ToolExecutor] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> AIServiceResult:
         try:
             self.validate_messages(messages)
@@ -51,12 +52,15 @@ class OpenAIService(BaseAIService):
             if tools:
                 return self._send_message_with_responses_api(chat_messages, tools)
 
-            kwargs = {
+            kwargs: Dict[str, Any] = {
                 "model": self.model,
                 "messages": chat_messages,
                 "max_tokens": 2000,
                 "temperature": 0.7,
             }
+            openai_response_format = self._to_openai_response_format(response_format)
+            if openai_response_format is not None:
+                kwargs["response_format"] = openai_response_format
             response: ChatCompletion = self.client.chat.completions.create(**kwargs)
 
             if not response.choices:
@@ -82,6 +86,7 @@ class OpenAIService(BaseAIService):
         tools: Optional[List[Dict[str, Any]]] = None,
         system: Optional[str] = None,
         tool_executor: Optional[ToolExecutor] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Iterator[Dict[str, Any]]:
         try:
             self.validate_messages(messages)
@@ -96,11 +101,15 @@ class OpenAIService(BaseAIService):
             # stream in either case.
             if tools or tool_executor is not None:
                 yield from super().stream_message(
-                    messages, tools, system=system, tool_executor=tool_executor
+                    messages,
+                    tools,
+                    system=system,
+                    tool_executor=tool_executor,
+                    response_format=response_format,
                 )
                 return
 
-            kwargs = {
+            kwargs: Dict[str, Any] = {
                 "model": self.model,
                 "messages": chat_messages,
                 "max_tokens": 2000,
@@ -108,6 +117,9 @@ class OpenAIService(BaseAIService):
                 "stream": True,
                 "stream_options": {"include_usage": True},
             }
+            openai_response_format = self._to_openai_response_format(response_format)
+            if openai_response_format is not None:
+                kwargs["response_format"] = openai_response_format
 
             content_parts: List[str] = []
             usage = AIUsage()
@@ -232,6 +244,26 @@ class OpenAIService(BaseAIService):
             content=content,
             usage=self._extract_usage(getattr(response, "usage", None)),
         )
+
+    @staticmethod
+    def _to_openai_response_format(
+        response_format: Optional[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        """Translate the unified structured-output spec into OpenAI's wire shape.
+
+        OpenAI expects `{type: "json_schema", json_schema: {name, schema, strict?}}`
+        on chat.completions. Returns None if the caller didn't request a
+        structured output.
+        """
+        if not response_format or response_format.get("type") != "json_schema":
+            return None
+        json_schema: Dict[str, Any] = {
+            "name": response_format.get("name") or "structured_response",
+            "schema": response_format["schema"],
+        }
+        if "strict" in response_format:
+            json_schema["strict"] = bool(response_format["strict"])
+        return {"type": "json_schema", "json_schema": json_schema}
 
     @staticmethod
     def _to_openai_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/packages/django-app/app/ai_chat/test/test_approval_flow.py
+++ b/packages/django-app/app/ai_chat/test/test_approval_flow.py
@@ -74,7 +74,9 @@ class ApprovalPausePersistTestCase(TestCase):
             ],
         )
 
-        def fake_stream(messages, tools, system=None, tool_executor=None):
+        def fake_stream(
+            messages, tools, system=None, tool_executor=None, response_format=None
+        ):
             yield {"type": "text", "delta": "I'll edit block X."}
             yield {"type": "approval_required", "tool_uses": pending.tool_uses}
             yield {
@@ -171,7 +173,9 @@ class ResumeApprovalCommandTestCase(TestCase):
     ):
         session, approval = self._create_pending()
 
-        def fake_stream(messages, tools, system=None, tool_executor=None):
+        def fake_stream(
+            messages, tools, system=None, tool_executor=None, response_format=None
+        ):
             yield {"type": "text", "delta": "Done."}
             yield {
                 "type": "done",
@@ -215,7 +219,9 @@ class ResumeApprovalCommandTestCase(TestCase):
     def test_resume_rejected_skips_execute(self, mock_execute, mock_create_service):
         session, approval = self._create_pending()
 
-        def fake_stream(messages, tools, system=None, tool_executor=None):
+        def fake_stream(
+            messages, tools, system=None, tool_executor=None, response_format=None
+        ):
             yield {
                 "type": "done",
                 "content": "",
@@ -265,7 +271,9 @@ class ResumeApprovalCommandTestCase(TestCase):
 
         captured_executor = {}
 
-        def fake_stream(messages, tools, system=None, tool_executor=None):
+        def fake_stream(
+            messages, tools, system=None, tool_executor=None, response_format=None
+        ):
             captured_executor["e"] = tool_executor
             yield {
                 "type": "done",

--- a/packages/django-app/app/ai_chat/test/test_send_message_command.py
+++ b/packages/django-app/app/ai_chat/test/test_send_message_command.py
@@ -130,6 +130,7 @@ class SendMessageCommandTestCase(TestCase):
             [{"type": "web_search_preview", "search_context_size": "medium"}],
             system=BRAINSPREAD_SYSTEM_PROMPT,
             tool_executor=None,
+            response_format=None,
         )
 
     @patch("ai_chat.services.ai_service_factory.AIServiceFactory.create_service")
@@ -472,6 +473,85 @@ class SendMessageCommandTestCase(TestCase):
         self.assertTrue(form.is_valid(), form.errors)
         self.assertFalse(form.cleaned_data["enable_web_search"])
 
+    def test_form_omits_response_format_by_default(self):
+        # response_format is opt-in; when the client doesn't send it the
+        # cleaned value is None and downstream services pass through the
+        # provider default (free-form text).
+        form = self._create_form()
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertIsNone(form.cleaned_data.get("response_format"))
+
+    def test_form_accepts_valid_json_schema_response_format(self):
+        form_data = {
+            "user": self.user.id,
+            "message": "extract",
+            "model": "gpt-4",
+            "context_blocks": [],
+            "response_format": {
+                "type": "json_schema",
+                "name": "tag_list",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "tags": {"type": "array", "items": {"type": "string"}}
+                    },
+                    "required": ["tags"],
+                },
+                "strict": True,
+            },
+        }
+        form = SendMessageForm(form_data)
+        self.assertTrue(form.is_valid(), form.errors)
+        cleaned = form.cleaned_data["response_format"]
+        self.assertEqual(cleaned["type"], "json_schema")
+        self.assertEqual(cleaned["name"], "tag_list")
+        self.assertTrue(cleaned["strict"])
+        self.assertEqual(cleaned["schema"]["required"], ["tags"])
+
+    def test_form_assigns_default_response_format_name(self):
+        form_data = {
+            "user": self.user.id,
+            "message": "extract",
+            "model": "gpt-4",
+            "context_blocks": [],
+            "response_format": {
+                "type": "json_schema",
+                "schema": {"type": "object", "properties": {}},
+            },
+        }
+        form = SendMessageForm(form_data)
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(
+            form.cleaned_data["response_format"]["name"], "structured_response"
+        )
+        # `strict` is omitted unless the caller sets it — keeps OpenAI from
+        # rejecting requests on models that don't accept the flag.
+        self.assertNotIn("strict", form.cleaned_data["response_format"])
+
+    def test_form_rejects_unsupported_response_format_type(self):
+        form_data = {
+            "user": self.user.id,
+            "message": "x",
+            "model": "gpt-4",
+            "context_blocks": [],
+            "response_format": {"type": "regex", "schema": {"type": "object"}},
+        }
+        form = SendMessageForm(form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("response_format", form.errors)
+
+    def test_form_rejects_response_format_without_schema(self):
+        form_data = {
+            "user": self.user.id,
+            "message": "x",
+            "model": "gpt-4",
+            "context_blocks": [],
+            "response_format": {"type": "json_schema"},
+        }
+        form = SendMessageForm(form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("response_format", form.errors)
+
     def test_format_message_no_context_blocks(self):
         """Test message formatting without context blocks"""
         form = self._create_form(message="Simple question")
@@ -496,6 +576,58 @@ class SendMessageCommandTestCase(TestCase):
             "Question with empty context", context_blocks
         )
         self.assertEqual(formatted_message, "Question with empty context")
+
+    @patch("ai_chat.services.ai_service_factory.AIServiceFactory.create_service")
+    @patch(
+        "ai_chat.repositories.chat_session_repository.ChatSessionRepository.create_session"
+    )
+    @patch(
+        "ai_chat.repositories.chat_message_repository.ChatMessageRepository.add_message"
+    )
+    @patch(
+        "ai_chat.repositories.chat_message_repository.ChatMessageRepository.get_messages"
+    )
+    def test_execute_passes_response_format_to_service(
+        self,
+        mock_get_messages,
+        mock_add_message,
+        mock_create_session,
+        mock_create_service,
+    ):
+        """response_format flows from the form through to service.send_message."""
+        mock_session = Mock()
+        mock_session.uuid = "test-session-uuid"
+        mock_create_session.return_value = mock_session
+
+        mock_message = Mock(role="user", content="extract")
+        mock_get_messages.return_value = [mock_message]
+
+        mock_service = Mock()
+        mock_service.send_message.return_value = AIServiceResult(content="{}")
+        mock_create_service.return_value = mock_service
+
+        form_data = {
+            "user": self.user.id,
+            "message": "extract",
+            "model": "gpt-4",
+            "context_blocks": [],
+            "response_format": {
+                "type": "json_schema",
+                "schema": {
+                    "type": "object",
+                    "properties": {"tags": {"type": "array"}},
+                },
+            },
+        }
+        form = SendMessageForm(form_data)
+        self.assertTrue(form.is_valid(), form.errors)
+        SendMessageCommand(form).execute()
+
+        kwargs = mock_service.send_message.call_args.kwargs
+        rf = kwargs["response_format"]
+        self.assertEqual(rf["type"], "json_schema")
+        self.assertEqual(rf["name"], "structured_response")
+        self.assertEqual(rf["schema"]["properties"]["tags"], {"type": "array"})
 
     @patch("ai_chat.services.ai_service_factory.AIServiceFactory.create_service")
     @patch(

--- a/packages/django-app/app/ai_chat/test/test_stream_send_message_command.py
+++ b/packages/django-app/app/ai_chat/test/test_stream_send_message_command.py
@@ -54,7 +54,9 @@ class StreamSendMessageCommandTestCase(TestCase):
     ):
         mock_get_messages.return_value = [Mock(role="user", content="Hello")]
 
-        def fake_stream(messages, tools, system=None, tool_executor=None):
+        def fake_stream(
+            messages, tools, system=None, tool_executor=None, response_format=None
+        ):
             yield {"type": "text", "delta": "Hi "}
             yield {"type": "text", "delta": "there"}
             yield {
@@ -94,7 +96,9 @@ class StreamSendMessageCommandTestCase(TestCase):
     ):
         mock_get_messages.return_value = [Mock(role="user", content="ask")]
 
-        def fake_stream(messages, tools, system=None, tool_executor=None):
+        def fake_stream(
+            messages, tools, system=None, tool_executor=None, response_format=None
+        ):
             yield {"type": "text", "delta": "Looking up..."}
             yield {
                 "type": "tool_use",

--- a/packages/django-app/app/ai_chat/tests/test_anthropic_service.py
+++ b/packages/django-app/app/ai_chat/tests/test_anthropic_service.py
@@ -122,6 +122,90 @@ class TestAnthropicServiceThinking:
             service.send_message([{"role": "user"}])
 
 
+class TestAnthropicResponseFormat:
+    @patch("anthropic.Anthropic")
+    def test_passes_json_schema_via_output_config_format(self, mock_anthropic_cls):
+        # Anthropic's structured-output knob lives at output_config.format —
+        # when the caller asks for json_schema, the schema must arrive in
+        # that nested shape, alongside any pre-existing effort knob.
+        mock_client = Mock()
+        mock_client.messages.create.return_value = _build_response(text='{"a":1}')
+        mock_anthropic_cls.return_value = mock_client
+
+        service = AnthropicService(api_key="k", model="claude-opus-4-7")
+        schema = {"type": "object", "properties": {"a": {"type": "integer"}}}
+        service.send_message(
+            [{"role": "user", "content": "go"}],
+            response_format={
+                "type": "json_schema",
+                "name": "ignored_by_anthropic",
+                "schema": schema,
+            },
+        )
+
+        kwargs = mock_client.messages.create.call_args.kwargs
+        # output_config keeps effort AND gains the json_schema format
+        assert kwargs["output_config"]["effort"] == "high"
+        assert kwargs["output_config"]["format"] == {
+            "type": "json_schema",
+            "schema": schema,
+        }
+
+    @patch("anthropic.Anthropic")
+    def test_omits_format_when_no_response_format(self, mock_anthropic_cls):
+        mock_client = Mock()
+        mock_client.messages.create.return_value = _build_response()
+        mock_anthropic_cls.return_value = mock_client
+
+        service = AnthropicService(api_key="k", model="claude-opus-4-7")
+        service.send_message([{"role": "user", "content": "hi"}])
+
+        kwargs = mock_client.messages.create.call_args.kwargs
+        # Effort still set, but no `format` key — keeps the request shape
+        # identical to pre-feature behaviour.
+        assert kwargs["output_config"] == {"effort": "high"}
+
+    @patch("anthropic.Anthropic")
+    def test_skips_output_config_on_unsupported_model_without_format(
+        self, mock_anthropic_cls
+    ):
+        # Older models don't accept output_config.effort. With no
+        # response_format requested either, the kwarg should be omitted
+        # entirely so the API doesn't 400.
+        mock_client = Mock()
+        mock_client.messages.create.return_value = _build_response()
+        mock_anthropic_cls.return_value = mock_client
+
+        service = AnthropicService(api_key="k", model="claude-3-5-sonnet-legacy")
+        service.send_message([{"role": "user", "content": "hi"}])
+
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert "output_config" not in kwargs
+
+    @patch("anthropic.Anthropic")
+    def test_format_only_when_model_lacks_effort(self, mock_anthropic_cls):
+        # If the model doesn't support effort but the caller asked for
+        # a json_schema, output_config should still go out — just
+        # without the effort knob.
+        mock_client = Mock()
+        mock_client.messages.create.return_value = _build_response(text="{}")
+        mock_anthropic_cls.return_value = mock_client
+
+        service = AnthropicService(api_key="k", model="claude-haiku-4-5")
+        schema = {"type": "object"}
+        service.send_message(
+            [{"role": "user", "content": "x"}],
+            response_format={"type": "json_schema", "schema": schema},
+        )
+
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert "effort" not in kwargs.get("output_config", {})
+        assert kwargs["output_config"]["format"] == {
+            "type": "json_schema",
+            "schema": schema,
+        }
+
+
 class TestSerializeBlock:
     """`_serialize_block` must round-trip every block type Anthropic emits
     so the next messages.create call accepts the replayed assistant turn.

--- a/packages/django-app/app/ai_chat/tests/test_google_service.py
+++ b/packages/django-app/app/ai_chat/tests/test_google_service.py
@@ -160,6 +160,51 @@ class TestGoogleService:
         result = service.validate_api_key()
         assert result is False
 
+    @patch("google.generativeai.GenerativeModel")
+    def test_send_message_passes_response_format_via_generation_config(
+        self, mock_model_class
+    ):
+        """Caller-supplied json_schema should land in generation_config."""
+        mock_response = Mock()
+        mock_response.text = '{"a":1}'
+        mock_response.usage_metadata = None
+
+        mock_model = Mock()
+        mock_model.generate_content.return_value = mock_response
+        mock_model_class.return_value = mock_model
+
+        service = GoogleService(api_key="test-key", model="gemini-1.5-pro")
+        schema = {"type": "object", "properties": {"a": {"type": "integer"}}}
+        service.send_message(
+            [{"role": "user", "content": "extract"}],
+            response_format={"type": "json_schema", "schema": schema},
+        )
+
+        kwargs = mock_model.generate_content.call_args.kwargs
+        gen_config = kwargs["generation_config"]
+        assert gen_config["response_mime_type"] == "application/json"
+        assert gen_config["response_schema"] == schema
+
+    @patch("google.generativeai.GenerativeModel")
+    def test_send_message_omits_generation_config_when_no_response_format(
+        self, mock_model_class
+    ):
+        mock_response = Mock()
+        mock_response.text = "ok"
+        mock_response.usage_metadata = None
+
+        mock_model = Mock()
+        mock_model.generate_content.return_value = mock_response
+        mock_model_class.return_value = mock_model
+
+        service = GoogleService(api_key="test-key", model="gemini-1.5-pro")
+        service.send_message([{"role": "user", "content": "hi"}])
+
+        kwargs = mock_model.generate_content.call_args.kwargs
+        # Without a structured-output request we don't pass generation_config
+        # at all — keeps default decoding behavior intact.
+        assert "generation_config" not in kwargs
+
     def test_format_messages_for_google(self):
         """Test message formatting for Google AI"""
         service = GoogleService(api_key="test-key", model="gemini-1.5-pro")

--- a/packages/django-app/app/ai_chat/tests/test_openai_service.py
+++ b/packages/django-app/app/ai_chat/tests/test_openai_service.py
@@ -59,6 +59,51 @@ class TestOpenAIServiceUsage:
         }
 
     @patch("ai_chat.services.openai_service.OpenAI")
+    def test_passes_response_format_json_schema(self, mock_openai_cls):
+        # OpenAI's chat.completions takes
+        # `response_format={"type": "json_schema", "json_schema": {name, schema, strict?}}`.
+        # The unified shape from the form maps onto that wire format.
+        mock_client = Mock()
+        mock_client.chat.completions.create.return_value = _build_chat_response(
+            text='{"x": 1}'
+        )
+        mock_openai_cls.return_value = mock_client
+
+        service = OpenAIService(api_key="k", model="gpt-4o")
+        schema = {"type": "object", "properties": {"x": {"type": "integer"}}}
+        service.send_message(
+            [{"role": "user", "content": "extract"}],
+            response_format={
+                "type": "json_schema",
+                "name": "extract_x",
+                "schema": schema,
+                "strict": True,
+            },
+        )
+
+        kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert kwargs["response_format"] == {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "extract_x",
+                "schema": schema,
+                "strict": True,
+            },
+        }
+
+    @patch("ai_chat.services.openai_service.OpenAI")
+    def test_omits_response_format_when_not_requested(self, mock_openai_cls):
+        mock_client = Mock()
+        mock_client.chat.completions.create.return_value = _build_chat_response()
+        mock_openai_cls.return_value = mock_client
+
+        service = OpenAIService(api_key="k", model="gpt-4o")
+        service.send_message([{"role": "user", "content": "hi"}])
+
+        kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert "response_format" not in kwargs
+
+    @patch("ai_chat.services.openai_service.OpenAI")
     def test_does_not_duplicate_system_prompt(self, mock_openai_cls):
         mock_client = Mock()
         mock_client.chat.completions.create.return_value = _build_chat_response()


### PR DESCRIPTION
## Summary
This PR adds support for structured output (JSON schema) across all AI service providers (OpenAI, Anthropic, Google). Users can now request JSON-constrained responses through a unified `response_format` parameter that gets translated to each provider's native format.

## Key Changes

### Form & Validation (`forms.py`)
- Added `response_format` JSONField to `SendMessageForm`
- Implemented `clean_response_format()` to validate and normalize structured-output requests
- Supports optional `name` and `strict` fields; applies sensible defaults (`name="structured_response"`)
- Rejects unsupported types and missing/empty schemas

### Service Base Class (`base_ai_service.py`)
- Added `response_format` parameter to `send_message()` and `stream_message()` signatures
- Updated docstrings to document the unified structured-output spec

### OpenAI Service (`openai_service.py`)
- Added `_to_openai_response_format()` static method to translate unified spec to OpenAI's wire format
- Maps `{type: "json_schema", schema, name, strict?}` → `{type: "json_schema", json_schema: {...}}`
- Conditionally includes `response_format` in API calls only when requested

### Anthropic Service (`anthropic_service.py`)
- Integrated structured output into `_build_kwargs()` method
- Translates to Anthropic's `output_config.format` nested structure
- Preserves existing `effort: "high"` setting while adding format when requested
- Handles model-specific capabilities (older models don't support `effort`)

### Google Service (`google_service.py`)
- Added `_build_generation_config()` static method
- Maps unified spec to Gemini's `generation_config` with `response_mime_type` and `response_schema`
- Passes config through all code paths (with/without tools, streaming/non-streaming)

### Commands (`send_message_command.py`, `stream_send_message_command.py`)
- Updated to extract and pass `response_format` from form to service layer

### Tests
- Added comprehensive test coverage for form validation (valid schemas, defaults, error cases)
- Added service-level tests for each provider's wire format translation
- Updated existing test mocks to include `response_format=None` parameter
- Verified end-to-end flow from form through to service calls

## Implementation Details
- The unified `response_format` dict is provider-agnostic; each service translates to its native shape
- When `response_format` is `None` or omitted, services behave identically to pre-feature behavior
- Default name `"structured_response"` is applied if not provided by caller
- The `strict` field is only included in the final request if explicitly set (avoids API rejections on models that don't support it)

https://claude.ai/code/session_01Qe6LcqZGtnbzQmodGGhhxc