### PR TITLE
Hashtag-in-code fixes + chat chip readability + mermaid leak

### DIFF
--- a/packages/django-app/app/knowledge/static/knowledge/js/services/mermaid.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/mermaid.js
@@ -48,16 +48,42 @@
       .replace(/>/g, "&gt;");
   }
 
-  // Mermaid's render() appends temp scaffolding directly to <body> while
-  // it measures the SVG (a `<div id="d{id}">`, sometimes an
-  // `<iframe id="i{id}">`). On parse failure those nodes can be left
-  // behind and the unstyled error SVG / sad-face icon ends up showing
-  // beneath the page content. We sweep them after each render.
+  // Mermaid's render() defaults to `select('body')` when no
+  // svgContainingElement is passed, then appends a measurement div
+  // (`<div id="d{id}"><svg id="{id}">...</svg></div>`). On the success
+  // path mermaid removes that div via removeTempElements(); on a render
+  // error the cleanup is skipped and the error SVG (the "Syntax error
+  // in graph" sad-face) is left visible at the bottom of the page.
+  //
+  // We give mermaid an offscreen host to measure into so any leak
+  // can't surface under the page, and still id-sweep as a belt-and-
+  // braces safety net.
+  let renderHost = null;
+  function getRenderHost() {
+    if (renderHost && renderHost.isConnected) return renderHost;
+    renderHost = document.createElement("div");
+    renderHost.id = "brainspread-mermaid-render-host";
+    renderHost.setAttribute("aria-hidden", "true");
+    renderHost.style.cssText =
+      "position:absolute;left:-99999px;top:-99999px;width:1px;height:1px;overflow:hidden;visibility:hidden;pointer-events:none";
+    document.body.appendChild(renderHost);
+    return renderHost;
+  }
+
   function cleanupOrphans(id) {
+    // Direct id matches mermaid uses (`d{id}` for the wrapper div,
+    // `i{id}` for the sandboxed iframe, `{id}` for the SVG itself).
     for (const orphanId of [`d${id}`, `i${id}`, id]) {
       const node = document.getElementById(orphanId);
-      if (node && node.parentNode === document.body) node.remove();
+      if (node) node.remove();
     }
+    // Belt-and-braces: drop anything mermaid stranded directly under
+    // <body>. We never put mermaid output there ourselves.
+    document
+      .querySelectorAll(
+        'body > div[id^="dmermaid-"], body > svg[id^="mermaid-"], body > iframe[id^="imermaid-"]'
+      )
+      .forEach((node) => node.remove());
   }
 
   async function renderOne(el) {
@@ -68,7 +94,7 @@
     }
     const id = `mermaid-${Math.random().toString(36).slice(2, 11)}`;
     try {
-      const { svg } = await window.mermaid.render(id, source);
+      const { svg } = await window.mermaid.render(id, source, getRenderHost());
       el.innerHTML = svg;
       el.dataset.mermaidRendered = "true";
     } catch (err) {

--- a/packages/django-app/app/knowledge/templates/knowledge/public_page.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/public_page.html
@@ -6,7 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex, nofollow" />
     <title>{{ page.title }}</title>
-    <link rel="stylesheet" href="{% static 'knowledge/css/public_page.css' %}?v={{ STATIC_VERSION }}" />
+    <link
+      rel="stylesheet"
+      href="{% static 'knowledge/css/public_page.css' %}?v={{ STATIC_VERSION }}"
+    />
   </head>
   <body class="public-page-body">
     <div class="public-page">
@@ -20,36 +23,46 @@
       </header>
 
       {% if blocks %}
-        <ul class="public-block-list">
-          {% include 'knowledge/_public_block_list.html' with blocks=blocks %}
-        </ul>
+      <ul class="public-block-list">
+        {% include 'knowledge/_public_block_list.html' with blocks=blocks %}
+      </ul>
       {% elif not references %}
-        <p class="public-page-empty">This page has no content yet.</p>
-      {% endif %}
-
-      {% if references %}
-        <section class="public-references">
-          <h2 class="public-references-title">linked references</h2>
-          <ul class="public-block-list public-references-list">
-            {% for ref in references %}
-              <li class="public-block public-block-type-{{ ref.block_type }} public-reference">
-                <div class="public-reference-source">
-                  {% if ref.source_page_type == 'daily' and ref.source_page_date %}
-                    {{ ref.source_page_date }}
-                  {% else %}
-                    {{ ref.source_page_title }}
-                  {% endif %}
-                </div>
-                {% if ref.asset_is_image and ref.asset_url %}
-                  <img class="public-block-image" src="{{ ref.asset_url }}" alt="" loading="lazy" />
-                {% elif ref.content_type == 'image' and ref.media_url %}
-                  <img class="public-block-image" src="{{ ref.media_url }}" alt="" loading="lazy" />
-                {% endif %}
-                <div class="public-block-content" data-md="{{ ref.content }}">{{ ref.content }}</div>
-              </li>
-            {% endfor %}
-          </ul>
-        </section>
+      <p class="public-page-empty">This page has no content yet.</p>
+      {% endif %} {% if references %}
+      <section class="public-references">
+        <h2 class="public-references-title">linked references</h2>
+        <ul class="public-block-list public-references-list">
+          {% for ref in references %}
+          <li
+            class="public-block public-block-type-{{ ref.block_type }} public-reference"
+          >
+            <div class="public-reference-source">
+              {% if ref.source_page_type == 'daily' and ref.source_page_date %}
+              {{ ref.source_page_date }} {% else %} {{ ref.source_page_title }}
+              {% endif %}
+            </div>
+            {% if ref.asset_is_image and ref.asset_url %}
+            <img
+              class="public-block-image"
+              src="{{ ref.asset_url }}"
+              alt=""
+              loading="lazy"
+            />
+            {% elif ref.content_type == 'image' and ref.media_url %}
+            <img
+              class="public-block-image"
+              src="{{ ref.media_url }}"
+              alt=""
+              loading="lazy"
+            />
+            {% endif %}
+            <div class="public-block-content" data-md="{{ ref.content }}">
+              {{ ref.content }}
+            </div>
+          </li>
+          {% endfor %}
+        </ul>
+      </section>
       {% endif %}
 
       <footer class="public-page-footer">
@@ -60,6 +73,78 @@
     <script src="https://cdn.jsdelivr.net/npm/marked@9.1.6/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
     <script>
+      // marked GFM autolinks bare URLs, but if the bundle is stale or
+      // some content edge-case slips through we still want bare URLs to
+      // render as clickable links — the prod symptom was a bare
+      // https://… URL not surfacing on the share page at all. Walk the
+      // rendered DOM and linkify any URL that's still a plain text node
+      // (skipping <a>/<code>/<pre>) as belt-and-braces.
+      var BARE_URL_RE =
+        /\b((?:https?:\/\/|www\.)[^\s<>"'()]+[^\s<>"'(),.;:!?])/g;
+
+      function linkifyTextNodes(rootEl) {
+        var walker = document.createTreeWalker(rootEl, NodeFilter.SHOW_TEXT, {
+          acceptNode: function (node) {
+            var p = node.parentNode;
+            while (p && p !== rootEl) {
+              var tag = p.tagName;
+              if (tag === "A" || tag === "CODE" || tag === "PRE") {
+                return NodeFilter.FILTER_REJECT;
+              }
+              p = p.parentNode;
+            }
+            return NodeFilter.FILTER_ACCEPT;
+          },
+        });
+        var targets = [];
+        var n;
+        while ((n = walker.nextNode())) targets.push(n);
+        for (var i = 0; i < targets.length; i++) {
+          var textNode = targets[i];
+          var text = textNode.nodeValue;
+          if (!BARE_URL_RE.test(text)) continue;
+          BARE_URL_RE.lastIndex = 0;
+          var frag = document.createDocumentFragment();
+          var lastIndex = 0;
+          var m;
+          while ((m = BARE_URL_RE.exec(text)) !== null) {
+            if (m.index > lastIndex) {
+              frag.appendChild(
+                document.createTextNode(text.slice(lastIndex, m.index))
+              );
+            }
+            var url = m[0];
+            var href = /^www\./i.test(url) ? "https://" + url : url;
+            var a = document.createElement("a");
+            a.href = href;
+            a.target = "_blank";
+            a.rel = "noopener noreferrer";
+            a.textContent = url;
+            frag.appendChild(a);
+            lastIndex = m.index + url.length;
+          }
+          if (lastIndex < text.length) {
+            frag.appendChild(document.createTextNode(text.slice(lastIndex)));
+          }
+          textNode.parentNode.replaceChild(frag, textNode);
+        }
+      }
+
+      // Open every outbound link in a new tab so the share doesn't lose
+      // its place when the reader clicks through, and add rel=noopener
+      // so the destination can't tamper with the opener window.
+      function decorateLinks(rootEl) {
+        var anchors = rootEl.querySelectorAll("a[href]");
+        for (var i = 0; i < anchors.length; i++) {
+          var a = anchors[i];
+          var href = a.getAttribute("href") || "";
+          if (/^(https?:|www\.|mailto:)/i.test(href)) {
+            a.setAttribute("target", "_blank");
+            a.setAttribute("rel", "noopener noreferrer");
+          }
+        }
+      }
+
       // Render each block's raw markdown into the corresponding container.
       // Using data-md keeps the source text on the element so View Source
       // still shows the original content, and we sanitize before injecting.
@@ -72,7 +157,11 @@
         }
         try {
           var html = marked.parse(raw, { breaks: true, gfm: true });
-          el.innerHTML = DOMPurify.sanitize(html);
+          el.innerHTML = DOMPurify.sanitize(html, {
+            ADD_ATTR: ["target", "rel"],
+          });
+          linkifyTextNodes(el);
+          decorateLinks(el);
         } catch (e) {
           el.textContent = raw;
         }


### PR DESCRIPTION
## Summary

A small batch of UI fixes around hashtag rendering and mermaid error handling.

### Hashtags inside code

- **Block content (`Page.js`)** — Reordered the markdown pipeline so inline-code spans are restored *after* the hashtag regex. `#foo` inside `` `…` `` and ```` ```…``` ```` is no longer turned into a tag link.
- **Page auto-creation (`sync_block_tags_command.py`)** — Strips fenced blocks and inline code before scanning for hashtags, so saving a block with `` `#include` `` no longer creates an "include" page.
- **Tests** — Added `test_sync_block_tags_command.py` covering plain hashtags, inline-code skip, fenced-block skip, and mixed content.

(AI chat already used DOM walking that skipped `<code>`/`<pre>`, so no code change was needed there.)

### Chat hashtag readability

- `.hashtag-mention` now mirrors `.inline-tag` exactly — same `--tag-bg` / `--tag-text` colors, same padding, square corners, `--tag-hover` on hover, underline on hover only.
- Selector bumped to `a.hashtag-mention` so it beats the `.message-content a { color: var(--accent-color) }` rule that was painting chip text in the accent color (often the same hue as `--tag-bg`, which made the text invisible).

### Mermaid parsing errors leaking under the page

Mermaid v11's `render()` defaults to `select('body')` and appends a measurement div (`<div id="d{id}"><svg id="{id}">…</svg></div>`). On a render-time exception its cleanup is skipped, leaving the "Syntax error in graph" sad-face SVG visible at the bottom of the page.

- Pass an offscreen-positioned host element as the third arg to `render()` so mermaid measures into it instead of `<body>`.
- Belt-and-braces id sweep (`d{id}`, `i{id}`, `{id}`) plus a broader `body > [id^="dmermaid-"]` query in case future mermaid versions change ids.

## Test plan

- [ ] Block with `` `#foo` `` and ` ```python\n#include <stdio.h>\n``` ` renders the code spans without hashtag chips and doesn't create `foo` / `include` pages.
- [ ] Plain `#bar` outside code still renders as a chip and creates the page.
- [ ] Hashtag chips in chat are readable on every theme (especially the green matrix theme), no underline on rest, underline on hover, navigates to the page on click.
- [ ] Pasting a mermaid block with intentionally bad syntax shows the inline error inside the block but no leftover sad-face SVG at the bottom of the page.

https://claude.ai/code/session_0116p3XfzgiPnoqtT62myHEY

---
_Generated by [Claude Code](https://claude.ai/code/session_0116p3XfzgiPnoqtT62myHEY)_