### PR TITLE
Add reminder action tokens for Discord quick-actions

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -24,7 +24,7 @@ jobs:
           PR_BRANCH: ${{ github.head_ref }}
           PORT: ${{ steps.vars.outputs.port }}
           STAGING_BASE_DIR: ${{ vars.DO_STAGING_BASE_DIR }}
-          DO_STAGING_HOST: ${{ vars.DO_STAGING_HOST }}
+          DO_STAGING_HOST: ${{ secrets.DO_STAGING_HOST }}
           DJANGO_SUPERUSER_EMAIL: ${{ secrets.SUPERUSER_EMAIL }}
           DJANGO_SUPERUSER_PASSWORD: ${{ secrets.SUPERUSER_PASSWORD }}
           STAGING_DISCORD_WEBHOOK_URL: ${{ secrets.STAGING_DISCORD_WEBHOOK_URL }}

--- a/packages/django-app/app/knowledge/admin.py
+++ b/packages/django-app/app/knowledge/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Block, Page, Reminder
+from .models import Block, Page, Reminder, ReminderAction
 
 
 @admin.register(Page)
@@ -157,3 +157,20 @@ class ReminderAdmin(admin.ModelAdmin):
             },
         ),
     )
+
+
+@admin.register(ReminderAction)
+class ReminderActionAdmin(admin.ModelAdmin):
+    list_display = (
+        "short_uuid",
+        "reminder",
+        "action",
+        "used_at",
+        "expires_at",
+        "created_at",
+    )
+    list_filter = ("action", "created_at")
+    search_fields = ("token", "reminder__block__user__email")
+    readonly_fields = ("id", "uuid", "token", "created_at", "modified_at")
+    raw_id_fields = ("reminder",)
+    ordering = ("-created_at",)

--- a/packages/django-app/app/knowledge/commands/__init__.py
+++ b/packages/django-app/app/knowledge/commands/__init__.py
@@ -6,6 +6,7 @@ from .bulk_schedule_command import BulkScheduleCommand
 from .bulk_set_block_type_command import BulkSetBlockTypeCommand
 from .bulk_snooze_command import BulkSnoozeCommand
 from .cancel_reminder_command import CancelReminderCommand
+from .consume_reminder_action_command import ConsumeReminderActionCommand
 from .create_block_command import CreateBlockCommand
 from .create_blocks_bulk_command import CreateBlocksBulkCommand
 from .create_page_command import CreatePageCommand

--- a/packages/django-app/app/knowledge/commands/consume_reminder_action_command.py
+++ b/packages/django-app/app/knowledge/commands/consume_reminder_action_command.py
@@ -1,0 +1,185 @@
+from datetime import timedelta
+from typing import Optional, TypedDict
+
+from django.db import transaction
+from django.utils import timezone
+
+from common.commands.abstract_base_command import AbstractBaseCommand
+
+from ..forms.consume_reminder_action_form import ConsumeReminderActionForm
+from ..forms.set_block_type_form import SetBlockTypeForm
+from ..models import Block, Reminder, ReminderAction
+from .set_block_type_command import SetBlockTypeCommand
+
+
+class ConsumeReminderActionData(TypedDict):
+    status: str
+    action: Optional[str]
+    block_uuid: Optional[str]
+    page_slug: Optional[str]
+    detail: str
+
+
+class ConsumeReminderActionCommand(AbstractBaseCommand):
+    """Resolve and execute a reminder action token.
+
+    The webhook reply view hands a raw `token` here. Outcomes:
+    - `executed` — token was valid and the action ran. `block_uuid`
+      and `page_slug` are populated so the view can build a "back to
+      block" link.
+    - `not_found` — no row for this token. Likely a typo or a token
+      from before this feature shipped.
+    - `expired` — token is past its `expires_at`. We don't extend.
+    - `already_used` — token was consumed already (single-use).
+    - `block_completed` — the block transitioned to a terminal state
+      (done/wontdo) before the user clicked. We treat this as a
+      no-op success: there's nothing useful left to do, and snoozing
+      a finished todo would be confusing.
+
+    The whole consume runs in a transaction so the action mutation
+    and `mark_used` flip atomically — no half-applied side effects
+    if the inner command raises.
+    """
+
+    def __init__(self, form: ConsumeReminderActionForm) -> None:
+        self.form = form
+
+    def execute(self) -> ConsumeReminderActionData:
+        super().execute()
+
+        token: str = self.form.cleaned_data["token"]
+        now = self.form.cleaned_data.get("now") or timezone.now()
+
+        try:
+            action_row: ReminderAction = ReminderAction.objects.select_related(
+                "reminder", "reminder__block", "reminder__block__page"
+            ).get(token=token)
+        except ReminderAction.DoesNotExist:
+            return _result("not_found", detail="Unknown action link.")
+
+        if action_row.used_at is not None:
+            return _result(
+                "already_used",
+                action=action_row.action,
+                detail="This action link has already been used.",
+            )
+
+        if now >= action_row.expires_at:
+            return _result(
+                "expired",
+                action=action_row.action,
+                detail="This action link has expired.",
+            )
+
+        reminder: Reminder = action_row.reminder
+        block: Block = reminder.block
+
+        if block.completed_at is not None:
+            # Stamp the token used so a stale link can't be replayed
+            # later, but report the no-op so the view can render
+            # something honest.
+            with transaction.atomic():
+                action_row.mark_used(now=now)
+            return _result(
+                "block_completed",
+                action=action_row.action,
+                block_uuid=str(block.uuid),
+                page_slug=block.page.slug if block.page_id else None,
+                detail="That block is already complete.",
+            )
+
+        with transaction.atomic():
+            self._apply_action(action_row.action, block, reminder, now)
+            action_row.mark_used(now=now)
+
+        return _result(
+            "executed",
+            action=action_row.action,
+            block_uuid=str(block.uuid),
+            page_slug=block.page.slug if block.page_id else None,
+            detail=_executed_detail(action_row.action),
+        )
+
+    def _apply_action(
+        self,
+        action: str,
+        block: Block,
+        reminder: Reminder,
+        now,
+    ) -> None:
+        if action == ReminderAction.ACTION_COMPLETE:
+            self._mark_block_done(block)
+            return
+
+        delta = _SNOOZE_DELTAS.get(action)
+        if delta is None:
+            # Choices are constrained at the model layer, so we'd only
+            # land here on a schema/data drift. Surface it loudly.
+            raise ValueError(f"unsupported reminder action: {action}")
+
+        self._snooze_reminder(reminder, delta, now)
+
+    @staticmethod
+    def _mark_block_done(block: Block) -> None:
+        # Routing through SetBlockTypeCommand keeps the completion
+        # behavior consistent with toggle-todo / chat tools — including
+        # the side-effect that flips any pending reminders to skipped.
+        set_form = SetBlockTypeForm(
+            {"user": block.user_id, "block": str(block.uuid), "block_type": "done"}
+        )
+        if not set_form.is_valid():
+            raise AssertionError(f"SetBlockTypeForm invalid: {set_form.errors}")
+        SetBlockTypeCommand(set_form).execute()
+
+    @staticmethod
+    def _snooze_reminder(reminder: Reminder, delta: timedelta, now) -> None:
+        # Reuse this Reminder row instead of spawning a new one. Resetting
+        # status + sent_at brings it back into the pending-reminder world,
+        # which means `Block.get_pending_reminder()` (used by the popover
+        # and snooze tools) will surface it again.
+        reminder.fire_at = now + delta
+        reminder.sent_at = None
+        reminder.status = Reminder.STATUS_PENDING
+        reminder.last_error = ""
+        reminder.save(
+            update_fields=[
+                "fire_at",
+                "sent_at",
+                "status",
+                "last_error",
+                "modified_at",
+            ]
+        )
+
+
+_SNOOZE_DELTAS = {
+    ReminderAction.ACTION_SNOOZE_1H: timedelta(hours=1),
+    ReminderAction.ACTION_SNOOZE_1D: timedelta(days=1),
+}
+
+
+def _executed_detail(action: str) -> str:
+    if action == ReminderAction.ACTION_COMPLETE:
+        return "Marked the block as done."
+    if action == ReminderAction.ACTION_SNOOZE_1H:
+        return "Snoozed for 1 hour."
+    if action == ReminderAction.ACTION_SNOOZE_1D:
+        return "Snoozed for 1 day."
+    return "Action applied."
+
+
+def _result(
+    status: str,
+    *,
+    action: Optional[str] = None,
+    block_uuid: Optional[str] = None,
+    page_slug: Optional[str] = None,
+    detail: str = "",
+) -> ConsumeReminderActionData:
+    return {
+        "status": status,
+        "action": action,
+        "block_uuid": block_uuid,
+        "page_slug": page_slug,
+        "detail": detail,
+    }

--- a/packages/django-app/app/knowledge/commands/send_due_reminders_command.py
+++ b/packages/django-app/app/knowledge/commands/send_due_reminders_command.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import List, Tuple, TypedDict
+from typing import Dict, List, Tuple, TypedDict
 
 from django.conf import settings
 from django.db import transaction
@@ -8,8 +8,12 @@ from django.utils import timezone
 
 from common.commands.abstract_base_command import AbstractBaseCommand
 from knowledge.forms.send_due_reminders_form import SendDueRemindersForm
-from knowledge.models import Reminder
+from knowledge.models import Reminder, ReminderAction
 from knowledge.services.discord_webhook import post_webhook
+from knowledge.services.reminder_actions import (
+    build_action_url,
+    create_action_tokens,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +84,12 @@ class SendDueRemindersCommand(AbstractBaseCommand):
                     skipped += 1
                     continue
 
+                # Mint the per-action tokens before posting so the
+                # links in the message resolve. Failing to mint tokens
+                # shouldn't block the reminder itself — fall back to a
+                # link-less embed so the user still gets pinged.
+                action_urls = _action_urls_for(reminder, settings.SITE_URL, now)
+
                 content, embeds = _build_payload(
                     reminder,
                     block,
@@ -88,6 +98,7 @@ class SendDueRemindersCommand(AbstractBaseCommand):
                     site_url=settings.SITE_URL,
                     pr_number=pr_number,
                     pr_url=pr_url,
+                    action_urls=action_urls,
                 )
                 url = block.user.discord_webhook_url
                 # Look up post_webhook at call time (not via `self.deliver`)
@@ -136,6 +147,31 @@ _COLOR_STAGING = 0xF59E0B  # amber
 _COLOR_DEFAULT = 0x6B7280  # gray (local / unknown)
 
 
+def _action_urls_for(reminder: Reminder, site_url: str, now) -> Dict[str, str]:
+    """Mint reminder-action tokens and return their absolute URLs.
+
+    Returns `{action: url}`. Skips when SITE_URL isn't a real http(s)
+    URL — without a working absolute base, the embed links would 404 so
+    the reminder is better off without them. Errors are swallowed so a
+    DB hiccup creating tokens doesn't block delivery; we log + carry
+    on. Worst case the user gets a notification with no quick-actions.
+    """
+    if not site_url or not site_url.startswith(("http://", "https://")):
+        return {}
+    try:
+        rows = create_action_tokens(reminder, now=now)
+    except Exception as e:
+        logger.warning(
+            "failed to mint reminder action tokens for %s: %s",
+            reminder.uuid,
+            e,
+        )
+        return {}
+    return {
+        action: build_action_url(site_url, row.token) for action, row in rows.items()
+    }
+
+
 def _build_payload(
     reminder: Reminder,
     block,
@@ -145,6 +181,7 @@ def _build_payload(
     site_url: str = "",
     pr_number: str = "",
     pr_url: str = "",
+    action_urls: Dict[str, str] | None = None,
 ) -> Tuple[str, List[dict]]:
     """Return `(content, [embed])` for the Discord webhook payload.
 
@@ -180,9 +217,19 @@ def _build_payload(
     if reminder.fire_at:
         embed["timestamp"] = reminder.fire_at.isoformat()
 
+    description_lines: List[str] = []
     page_link = _page_link(block, site_url)
     if page_link:
-        embed["description"] = f"[Open block →]({page_link})"
+        description_lines.append(f"[Open block →]({page_link})")
+
+    action_line = _action_links_line(action_urls or {})
+    if action_line:
+        description_lines.append(action_line)
+
+    if description_lines:
+        # Two newlines so Discord renders each link group on its own
+        # line without collapsing the second into a continuation.
+        embed["description"] = "\n\n".join(description_lines)
 
     if block.scheduled_for:
         embed["fields"] = [
@@ -232,6 +279,28 @@ def _author_block(environment: str, pr_number: str, pr_url: str) -> dict:
     if pr_url and pr_url.startswith(("http://", "https://")):
         author["url"] = pr_url
     return author
+
+
+_ACTION_LABELS = [
+    (ReminderAction.ACTION_COMPLETE, "Mark done"),
+    (ReminderAction.ACTION_SNOOZE_1H, "Snooze 1h"),
+    (ReminderAction.ACTION_SNOOZE_1D, "Snooze 1d"),
+]
+
+
+def _action_links_line(action_urls: Dict[str, str]) -> str:
+    """Render the inline action-link row, e.g.
+    `[Mark done](u1) · [Snooze 1h](u2) · [Snooze 1d](u3)`.
+
+    Returns "" when no urls are supplied — the embed is then rendered
+    without a quick-action row, same as before this feature.
+    """
+    parts: List[str] = []
+    for action, label in _ACTION_LABELS:
+        url = action_urls.get(action)
+        if url:
+            parts.append(f"[{label}]({url})")
+    return " · ".join(parts)
 
 
 def _page_link(block, site_url: str) -> str:

--- a/packages/django-app/app/knowledge/forms/__init__.py
+++ b/packages/django-app/app/knowledge/forms/__init__.py
@@ -6,6 +6,7 @@ from .bulk_schedule_form import BulkScheduleForm
 from .bulk_set_block_type_form import BulkSetBlockTypeForm
 from .bulk_snooze_form import BulkSnoozeForm
 from .cancel_reminder_form import CancelReminderForm
+from .consume_reminder_action_form import ConsumeReminderActionForm
 from .create_block_form import CreateBlockForm
 from .create_blocks_bulk_form import CreateBlocksBulkForm
 from .create_page_form import CreatePageForm

--- a/packages/django-app/app/knowledge/forms/consume_reminder_action_form.py
+++ b/packages/django-app/app/knowledge/forms/consume_reminder_action_form.py
@@ -1,0 +1,17 @@
+from django import forms
+
+from common.forms import BaseForm
+
+
+class ConsumeReminderActionForm(BaseForm):
+    """Inputs for `ConsumeReminderActionCommand`.
+
+    The token is the only piece of authority the caller needs: it
+    resolves to a (reminder, action) pair and proves the holder is
+    allowed to run that action on that reminder. `now` is accepted
+    purely so tests can pin a deterministic clock — production callers
+    leave it absent.
+    """
+
+    token = forms.CharField(max_length=64, required=True)
+    now = forms.DateTimeField(required=False)

--- a/packages/django-app/app/knowledge/migrations/0028_reminderaction.py
+++ b/packages/django-app/app/knowledge/migrations/0028_reminderaction.py
@@ -1,0 +1,94 @@
+import uuid
+
+from django.db import migrations, models
+
+import knowledge.models.reminder_action
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("knowledge", "0027_alter_reminder_status"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ReminderAction",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "uuid",
+                    models.UUIDField(
+                        default=uuid.uuid4, editable=False, unique=True
+                    ),
+                ),
+                (
+                    "created_at",
+                    models.DateTimeField(auto_now_add=True, db_index=True),
+                ),
+                (
+                    "modified_at",
+                    models.DateTimeField(auto_now=True, db_index=True),
+                ),
+                (
+                    "action",
+                    models.CharField(
+                        choices=[
+                            ("complete", "Mark complete"),
+                            ("snooze_1h", "Snooze 1 hour"),
+                            ("snooze_1d", "Snooze 1 day"),
+                        ],
+                        max_length=32,
+                    ),
+                ),
+                (
+                    "token",
+                    models.CharField(
+                        default=knowledge.models.reminder_action._generate_token,
+                        max_length=64,
+                        unique=True,
+                    ),
+                ),
+                (
+                    "used_at",
+                    models.DateTimeField(
+                        blank=True,
+                        help_text="When the token was consumed (single-use)",
+                        null=True,
+                    ),
+                ),
+                (
+                    "expires_at",
+                    models.DateTimeField(
+                        help_text="After this point the token is rejected",
+                    ),
+                ),
+                (
+                    "reminder",
+                    models.ForeignKey(
+                        on_delete=models.deletion.CASCADE,
+                        related_name="actions",
+                        to="knowledge.reminder",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "reminder_actions",
+                "ordering": ("-created_at",),
+            },
+        ),
+        migrations.AddIndex(
+            model_name="reminderaction",
+            index=models.Index(
+                fields=["reminder"], name="reminder_ac_reminde_29870c_idx"
+            ),
+        ),
+    ]

--- a/packages/django-app/app/knowledge/models/__init__.py
+++ b/packages/django-app/app/knowledge/models/__init__.py
@@ -1,3 +1,4 @@
 from .block import Block, BlockData
 from .page import Page, PageData, PagesData, PageWithBlocksData
 from .reminder import Reminder, ReminderData
+from .reminder_action import ReminderAction

--- a/packages/django-app/app/knowledge/models/reminder_action.py
+++ b/packages/django-app/app/knowledge/models/reminder_action.py
@@ -1,0 +1,81 @@
+import secrets
+from datetime import timedelta
+from typing import Optional
+
+from django.db import models
+from django.utils import timezone
+
+from common.models.crud_timestamps_mixin import CRUDTimestampsMixin
+from common.models.uuid_mixin import UUIDModelMixin
+
+
+def _generate_token() -> str:
+    # ~256 bits of entropy. token_urlsafe is path-safe so the token can
+    # ride directly in the URL without encoding.
+    return secrets.token_urlsafe(32)
+
+
+class ReminderAction(UUIDModelMixin, CRUDTimestampsMixin):
+    """Single-use reply action attached to a delivered reminder.
+
+    When `SendDueRemindersCommand` ships a reminder to Discord it also
+    mints a small set of action rows (one per supported action). Each
+    row carries an unguessable `token` that resolves to a specific
+    (reminder, action) pair. Clicking the corresponding link in the
+    Discord message hits the public `reminder_action` view, which
+    consumes the token and performs the action — see
+    `ConsumeReminderActionCommand`.
+
+    Tokens are intentionally narrow: a token can only run its bound
+    action on its bound reminder. Possessing one doesn't grant any
+    other access. They expire shortly after delivery (default 7d) and
+    flip to single-use the moment they're consumed.
+    """
+
+    ACTION_COMPLETE = "complete"
+    ACTION_SNOOZE_1H = "snooze_1h"
+    ACTION_SNOOZE_1D = "snooze_1d"
+    ACTION_CHOICES = [
+        (ACTION_COMPLETE, "Mark complete"),
+        (ACTION_SNOOZE_1H, "Snooze 1 hour"),
+        (ACTION_SNOOZE_1D, "Snooze 1 day"),
+    ]
+
+    DEFAULT_TTL = timedelta(days=7)
+
+    reminder = models.ForeignKey(
+        "knowledge.Reminder",
+        on_delete=models.CASCADE,
+        related_name="actions",
+    )
+    action = models.CharField(max_length=32, choices=ACTION_CHOICES)
+    # `unique=True` doubles as the lookup index — the public view
+    # resolves a click by token alone.
+    token = models.CharField(max_length=64, unique=True, default=_generate_token)
+    used_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text="When the token was consumed (single-use)",
+    )
+    expires_at = models.DateTimeField(
+        help_text="After this point the token is rejected",
+    )
+
+    class Meta:
+        db_table = "reminder_actions"
+        ordering = ("-created_at",)
+        indexes = [
+            models.Index(fields=["reminder"]),
+        ]
+
+    def __str__(self) -> str:
+        return f"ReminderAction({self.uuid}) {self.action}"
+
+    def is_usable(self, *, now: Optional["timezone.datetime"] = None) -> bool:
+        moment = now or timezone.now()
+        return self.used_at is None and moment < self.expires_at
+
+    def mark_used(self, *, now: Optional["timezone.datetime"] = None) -> None:
+        moment = now or timezone.now()
+        self.used_at = moment
+        self.save(update_fields=["used_at", "modified_at"])

--- a/packages/django-app/app/knowledge/services/reminder_actions.py
+++ b/packages/django-app/app/knowledge/services/reminder_actions.py
@@ -1,0 +1,51 @@
+from datetime import timedelta
+from typing import Dict, List, Optional
+
+from django.utils import timezone
+
+from knowledge.models import Reminder, ReminderAction
+
+
+def create_action_tokens(
+    reminder: Reminder,
+    *,
+    actions: Optional[List[str]] = None,
+    ttl: Optional[timedelta] = None,
+    now: Optional["timezone.datetime"] = None,
+) -> Dict[str, ReminderAction]:
+    """Mint one ReminderAction per action for `reminder`.
+
+    Returns a `{action: ReminderAction}` dict so callers can look up
+    the per-action token without re-querying. `actions` defaults to
+    the full set we surface in Discord (`complete`, `snooze_1h`,
+    `snooze_1d`) — pass a subset if you ever want to hide an action.
+    """
+    moment = now or timezone.now()
+    expires_at = moment + (ttl or ReminderAction.DEFAULT_TTL)
+    chosen = actions or [
+        ReminderAction.ACTION_COMPLETE,
+        ReminderAction.ACTION_SNOOZE_1H,
+        ReminderAction.ACTION_SNOOZE_1D,
+    ]
+
+    out: Dict[str, ReminderAction] = {}
+    for action in chosen:
+        out[action] = ReminderAction.objects.create(
+            reminder=reminder,
+            action=action,
+            expires_at=expires_at,
+        )
+    return out
+
+
+def build_action_url(site_url: str, token: str) -> str:
+    """Absolute URL to the public action endpoint for `token`.
+
+    Returns "" when SITE_URL isn't a real http(s) URL, matching the
+    existing `_page_link` skip — the embed should render without
+    action links rather than with broken ones.
+    """
+    if not site_url or not site_url.startswith(("http://", "https://")):
+        return ""
+    base = site_url.rstrip("/")
+    return f"{base}/knowledge/r/{token}/"

--- a/packages/django-app/app/knowledge/templates/knowledge/reminder_action.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/reminder_action.html
@@ -1,0 +1,63 @@
+{% load static %}
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>{{ title|default:"Reminder action" }} · brainspread</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        background: #f5f5f5;
+        color: #1f2937;
+        margin: 0;
+        padding: 2rem 1rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+      }
+      .card {
+        background: #fff;
+        max-width: 28rem;
+        width: 100%;
+        padding: 2rem;
+        border: 1px solid #e5e7eb;
+        border-radius: 3px;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+      }
+      .card h1 {
+        margin: 0 0 0.75rem;
+        font-size: 1.25rem;
+        font-weight: 600;
+      }
+      .card p {
+        margin: 0 0 1.5rem;
+        line-height: 1.4;
+        color: #374151;
+      }
+      .card a {
+        display: inline-block;
+        padding: 0.5rem 0.875rem;
+        background: #6366f1;
+        color: #fff;
+        text-decoration: none;
+        border-radius: 3px;
+        font-size: 0.9rem;
+      }
+      .card a:hover {
+        background: #4f46e5;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <h1>{{ title }}</h1>
+      <p>{{ message }}</p>
+      {% if block_url %}
+        <a href="{{ block_url }}">Open block</a>
+      {% endif %}
+    </main>
+  </body>
+</html>

--- a/packages/django-app/app/knowledge/templates/knowledge/reminder_action.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/reminder_action.html
@@ -5,58 +5,102 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex, nofollow" />
-    <title>{{ title|default:"Reminder action" }} · brainspread</title>
+    <title>{{ title|default:"reminder" }} · brainspread</title>
     <style>
-      body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-        background: #f5f5f5;
-        color: #1f2937;
+      /* Self-contained brutalist palette to match the editor's default
+         dark/green look. We don't pull in app.css because this view is
+         shown to logged-out browsers (followed from a Discord ping)
+         and theme preference isn't readable here. */
+      :root {
+        --bg: #000000;
+        --fg: #00ff00;
+        --muted: #888888;
+        --border: #00ff00;
+      }
+
+      * { box-sizing: border-box; }
+
+      html, body {
         margin: 0;
-        padding: 2rem 1rem;
+        padding: 0;
+        height: 100%;
+      }
+
+      body {
+        font-family:
+          "SF Mono", "Monaco", "Inconsolata", "Roboto Mono", "Source Code Pro",
+          monospace;
+        background: var(--bg);
+        color: var(--fg);
+        line-height: 1.4;
         display: flex;
         align-items: center;
         justify-content: center;
-        min-height: 100vh;
+        padding: 2rem 1rem;
       }
-      .card {
-        background: #fff;
-        max-width: 28rem;
+
+      main {
         width: 100%;
+        max-width: 32rem;
+        border: 3px solid var(--border);
+        background: var(--bg);
         padding: 2rem;
-        border: 1px solid #e5e7eb;
-        border-radius: 3px;
-        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+        box-shadow: 6px 6px 0 var(--border);
       }
-      .card h1 {
+
+      .brand {
+        font-size: 0.8rem;
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        color: var(--muted);
+        margin: 0 0 1.25rem;
+      }
+
+      h1 {
         margin: 0 0 0.75rem;
         font-size: 1.25rem;
-        font-weight: 600;
+        font-weight: bold;
+        letter-spacing: 0.5px;
       }
-      .card p {
+
+      p {
         margin: 0 0 1.5rem;
-        line-height: 1.4;
-        color: #374151;
+        color: var(--fg);
       }
-      .card a {
+
+      .btn {
         display: inline-block;
-        padding: 0.5rem 0.875rem;
-        background: #6366f1;
-        color: #fff;
+        padding: 0.6rem 1.1rem;
+        border: 3px solid var(--border);
+        background: var(--bg);
+        color: var(--fg);
         text-decoration: none;
-        border-radius: 3px;
-        font-size: 0.9rem;
+        font-family: inherit;
+        font-size: 0.95rem;
+        font-weight: bold;
+        letter-spacing: 0.5px;
+        box-shadow: 4px 4px 0 var(--border);
+        transition: none;
       }
-      .card a:hover {
-        background: #4f46e5;
+
+      .btn:hover {
+        transform: translate(-2px, -2px);
+        box-shadow: 6px 6px 0 var(--border);
+      }
+
+      .btn:active {
+        transform: translate(2px, 2px);
+        box-shadow: 2px 2px 0 var(--border);
       }
     </style>
   </head>
   <body>
-    <main class="card">
+    <main>
+      <p class="brand">brainspread</p>
       <h1>{{ title }}</h1>
       <p>{{ message }}</p>
       {% if block_url %}
-        <a href="{{ block_url }}">Open block</a>
+        <a class="btn" href="{{ block_url }}">Open block →</a>
       {% endif %}
     </main>
   </body>

--- a/packages/django-app/app/knowledge/test/commands/test_consume_reminder_action_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_consume_reminder_action_command.py
@@ -1,0 +1,145 @@
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from knowledge.commands import ConsumeReminderActionCommand
+from knowledge.forms import ConsumeReminderActionForm
+from knowledge.models import Reminder, ReminderAction
+
+from ..helpers import BlockFactory, PageFactory, UserFactory
+
+
+class ConsumeReminderActionCommandTests(TestCase):
+    def setUp(self) -> None:
+        self.user = UserFactory()
+        self.page = PageFactory(user=self.user)
+        self.block = BlockFactory(
+            user=self.user,
+            page=self.page,
+            content="TODO ship",
+            block_type="todo",
+        )
+        self.reminder = Reminder.objects.create(
+            block=self.block,
+            fire_at=timezone.now() - timedelta(minutes=5),
+            status=Reminder.STATUS_SENT,
+            sent_at=timezone.now() - timedelta(minutes=4),
+        )
+
+    def _make_action(self, action: str, *, expires_in=timedelta(days=7)):
+        return ReminderAction.objects.create(
+            reminder=self.reminder,
+            action=action,
+            expires_at=timezone.now() + expires_in,
+        )
+
+    def _run(self, token: str, *, now=None):
+        data = {"token": token}
+        if now is not None:
+            data["now"] = now.isoformat()
+        form = ConsumeReminderActionForm(data)
+        assert form.is_valid(), form.errors
+        return ConsumeReminderActionCommand(form).execute()
+
+    def test_complete_marks_block_done_and_consumes_token(self) -> None:
+        action = self._make_action(ReminderAction.ACTION_COMPLETE)
+
+        result = self._run(action.token)
+
+        self.assertEqual(result["status"], "executed")
+        self.assertEqual(result["action"], ReminderAction.ACTION_COMPLETE)
+        self.assertEqual(result["block_uuid"], str(self.block.uuid))
+        self.assertEqual(result["page_slug"], self.page.slug)
+
+        self.block.refresh_from_db()
+        self.assertEqual(self.block.block_type, "done")
+        self.assertIsNotNone(self.block.completed_at)
+
+        action.refresh_from_db()
+        self.assertIsNotNone(action.used_at)
+
+    def test_snooze_1h_resets_pending_with_new_fire_at(self) -> None:
+        action = self._make_action(ReminderAction.ACTION_SNOOZE_1H)
+        pinned = timezone.now()
+
+        result = self._run(action.token, now=pinned)
+
+        self.assertEqual(result["status"], "executed")
+
+        self.reminder.refresh_from_db()
+        self.assertEqual(self.reminder.status, Reminder.STATUS_PENDING)
+        self.assertIsNone(self.reminder.sent_at)
+        self.assertEqual(
+            self.reminder.fire_at.replace(microsecond=0),
+            (pinned + timedelta(hours=1)).replace(microsecond=0),
+        )
+
+        action.refresh_from_db()
+        self.assertIsNotNone(action.used_at)
+
+    def test_snooze_1d_resets_pending_with_new_fire_at(self) -> None:
+        action = self._make_action(ReminderAction.ACTION_SNOOZE_1D)
+        pinned = timezone.now()
+
+        result = self._run(action.token, now=pinned)
+
+        self.assertEqual(result["status"], "executed")
+
+        self.reminder.refresh_from_db()
+        self.assertEqual(self.reminder.status, Reminder.STATUS_PENDING)
+        self.assertEqual(
+            self.reminder.fire_at.replace(microsecond=0),
+            (pinned + timedelta(days=1)).replace(microsecond=0),
+        )
+
+    def test_unknown_token_returns_not_found(self) -> None:
+        result = self._run("definitely-not-a-real-token-value")
+        self.assertEqual(result["status"], "not_found")
+        self.assertIsNone(result["block_uuid"])
+
+    def test_expired_token_is_rejected_and_block_unchanged(self) -> None:
+        action = self._make_action(
+            ReminderAction.ACTION_COMPLETE, expires_in=timedelta(seconds=-1)
+        )
+
+        result = self._run(action.token)
+
+        self.assertEqual(result["status"], "expired")
+        self.block.refresh_from_db()
+        self.assertEqual(self.block.block_type, "todo")
+        action.refresh_from_db()
+        self.assertIsNone(action.used_at)
+
+    def test_already_used_token_does_not_re_run(self) -> None:
+        action = self._make_action(ReminderAction.ACTION_COMPLETE)
+        action.used_at = timezone.now() - timedelta(minutes=1)
+        action.save(update_fields=["used_at", "modified_at"])
+
+        result = self._run(action.token)
+
+        self.assertEqual(result["status"], "already_used")
+        self.block.refresh_from_db()
+        self.assertEqual(self.block.block_type, "todo")
+
+    def test_completed_block_is_no_op_and_marks_token_used(self) -> None:
+        # If the user clicks an action after completing the block via
+        # another channel, we treat it as a graceful no-op rather than
+        # un-completing or re-snoozing — see the command docstring.
+        self.block.block_type = "done"
+        self.block.completed_at = timezone.now()
+        self.block.save(update_fields=["block_type", "completed_at", "modified_at"])
+
+        action = self._make_action(ReminderAction.ACTION_SNOOZE_1H)
+
+        result = self._run(action.token)
+
+        self.assertEqual(result["status"], "block_completed")
+        self.assertEqual(result["block_uuid"], str(self.block.uuid))
+
+        action.refresh_from_db()
+        self.assertIsNotNone(action.used_at)
+
+        self.reminder.refresh_from_db()
+        # No snooze applied — reminder still has its original sent state.
+        self.assertEqual(self.reminder.status, Reminder.STATUS_SENT)

--- a/packages/django-app/app/knowledge/test/commands/test_reminder_actions_service.py
+++ b/packages/django-app/app/knowledge/test/commands/test_reminder_actions_service.py
@@ -1,0 +1,84 @@
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from knowledge.models import Reminder, ReminderAction
+from knowledge.services.reminder_actions import (
+    build_action_url,
+    create_action_tokens,
+)
+
+from ..helpers import BlockFactory, PageFactory, UserFactory
+
+
+class CreateActionTokensTests(TestCase):
+    def setUp(self) -> None:
+        self.user = UserFactory()
+        self.page = PageFactory(user=self.user)
+        self.block = BlockFactory(user=self.user, page=self.page)
+        self.reminder = Reminder.objects.create(
+            block=self.block,
+            fire_at=timezone.now(),
+        )
+
+    def test_creates_one_token_per_default_action(self) -> None:
+        rows = create_action_tokens(self.reminder)
+
+        self.assertEqual(
+            set(rows.keys()),
+            {
+                ReminderAction.ACTION_COMPLETE,
+                ReminderAction.ACTION_SNOOZE_1H,
+                ReminderAction.ACTION_SNOOZE_1D,
+            },
+        )
+        # Tokens are unique per row — collisions would break the
+        # uniqueness constraint at write time, but assert here too.
+        self.assertEqual(len({r.token for r in rows.values()}), 3)
+
+    def test_tokens_default_expiry_uses_model_ttl(self) -> None:
+        pinned = timezone.now()
+
+        rows = create_action_tokens(self.reminder, now=pinned)
+
+        for row in rows.values():
+            self.assertAlmostEqual(
+                (row.expires_at - pinned).total_seconds(),
+                ReminderAction.DEFAULT_TTL.total_seconds(),
+                delta=2,
+            )
+
+    def test_actions_arg_subsets_what_gets_created(self) -> None:
+        rows = create_action_tokens(
+            self.reminder, actions=[ReminderAction.ACTION_COMPLETE]
+        )
+        self.assertEqual(list(rows.keys()), [ReminderAction.ACTION_COMPLETE])
+        self.assertEqual(self.reminder.actions.count(), 1)
+
+    def test_custom_ttl_is_respected(self) -> None:
+        pinned = timezone.now()
+        rows = create_action_tokens(self.reminder, ttl=timedelta(hours=2), now=pinned)
+        for row in rows.values():
+            self.assertAlmostEqual(
+                (row.expires_at - pinned).total_seconds(),
+                7200,
+                delta=2,
+            )
+
+
+class BuildActionUrlTests(TestCase):
+    def test_builds_absolute_url_when_site_url_is_real(self) -> None:
+        url = build_action_url("https://app.example.com", "tok123")
+        self.assertEqual(url, "https://app.example.com/knowledge/r/tok123/")
+
+    def test_strips_trailing_slash_on_site_url(self) -> None:
+        url = build_action_url("https://app.example.com/", "tok")
+        self.assertEqual(url, "https://app.example.com/knowledge/r/tok/")
+
+    def test_returns_empty_for_placeholder_site_url(self) -> None:
+        # Default SITE_URL in dev/test is "0.0.0.0" — without a scheme,
+        # the embed link would be invalid, so the helper returns "" and
+        # the caller renders no action row.
+        self.assertEqual(build_action_url("0.0.0.0", "tok"), "")
+        self.assertEqual(build_action_url("", "tok"), "")

--- a/packages/django-app/app/knowledge/test/commands/test_send_due_reminders_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_send_due_reminders_command.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 
 from knowledge.commands import SendDueRemindersCommand
 from knowledge.forms import SendDueRemindersForm
-from knowledge.models import Reminder
+from knowledge.models import Reminder, ReminderAction
 from knowledge.services.discord_webhook import DiscordDeliveryResult
 
 from ..helpers import BlockFactory, PageFactory, UserFactory
@@ -242,7 +242,9 @@ class TestSendDueRemindersCommand(TestCase):
     def test_embed_description_carries_open_block_link(self):
         # When SITE_URL is real, the embed gets a description with a
         # markdown link to the block — that's the "open block" call to
-        # action that sits visually right under the title.
+        # action that sits visually right under the title. The action
+        # quick-row gets appended after it (see
+        # `test_embed_includes_action_links_when_site_url_is_real`).
         page = PageFactory(user=self.user, title="Backlog", slug="backlog")
         block = BlockFactory(user=self.user, page=page, content="TODO ship")
         Reminder.objects.create(
@@ -255,11 +257,12 @@ class TestSendDueRemindersCommand(TestCase):
             self._run()
 
         embed = captured["embeds"][0]
-        expected = (
+        open_block_link = (
             f"[Open block →](https://app.example.com/knowledge/page/backlog/"
             f"#block-{block.uuid})"
         )
-        self.assertEqual(embed["description"], expected)
+        # First line of the description is always the open-block link.
+        self.assertTrue(embed["description"].startswith(open_block_link))
 
     def test_embed_omits_description_when_site_url_is_placeholder(self):
         # Default SITE_URL is "0.0.0.0" — no scheme, can't form a real
@@ -381,6 +384,65 @@ class TestSendDueRemindersCommand(TestCase):
 
         embed = captured["embeds"][0]
         self.assertEqual(embed["footer"], {"text": "on Backlog"})
+
+    def test_embed_includes_action_links_when_site_url_is_real(self):
+        # When a real SITE_URL is set, the dispatcher mints per-action
+        # tokens and the embed description picks up a quick-action row
+        # ([Mark done](u) · [Snooze 1h](u) · [Snooze 1d](u)) underneath
+        # the existing "Open block" link.
+        page = PageFactory(user=self.user, title="Backlog", slug="backlog")
+        block = BlockFactory(user=self.user, page=page, content="TODO ship")
+        reminder = Reminder.objects.create(
+            block=block,
+            fire_at=timezone.now() - timedelta(minutes=1),
+        )
+
+        captured, patcher = self._capture_payload()
+        with self.settings(SITE_URL="https://app.example.com"), patcher:
+            self._run()
+
+        embed = captured["embeds"][0]
+        description = embed["description"]
+        self.assertIn("[Open block →]", description)
+        self.assertIn("[Mark done]", description)
+        self.assertIn("[Snooze 1h]", description)
+        self.assertIn("[Snooze 1d]", description)
+
+        # Three action rows minted, all linked to this reminder, none
+        # consumed yet.
+        actions = list(ReminderAction.objects.filter(reminder=reminder))
+        self.assertEqual(len(actions), 3)
+        self.assertEqual(
+            {a.action for a in actions},
+            {
+                ReminderAction.ACTION_COMPLETE,
+                ReminderAction.ACTION_SNOOZE_1H,
+                ReminderAction.ACTION_SNOOZE_1D,
+            },
+        )
+        # Token URLs in the description must match what was minted.
+        for a in actions:
+            self.assertIn(
+                f"https://app.example.com/knowledge/r/{a.token}/", description
+            )
+
+    def test_no_action_links_when_site_url_is_placeholder(self):
+        # 0.0.0.0 doesn't form a real URL, so the embed renders without
+        # action links — and we don't burn token rows we can't link to.
+        block = BlockFactory(user=self.user, page=self.page, content="TODO ship")
+        reminder = Reminder.objects.create(
+            block=block,
+            fire_at=timezone.now() - timedelta(minutes=1),
+        )
+
+        captured, patcher = self._capture_payload()
+        with self.settings(SITE_URL="0.0.0.0"), patcher:
+            self._run()
+
+        embed = captured["embeds"][0]
+        # No description at all — no page link, no action links.
+        self.assertNotIn("description", embed)
+        self.assertEqual(ReminderAction.objects.filter(reminder=reminder).count(), 0)
 
     def test_color_varies_by_env(self):
         # Quick visual cue for which deploy a ping came from. Asserts on

--- a/packages/django-app/app/knowledge/test/views/test_reminder_action_view.py
+++ b/packages/django-app/app/knowledge/test/views/test_reminder_action_view.py
@@ -1,0 +1,97 @@
+from datetime import timedelta
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from knowledge.models import Reminder, ReminderAction
+from knowledge.test.helpers import BlockFactory, PageFactory, UserFactory
+
+
+class ReminderActionViewTests(TestCase):
+    """Public, no-auth view that consumes a reminder-action token from
+    the user's Discord notification.
+
+    Tests focus on the HTTP shape — status codes and end-to-end side
+    effects on the underlying block/reminder. The command-level matrix
+    (snooze, expiry, etc.) lives in
+    `test_consume_reminder_action_command.py`.
+    """
+
+    def setUp(self) -> None:
+        self.user = UserFactory()
+        self.page = PageFactory(user=self.user, slug="backlog")
+        self.block = BlockFactory(
+            user=self.user,
+            page=self.page,
+            content="TODO ship",
+            block_type="todo",
+        )
+        self.reminder = Reminder.objects.create(
+            block=self.block,
+            fire_at=timezone.now() - timedelta(minutes=5),
+            status=Reminder.STATUS_SENT,
+            sent_at=timezone.now() - timedelta(minutes=4),
+        )
+
+    def _make_action(self, action: str, *, expires_in=timedelta(days=7)):
+        return ReminderAction.objects.create(
+            reminder=self.reminder,
+            action=action,
+            expires_at=timezone.now() + expires_in,
+        )
+
+    def test_complete_runs_action_and_returns_200(self) -> None:
+        action = self._make_action(ReminderAction.ACTION_COMPLETE)
+        url = reverse("knowledge:reminder_action", args=[action.token])
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.block.refresh_from_db()
+        self.assertEqual(self.block.block_type, "done")
+        action.refresh_from_db()
+        self.assertIsNotNone(action.used_at)
+
+    def test_unknown_token_returns_404(self) -> None:
+        url = reverse("knowledge:reminder_action", args=["nope"])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_expired_token_returns_410(self) -> None:
+        action = self._make_action(
+            ReminderAction.ACTION_COMPLETE, expires_in=timedelta(seconds=-1)
+        )
+        url = reverse("knowledge:reminder_action", args=[action.token])
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 410)
+        self.block.refresh_from_db()
+        self.assertEqual(self.block.block_type, "todo")
+
+    def test_used_token_returns_410_and_does_not_re_run(self) -> None:
+        action = self._make_action(ReminderAction.ACTION_COMPLETE)
+        action.used_at = timezone.now() - timedelta(minutes=1)
+        action.save(update_fields=["used_at", "modified_at"])
+        url = reverse("knowledge:reminder_action", args=[action.token])
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 410)
+        self.block.refresh_from_db()
+        self.assertEqual(self.block.block_type, "todo")
+
+    def test_view_does_not_require_authentication(self) -> None:
+        # Discord users follow these links unauthenticated. The token
+        # itself is the credential — no session/cookie/header should be
+        # needed to consume it.
+        action = self._make_action(ReminderAction.ACTION_SNOOZE_1H)
+        url = reverse("knowledge:reminder_action", args=[action.token])
+
+        # No login_required calls; just hit it raw.
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.reminder.refresh_from_db()
+        self.assertEqual(self.reminder.status, Reminder.STATUS_PENDING)

--- a/packages/django-app/app/knowledge/urls.py
+++ b/packages/django-app/app/knowledge/urls.py
@@ -20,6 +20,14 @@ urlpatterns = [
         views.public_asset,
         name="public_asset",
     ),
+    # Reminder action callback (no auth) — followed from a Discord
+    # notification's "Mark done" / "Snooze" links. The token is the
+    # only credential needed; see ConsumeReminderActionCommand.
+    path(
+        "r/<str:token>/",
+        views.reminder_action,
+        name="reminder_action",
+    ),
     # Block-centric API endpoints
     path("api/blocks/", views.create_block, name="create_block"),
     path("api/blocks/update/", views.update_block, name="update_block"),

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -13,6 +13,7 @@ from assets.models import Asset
 from knowledge.commands import (
     BulkDeleteBlocksCommand,
     BulkMoveBlocksCommand,
+    ConsumeReminderActionCommand,
     CreateBlockCommand,
     CreatePageCommand,
     DeleteBlockCommand,
@@ -45,6 +46,7 @@ from knowledge.commands.move_undone_todos_command import MoveUndoneTodosData
 from knowledge.forms import (
     BulkDeleteBlocksForm,
     BulkMoveBlocksForm,
+    ConsumeReminderActionForm,
     CreateBlockForm,
     CreatePageForm,
     DeleteBlockForm,
@@ -1306,6 +1308,94 @@ def bulk_delete_blocks(request):
             "errors": {"non_field_errors": [str(e)]},
         }
         return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+def reminder_action(request, token: str):
+    """Public, no-auth handler for a reminder action click from Discord.
+
+    Resolves `token` to a (reminder, action) pair via
+    `ConsumeReminderActionCommand`. The command itself is responsible
+    for authorizing the click — possession of an unguessable, single-
+    use, time-bound token is the credential. The view's only job is
+    HTTP shape: return the right status code and render a small
+    confirmation page so the user sees something legible after the
+    click instead of a JSON blob.
+
+    Status codes mirror the command result:
+      - 200: action ran (or block was already complete; no-op)
+      - 404: unknown token
+      - 410: token expired or already used
+    """
+    form = ConsumeReminderActionForm({"token": token})
+    if not form.is_valid():
+        # The URL pattern only matches `<str:token>`, so an invalid form
+        # here means the input is too long / malformed — same UX as
+        # "unknown token" from the user's POV.
+        return render(
+            request,
+            "knowledge/reminder_action.html",
+            {
+                "title": "Action link not found",
+                "message": "Unknown action link.",
+                "block_url": "",
+            },
+            status=404,
+        )
+
+    result = ConsumeReminderActionCommand(form).execute()
+    block_url = _block_link_for_result(result)
+
+    status_code = {
+        "executed": 200,
+        "block_completed": 200,
+        "not_found": 404,
+        "expired": 410,
+        "already_used": 410,
+    }.get(result["status"], 400)
+
+    title = {
+        "executed": "Done",
+        "block_completed": "Already complete",
+        "not_found": "Action link not found",
+        "expired": "Action link expired",
+        "already_used": "Already used",
+    }.get(result["status"], "")
+
+    response = render(
+        request,
+        "knowledge/reminder_action.html",
+        {
+            "title": title,
+            "message": result["detail"],
+            "block_url": block_url,
+        },
+        status=status_code,
+    )
+    # Action confirmation pages are stateful (they show "executed" /
+    # "expired" depending on the click), so don't let an intermediary
+    # cache them.
+    response["Cache-Control"] = "no-store"
+    return response
+
+
+def _block_link_for_result(result) -> str:
+    """Build the in-app block link for the confirmation page, if we can.
+
+    Skips when SITE_URL isn't a real http(s) URL (mirrors the embed's
+    `_page_link` behavior) and when the result lacks a block — e.g.
+    the token didn't resolve.
+    """
+    from django.conf import settings
+
+    site_url = settings.SITE_URL or ""
+    if not site_url.startswith(("http://", "https://")):
+        return ""
+    block_uuid = result.get("block_uuid")
+    page_slug = result.get("page_slug")
+    if not block_uuid or not page_slug:
+        return ""
+    base = site_url.rstrip("/")
+    return f"{base}/knowledge/page/{page_slug}/#block-{block_uuid}"
 
 
 @api_view(["POST"])


### PR DESCRIPTION
## Summary
Implement a token-based system for single-use, time-bound reminder actions that users can trigger directly from Discord notifications. This allows users to mark blocks as done or snooze reminders without leaving Discord.

## Key Changes

- **New `ReminderAction` model** (`models/reminder_action.py`): Stores single-use action tokens tied to specific reminders. Each token is unguessable, expires after 7 days by default, and can only be consumed once. Supports three actions: mark complete, snooze 1 hour, snooze 1 day.

- **New `ConsumeReminderActionCommand`** (`commands/consume_reminder_action_command.py`): Resolves and executes reminder action tokens. Handles authorization (token validity, expiry, single-use), executes the bound action (completing the block or snoozing the reminder), and returns detailed status for the view layer. All mutations run in a transaction for atomicity.

- **New public `reminder_action` view** (`views.py`): No-auth HTTP endpoint that accepts a token from Discord links. Maps command results to appropriate HTTP status codes (200 for success, 404 for unknown token, 410 for expired/used tokens) and renders a confirmation page.

- **Token generation service** (`services/reminder_actions.py`): Helper functions to mint action tokens for a reminder and build absolute URLs for Discord embeds. Gracefully skips URL generation when `SITE_URL` isn't a real http(s) URL.

- **Updated `SendDueRemindersCommand`** (`commands/send_due_reminders_command.py`): Now mints action tokens when delivering reminders and includes quick-action links in the Discord embed description (e.g., `[Mark done] · [Snooze 1h] · [Snooze 1d]`). Token creation failures are logged but don't block reminder delivery.

- **New form** (`forms/consume_reminder_action_form.py`): Validates the token input and optional `now` parameter for testing.

- **New template** (`templates/knowledge/reminder_action.html`): Simple confirmation page shown after a user clicks an action link, with optional "Open block" link back to the app.

- **Database migration** (`migrations/0028_reminderaction.py`): Creates the `reminder_actions` table with indexes on reminder and token.

- **Admin interface** (`admin.py`): Added `ReminderActionAdmin` for viewing and debugging action tokens.

- **URL routing** (`urls.py`): Added `/knowledge/r/<token>/` route for the public action endpoint.

- **Comprehensive tests**: Added test suites for the command, view, and service layer covering success paths, expiry, single-use enforcement, and edge cases (e.g., block already completed).

## Notable Implementation Details

- Tokens use `secrets.token_urlsafe(32)` for ~256 bits of entropy and are path-safe for direct URL inclusion.
- The `ConsumeReminderActionCommand` treats a completed block as a graceful no-op (marks token used but doesn't re-apply the action), preventing confusing behavior if a user clicks after completing via another channel.
- Snooze actions reuse the existing `Reminder` row rather than creating a new one, resetting it to `STATUS_PENDING` so it re-enters the reminder queue.
- Complete actions route through `SetBlockTypeCommand` to ensure consistent side effects (e.g., skipping pending reminders).
- Action token creation is wrapped in error handling so a DB hiccup doesn't block reminder delivery; the reminder ships without quick-action links as a fallback.

https://claude.ai/code/session_01CsneWAiTeg6aoskzpaXFZo