### PR TITLE
Fix orphaned blocks and improve block movement safety

### DIFF
--- a/packages/django-app/app/knowledge/commands/create_block_command.py
+++ b/packages/django-app/app/knowledge/commands/create_block_command.py
@@ -42,9 +42,7 @@ class CreateBlockCommand(AbstractBaseCommand):
         # creation — SetBlockTypeCommand only fires on transitions, so a
         # block born done would otherwise have a null completed_at and
         # be invisible to "done this week" / completion queries.
-        completed_at = (
-            timezone.now() if final_block_type in COMPLETED_TYPES else None
-        )
+        completed_at = timezone.now() if final_block_type in COMPLETED_TYPES else None
 
         # Create the block
         block = Block.objects.create(

--- a/packages/django-app/app/knowledge/commands/create_block_command.py
+++ b/packages/django-app/app/knowledge/commands/create_block_command.py
@@ -1,9 +1,12 @@
+from django.utils import timezone
+
 from common.commands.abstract_base_command import AbstractBaseCommand
 
 from ..forms.create_block_form import CreateBlockForm
 from ..forms.sync_block_tags_form import SyncBlockTagsForm
 from ..forms.touch_page_form import TouchPageForm
 from ..models import Block
+from .set_block_type_command import COMPLETED_TYPES
 from .sync_block_tags_command import SyncBlockTagsCommand
 from .touch_page_command import TouchPageCommand
 
@@ -35,6 +38,14 @@ class CreateBlockCommand(AbstractBaseCommand):
         # Auto-detect block type from content if not explicitly set
         final_block_type = self._detect_block_type_from_content(content, block_type)
 
+        # Terminal states (done/wontdo) need completed_at stamped at
+        # creation — SetBlockTypeCommand only fires on transitions, so a
+        # block born done would otherwise have a null completed_at and
+        # be invisible to "done this week" / completion queries.
+        completed_at = (
+            timezone.now() if final_block_type in COMPLETED_TYPES else None
+        )
+
         # Create the block
         block = Block.objects.create(
             user=user,
@@ -48,6 +59,7 @@ class CreateBlockCommand(AbstractBaseCommand):
             media_metadata=media_metadata,
             properties=properties,
             asset=asset,
+            completed_at=completed_at,
         )
 
         # Extract and set tags from content (business logic)
@@ -92,9 +104,18 @@ class CreateBlockCommand(AbstractBaseCommand):
         content_stripped = content.strip()
         content_lower = content_stripped.lower()
 
-        # Check for TODO patterns
+        # Check for state-prefix patterns. Mirrors UpdateBlockCommand so
+        # "DONE buy milk" lands as a done block on either path.
         if content_lower.startswith("todo"):
             return "todo"
+        elif content_lower.startswith("doing"):
+            return "doing"
+        elif content_lower.startswith("done"):
+            return "done"
+        elif content_lower.startswith("later"):
+            return "later"
+        elif content_lower.startswith("wontdo"):
+            return "wontdo"
         elif content_lower.startswith("[ ]"):
             return "todo"
         elif content_lower.startswith("[x]"):

--- a/packages/django-app/app/knowledge/commands/update_block_command.py
+++ b/packages/django-app/app/knowledge/commands/update_block_command.py
@@ -6,6 +6,7 @@ from ..forms.sync_block_tags_form import SyncBlockTagsForm
 from ..forms.touch_page_form import TouchPageForm
 from ..forms.update_block_form import UpdateBlockForm
 from ..models import Block
+from .set_block_type_command import SetBlockTypeCommand
 from .sync_block_tags_command import SyncBlockTagsCommand
 from .touch_page_command import TouchPageCommand
 
@@ -69,6 +70,14 @@ class UpdateBlockCommand(AbstractBaseCommand):
                 block.content, block.block_type
             )
             if auto_detected_type != block.block_type:
+                # Mirror SetBlockTypeCommand's completed_at semantics on
+                # the content-driven path — entering done/wontdo via
+                # typing "DONE foo" must stamp completed_at; backing out
+                # must clear it. Otherwise the block reads as terminal
+                # but stays invisible to "done this week"-style queries.
+                block.completed_at = SetBlockTypeCommand._next_completed_at(
+                    block.block_type, auto_detected_type, block.completed_at
+                )
                 block.block_type = auto_detected_type
 
         block.save()

--- a/packages/django-app/app/knowledge/management/commands/fix_orphaned_blocks.py
+++ b/packages/django-app/app/knowledge/management/commands/fix_orphaned_blocks.py
@@ -1,0 +1,99 @@
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.db.models import Max
+
+from core.models import User
+from knowledge.repositories import BlockRepository
+
+
+class Command(BaseCommand):
+    help = (
+        "Promote blocks whose parent lives on a different page back to "
+        "root on their own page. Older move paths could leave blocks "
+        "with a cross-page parent — visible to type-based custom views "
+        "but invisible to the recursive page render."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would change without writing anything",
+        )
+        parser.add_argument(
+            "--user",
+            type=str,
+            help="Limit to one user's blocks (email). Omit to scan all users.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        dry_run: bool = options["dry_run"]
+        user_email: str = options.get("user")
+
+        user = None
+        if user_email:
+            try:
+                user = User.objects.get(email=user_email)
+            except User.DoesNotExist:
+                raise CommandError(f"User with email '{user_email}' does not exist")
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING("DRY RUN MODE - no changes will be made")
+            )
+
+        orphans = list(
+            BlockRepository.get_orphaned_blocks(user=user).select_related(
+                "page", "parent__page"
+            )
+        )
+
+        if not orphans:
+            self.stdout.write(self.style.SUCCESS("No orphaned blocks found."))
+            return
+
+        self.stdout.write(f"Found {len(orphans)} orphaned block(s).")
+
+        # Compute new orders up front so we put each fixed block at the
+        # bottom of its page (avoids order collisions with existing roots).
+        # Reuse a cached max per page across the same run.
+        next_order_for_page: dict = {}
+
+        def next_order(page_id: int) -> int:
+            if page_id not in next_order_for_page:
+                current_max = (
+                    BlockRepository.get_queryset()
+                    .filter(page_id=page_id, parent__isnull=True)
+                    .aggregate(m=Max("order"))["m"]
+                )
+                next_order_for_page[page_id] = (current_max or 0) + 1
+            else:
+                next_order_for_page[page_id] += 1
+            return next_order_for_page[page_id]
+
+        fixed = 0
+        with transaction.atomic():
+            for block in orphans:
+                new_order = next_order(block.page_id)
+                self.stdout.write(
+                    f"  block={block.uuid} page={block.page.title!r} "
+                    f"parent_page={block.parent.page.title!r} -> root@{new_order}"
+                )
+                if not dry_run:
+                    block.parent = None
+                    block.order = new_order
+                    block.save(update_fields=["parent", "order"])
+                fixed += 1
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"DRY RUN COMPLETE: would fix {fixed} block(s)"
+                )
+            )
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(f"COMPLETE: fixed {fixed} block(s)")
+            )

--- a/packages/django-app/app/knowledge/management/commands/fix_orphaned_blocks.py
+++ b/packages/django-app/app/knowledge/management/commands/fix_orphaned_blocks.py
@@ -89,11 +89,7 @@ class Command(BaseCommand):
 
         if dry_run:
             self.stdout.write(
-                self.style.WARNING(
-                    f"DRY RUN COMPLETE: would fix {fixed} block(s)"
-                )
+                self.style.WARNING(f"DRY RUN COMPLETE: would fix {fixed} block(s)")
             )
         else:
-            self.stdout.write(
-                self.style.SUCCESS(f"COMPLETE: fixed {fixed} block(s)")
-            )
+            self.stdout.write(self.style.SUCCESS(f"COMPLETE: fixed {fixed} block(s)"))

--- a/packages/django-app/app/knowledge/repositories/block_repository.py
+++ b/packages/django-app/app/knowledge/repositories/block_repository.py
@@ -472,7 +472,15 @@ class BlockRepository(BaseRepository):
 
     @classmethod
     def move_blocks_to_page(cls, blocks: List[Block], target_page: Page) -> bool:
-        """Move blocks to target page and update their order"""
+        """Move blocks to target page and update their order.
+
+        Blocks whose parent isn't also being moved are promoted to root on
+        the target page — leaving parent_id pointing at a block on a
+        different page produces an orphan: invisible to the recursive
+        page render (which starts from parent=None) but still surfaced by
+        type-based custom views. Descendants of moved blocks ride along
+        so subtrees stay intact on the target page.
+        """
         if not blocks:
             return True
 
@@ -483,11 +491,31 @@ class BlockRepository(BaseRepository):
                 max_order = queryset.aggregate(max_order=Max("order"))["max_order"]
                 max_order = max_order if max_order is not None else 0
 
-                # Update each block's page and order
+                selected_pks = {b.pk for b in blocks}
+
                 for i, block in enumerate(blocks, start=1):
                     block.page = target_page
                     block.order = max_order + i
-                    block.save(update_fields=["page", "order"])
+                    update_fields = ["page", "order"]
+                    if (
+                        block.parent_id is not None
+                        and block.parent_id not in selected_pks
+                    ):
+                        block.parent = None
+                        update_fields.append("parent")
+                    block.save(update_fields=update_fields)
+
+                # Drag descendants of moved blocks onto the target page so
+                # the subtree stays intact. Skip blocks already in the
+                # moving set — they were handled above.
+                seen = set(selected_pks)
+                for block in blocks:
+                    for descendant in cls.get_block_descendants(block):
+                        if descendant.pk in seen:
+                            continue
+                        seen.add(descendant.pk)
+                        descendant.page = target_page
+                        descendant.save(update_fields=["page"])
 
                 return True
         except Exception:

--- a/packages/django-app/app/knowledge/repositories/block_repository.py
+++ b/packages/django-app/app/knowledge/repositories/block_repository.py
@@ -2,7 +2,7 @@ from datetime import date, datetime
 from typing import Any, Dict, Iterable, List, Optional
 
 from django.db import transaction
-from django.db.models import Count, Max, Q, QuerySet
+from django.db.models import Count, F, Max, Q, QuerySet
 from django.db.models.functions import TruncDate
 
 from common.repositories.base_repository import BaseRepository
@@ -282,6 +282,24 @@ class BlockRepository(BaseRepository):
             .prefetch_related("reminders")
             .order_by("scheduled_for", "order")[:limit]
         )
+
+    @classmethod
+    def get_orphaned_blocks(cls, user=None) -> QuerySet:
+        """Blocks whose parent lives on a different page than they do.
+
+        Produced by older move paths that updated `page` without clearing
+        `parent` — invisible on the recursive page render (which starts
+        from parent=None) but still surfaced by type-based queries.
+        Newly-introduced moves are safe; this is a historical-data probe.
+        """
+        qs = (
+            cls.get_queryset()
+            .filter(parent__isnull=False)
+            .exclude(parent__page_id=F("page_id"))
+        )
+        if user is not None:
+            qs = qs.filter(user=user)
+        return qs
 
     @classmethod
     def get_root_blocks_for_pages(cls, page_ids: Iterable[int]) -> List[Block]:

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -1379,6 +1379,21 @@ const Page = {
         }
       );
 
+      // Extract key::value properties as placeholders so later markdown
+      // transforms (emphasis, URL linkification) don't touch the chip
+      // text — a value like *foo* would otherwise pick up italics.
+      // Pattern mirrors Block.extract_properties_from_content's inline
+      // form: word-boundary key, ::, single-token value.
+      const propertySegments = [];
+      formatted = formatted.replace(
+        /\b([a-zA-Z0-9_-]+)::([^\s]+)/g,
+        (_match, key, value) => {
+          const idx = propertySegments.length;
+          propertySegments.push({ key, value });
+          return `\x00PROP${idx}\x00`;
+        }
+      );
+
       // Format lines starting with > as blockquotes
       formatted = formatted.replace(
         /^>\s?(.+)/gm,
@@ -1456,6 +1471,25 @@ const Page = {
         /#([a-zA-Z0-9_-]+)/g,
         '<a class="inline-tag clickable-tag" href="/knowledge/page/$1/" data-tag="$1">#$1</a>'
       );
+
+      // Restore key::value property placeholders as chips. Reuses the
+      // hashtag chip styling (.inline-tag .clickable-tag) and routes to
+      // the saved-views page with prefill params so the user lands on a
+      // property_eq query they can run or save.
+      propertySegments.forEach(({ key, value }, idx) => {
+        const safeKey = this.escapeHtml(key);
+        const safeValue = this.escapeHtml(value);
+        const href =
+          `/knowledge/views/?property_key=${encodeURIComponent(key)}` +
+          `&property_value=${encodeURIComponent(value)}`;
+        const replacement =
+          `<a class="inline-tag inline-property clickable-tag" ` +
+          `href="${href}" ` +
+          `data-property-key="${this.escapeAttr(key)}" ` +
+          `data-property-value="${this.escapeAttr(value)}">` +
+          `${safeKey}::${safeValue}</a>`;
+        formatted = formatted.split(`\x00PROP${idx}\x00`).join(replacement);
+      });
 
       // Restore inline code spans now that hashtag replacement is done.
       codeSegments.forEach((code, idx) => {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
@@ -84,6 +84,11 @@ const SavedViewsPage = {
     await this.loadList();
     if (this.activeSlug) {
       await this.loadActive(this.activeSlug);
+    } else {
+      // ?property_key=K&property_value=V on the index drops the user
+      // into "creating" mode with a property_eq filter prefilled —
+      // the landing target for property-chip clicks in block content.
+      this._maybePrefillFromQuery();
     }
     window.addEventListener("popstate", this.onPopState);
   },
@@ -435,6 +440,23 @@ const SavedViewsPage = {
     showCreate() {
       this.creating = true;
       this.editor = this._emptyEditor();
+      this.editorErrors = {};
+      this.saveError = null;
+    },
+
+    _maybePrefillFromQuery() {
+      const params = new URLSearchParams(window.location.search);
+      const key = params.get("property_key");
+      const value = params.get("property_value");
+      if (!key || !value) return;
+      this.creating = true;
+      this.editor = this._emptyEditor();
+      this.editor.name = `${key} = ${value}`;
+      this.editor.filter = JSON.stringify(
+        { property_eq: { key, value } },
+        null,
+        2
+      );
       this.editorErrors = {};
       this.saveError = null;
     },

--- a/packages/django-app/app/knowledge/test/commands/test_create_block_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_create_block_command.py
@@ -86,6 +86,57 @@ class TestCreateBlockCommand(TestCase):
 
         self.assertEqual(block.block_type, "done")
 
+    def test_should_auto_detect_done_from_done_prefix(self):
+        """Blocks starting with 'DONE' are created as done type with
+        completed_at stamped — otherwise they're invisible to completion
+        queries since SetBlockTypeCommand only fires on transitions."""
+        form_data = {
+            "user": self.user.id,
+            "page": self.page.uuid,
+            "content": "DONE shipped the fix",
+        }
+        form = CreateBlockForm(form_data)
+        form.is_valid()
+        command = CreateBlockCommand(form)
+        block = command.execute()
+
+        self.assertEqual(block.block_type, "done")
+        self.assertIsNotNone(block.completed_at)
+
+    def test_should_stamp_completed_at_for_explicit_done_block(self):
+        """Explicit block_type=done also needs completed_at stamped at
+        creation — the trigger isn't the DONE prefix, it's the terminal
+        state."""
+        form_data = {
+            "user": self.user.id,
+            "page": self.page.uuid,
+            "content": "anything",
+            "block_type": "done",
+        }
+        form = CreateBlockForm(form_data)
+        form.is_valid()
+        command = CreateBlockCommand(form)
+        block = command.execute()
+
+        self.assertEqual(block.block_type, "done")
+        self.assertIsNotNone(block.completed_at)
+
+    def test_should_leave_completed_at_null_for_non_terminal_block(self):
+        """Non-terminal types (bullet, todo, doing, later) don't get a
+        completed_at stamp on creation."""
+        form_data = {
+            "user": self.user.id,
+            "page": self.page.uuid,
+            "content": "TODO write tests",
+        }
+        form = CreateBlockForm(form_data)
+        form.is_valid()
+        command = CreateBlockCommand(form)
+        block = command.execute()
+
+        self.assertEqual(block.block_type, "todo")
+        self.assertIsNone(block.completed_at)
+
     def test_should_not_override_explicit_block_type(self):
         """Test that explicit block_type is not overridden by auto-detection"""
         form_data = {

--- a/packages/django-app/app/knowledge/test/commands/test_fix_orphaned_blocks.py
+++ b/packages/django-app/app/knowledge/test/commands/test_fix_orphaned_blocks.py
@@ -1,0 +1,107 @@
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from knowledge.test.helpers import BlockFactory, PageFactory, UserFactory
+
+
+@pytest.fixture
+def user(db):
+    return UserFactory()
+
+
+@pytest.fixture
+def other_user(db):
+    return UserFactory()
+
+
+def _run(*args):
+    out = StringIO()
+    call_command("fix_orphaned_blocks", *args, stdout=out)
+    return out.getvalue()
+
+
+@pytest.mark.django_db
+def test_reports_when_no_orphans(user):
+    page = PageFactory(user=user)
+    parent = BlockFactory(user=user, page=page, order=1)
+    BlockFactory(user=user, page=page, parent=parent, order=2)
+    output = _run()
+    assert "No orphaned blocks found." in output
+
+
+@pytest.mark.django_db
+def test_dry_run_reports_but_does_not_change_anything(user):
+    source_page = PageFactory(user=user, title="source")
+    target_page = PageFactory(user=user, title="target")
+    parent = BlockFactory(user=user, page=source_page, order=1)
+    orphan = BlockFactory(
+        user=user, page=target_page, parent=parent, order=5
+    )
+
+    output = _run("--dry-run")
+    assert "would fix 1 block" in output
+
+    orphan.refresh_from_db()
+    assert orphan.parent_id == parent.pk
+    assert orphan.order == 5
+
+
+@pytest.mark.django_db
+def test_promotes_orphan_to_root_on_its_own_page(user):
+    source_page = PageFactory(user=user, title="source")
+    target_page = PageFactory(user=user, title="target")
+    parent = BlockFactory(user=user, page=source_page, order=1)
+    existing_root = BlockFactory(user=user, page=target_page, order=1)
+    orphan = BlockFactory(
+        user=user, page=target_page, parent=parent, order=5
+    )
+
+    output = _run()
+    assert "fixed 1 block" in output
+
+    orphan.refresh_from_db()
+    assert orphan.parent is None
+    # Lands at the bottom of the target page (max existing root order + 1).
+    assert orphan.order == existing_root.order + 1
+
+
+@pytest.mark.django_db
+def test_leaves_correctly_parented_blocks_alone(user):
+    page = PageFactory(user=user)
+    parent = BlockFactory(user=user, page=page, order=1)
+    child = BlockFactory(user=user, page=page, parent=parent, order=2)
+
+    _run()
+
+    child.refresh_from_db()
+    assert child.parent_id == parent.pk
+    assert child.order == 2
+
+
+@pytest.mark.django_db
+def test_scopes_to_user_when_email_provided(user, other_user):
+    # Orphan owned by `user`.
+    user_source = PageFactory(user=user, title="user-source")
+    user_target = PageFactory(user=user, title="user-target")
+    user_parent = BlockFactory(user=user, page=user_source)
+    user_orphan = BlockFactory(
+        user=user, page=user_target, parent=user_parent
+    )
+
+    # Orphan owned by `other_user` — should be skipped when --user filters.
+    other_source = PageFactory(user=other_user, title="other-source")
+    other_target = PageFactory(user=other_user, title="other-target")
+    other_parent = BlockFactory(user=other_user, page=other_source)
+    other_orphan = BlockFactory(
+        user=other_user, page=other_target, parent=other_parent
+    )
+
+    _run("--user", user.email)
+
+    user_orphan.refresh_from_db()
+    other_orphan.refresh_from_db()
+
+    assert user_orphan.parent is None
+    assert other_orphan.parent_id == other_parent.pk

--- a/packages/django-app/app/knowledge/test/commands/test_fix_orphaned_blocks.py
+++ b/packages/django-app/app/knowledge/test/commands/test_fix_orphaned_blocks.py
@@ -36,9 +36,7 @@ def test_dry_run_reports_but_does_not_change_anything(user):
     source_page = PageFactory(user=user, title="source")
     target_page = PageFactory(user=user, title="target")
     parent = BlockFactory(user=user, page=source_page, order=1)
-    orphan = BlockFactory(
-        user=user, page=target_page, parent=parent, order=5
-    )
+    orphan = BlockFactory(user=user, page=target_page, parent=parent, order=5)
 
     output = _run("--dry-run")
     assert "would fix 1 block" in output
@@ -54,9 +52,7 @@ def test_promotes_orphan_to_root_on_its_own_page(user):
     target_page = PageFactory(user=user, title="target")
     parent = BlockFactory(user=user, page=source_page, order=1)
     existing_root = BlockFactory(user=user, page=target_page, order=1)
-    orphan = BlockFactory(
-        user=user, page=target_page, parent=parent, order=5
-    )
+    orphan = BlockFactory(user=user, page=target_page, parent=parent, order=5)
 
     output = _run()
     assert "fixed 1 block" in output
@@ -86,17 +82,13 @@ def test_scopes_to_user_when_email_provided(user, other_user):
     user_source = PageFactory(user=user, title="user-source")
     user_target = PageFactory(user=user, title="user-target")
     user_parent = BlockFactory(user=user, page=user_source)
-    user_orphan = BlockFactory(
-        user=user, page=user_target, parent=user_parent
-    )
+    user_orphan = BlockFactory(user=user, page=user_target, parent=user_parent)
 
     # Orphan owned by `other_user` — should be skipped when --user filters.
     other_source = PageFactory(user=other_user, title="other-source")
     other_target = PageFactory(user=other_user, title="other-target")
     other_parent = BlockFactory(user=other_user, page=other_source)
-    other_orphan = BlockFactory(
-        user=other_user, page=other_target, parent=other_parent
-    )
+    other_orphan = BlockFactory(user=other_user, page=other_target, parent=other_parent)
 
     _run("--user", user.email)
 

--- a/packages/django-app/app/knowledge/test/commands/test_move_undone_todos_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_move_undone_todos_command.py
@@ -528,6 +528,104 @@ class TestMoveUndoneTodosCommand(TestCase):
         self.assertIn("user", form.errors)
 
     @patch("core.models.user.timezone")
+    def test_should_promote_nested_todo_to_root_on_target_page(self, mock_timezone):
+        """A nested TODO on an old daily page must be reparented to None
+        on the target page — otherwise its parent_id keeps pointing at a
+        block on the source page and it renders as an orphan (visible in
+        custom views but missing from the recursive page render)."""
+        today = date(2025, 6, 30)
+        mock_timezone.now.return_value = _utc_noon(today)
+
+        yesterday = date(2025, 6, 29)
+        yesterday_page = PageFactory(
+            user=self.user,
+            date=yesterday,
+            page_type="daily",
+            title="2025-06-29",
+            slug="2025-06-29",
+        )
+
+        parent_bullet = BlockFactory(
+            user=self.user,
+            page=yesterday_page,
+            content="Tasks",
+            block_type="bullet",
+            order=1,
+        )
+        nested_todo = BlockFactory(
+            user=self.user,
+            page=yesterday_page,
+            parent=parent_bullet,
+            content="TODO nested task",
+            block_type="todo",
+            order=2,
+        )
+
+        form = MoveUndoneTodosForm({"user": self.user})
+        self.assertTrue(form.is_valid())
+        result = MoveUndoneTodosCommand(form).execute()
+
+        self.assertEqual(result["moved_count"], 1)
+
+        nested_todo.refresh_from_db()
+        parent_bullet.refresh_from_db()
+
+        # TODO moved to today's page AND promoted to root — parent must
+        # be cleared so it isn't dangling on the source page.
+        self.assertEqual(nested_todo.page.date, today)
+        self.assertIsNone(nested_todo.parent)
+
+        # The original parent stays put on yesterday's page.
+        self.assertEqual(parent_bullet.page, yesterday_page)
+
+    @patch("core.models.user.timezone")
+    def test_should_preserve_subtree_when_moving_parent_todo(self, mock_timezone):
+        """When a TODO with children moves, the descendants ride along
+        so the subtree stays intact on the target page (and doesn't get
+        orphaned on the source page)."""
+        today = date(2025, 6, 30)
+        mock_timezone.now.return_value = _utc_noon(today)
+
+        yesterday = date(2025, 6, 29)
+        yesterday_page = PageFactory(
+            user=self.user,
+            date=yesterday,
+            page_type="daily",
+            title="2025-06-29",
+            slug="2025-06-29",
+        )
+
+        parent_todo = BlockFactory(
+            user=self.user,
+            page=yesterday_page,
+            content="TODO with details",
+            block_type="todo",
+            order=1,
+        )
+        child_note = BlockFactory(
+            user=self.user,
+            page=yesterday_page,
+            parent=parent_todo,
+            content="some context",
+            block_type="bullet",
+            order=2,
+        )
+
+        form = MoveUndoneTodosForm({"user": self.user})
+        self.assertTrue(form.is_valid())
+        result = MoveUndoneTodosCommand(form).execute()
+
+        self.assertEqual(result["moved_count"], 1)
+
+        parent_todo.refresh_from_db()
+        child_note.refresh_from_db()
+
+        # Subtree moved together; child keeps its parent pointer.
+        self.assertEqual(parent_todo.page.date, today)
+        self.assertEqual(child_note.page.date, today)
+        self.assertEqual(child_note.parent, parent_todo)
+
+    @patch("core.models.user.timezone")
     def test_should_skip_dated_blocks_during_rollover(self, mock_timezone):
         """Dated blocks (scheduled_for set) stay on their original page —
         they surface via the overdue query instead."""

--- a/packages/django-app/app/knowledge/test/commands/test_update_block_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_update_block_command.py
@@ -102,6 +102,61 @@ class TestUpdateBlockCommand(TestCase):
         self.assertEqual(updated_block.block_type, "done")
         self.assertEqual(updated_block.content, "[x] Task completed")
 
+    def test_should_stamp_completed_at_when_content_transitions_to_done(self):
+        """Updating an empty bullet to start with 'DONE' must stamp
+        completed_at. This is the real editor flow — Enter creates an
+        empty bullet, then typing 'DONE shipped it' routes through
+        UpdateBlockCommand. Without this stamp the block reads as done
+        but stays invisible to 'done this week' queries."""
+        form_data = {
+            "user": self.user.id,
+            "page": self.page.uuid,
+            "content": "",
+        }
+        form = CreateBlockForm(form_data)
+        form.is_valid()
+        bullet = CreateBlockCommand(form).execute()
+        self.assertEqual(bullet.block_type, "bullet")
+        self.assertIsNone(bullet.completed_at)
+
+        form_data = {
+            "user": self.user.id,
+            "block": str(bullet.uuid),
+            "content": "DONE shipped it",
+        }
+        form = UpdateBlockForm(form_data)
+        form.is_valid()
+        updated = UpdateBlockCommand(form).execute()
+
+        self.assertEqual(updated.block_type, "done")
+        self.assertIsNotNone(updated.completed_at)
+
+    def test_should_clear_completed_at_when_content_leaves_done(self):
+        """The reverse: editing a done block's content so it no longer
+        starts with 'DONE' must clear completed_at."""
+        form_data = {
+            "user": self.user.id,
+            "page": self.page.uuid,
+            "content": "DONE shipped it",
+        }
+        form = CreateBlockForm(form_data)
+        form.is_valid()
+        done_block = CreateBlockCommand(form).execute()
+        self.assertEqual(done_block.block_type, "done")
+        self.assertIsNotNone(done_block.completed_at)
+
+        form_data = {
+            "user": self.user.id,
+            "block": str(done_block.uuid),
+            "content": "TODO actually still working on it",
+        }
+        form = UpdateBlockForm(form_data)
+        form.is_valid()
+        updated = UpdateBlockCommand(form).execute()
+
+        self.assertEqual(updated.block_type, "todo")
+        self.assertIsNone(updated.completed_at)
+
     def test_should_not_override_heading_block_type(self):
         """Test that auto-detection doesn't override heading type"""
         # Create a heading block


### PR DESCRIPTION
## Summary

This PR addresses data integrity issues with block movement and introduces tooling to fix historical orphaned blocks. It ensures blocks maintain valid parent-child relationships across page moves and adds safeguards to prevent future orphans.

## Key Changes

- **New management command `fix_orphaned_blocks`**: Identifies and repairs blocks whose parent lives on a different page (orphans invisible to recursive page renders but surfaced by type-based queries). Supports dry-run mode and per-user filtering.

- **Enhanced `BlockRepository.move_blocks_to_page()`**: 
  - Promotes blocks to root on target page if their parent isn't also being moved (prevents cross-page parent pointers)
  - Drags descendants of moved blocks onto target page to keep subtrees intact
  - Ensures moved blocks don't become orphans

- **New `BlockRepository.get_orphaned_blocks()` method**: Queries blocks with `parent__isnull=False` but `parent.page_id != block.page_id`, with optional user filtering.

- **Improved `CreateBlockCommand`**:
  - Auto-detects terminal block types (done, wontdo) from content prefixes (e.g., "DONE shipped the fix")
  - Stamps `completed_at` at creation for terminal states so they're visible to completion queries
  - Extends auto-detection to cover doing, later, and wontdo in addition to todo

- **Property chip rendering in Page.js**: Extracts and renders `key::value` properties as clickable chips that link to saved views with prefilled `property_eq` filters.

- **SavedViewsPage prefill from query params**: Supports `?property_key=K&property_value=V` to drop users into create mode with a property filter pre-populated (landing target for property-chip clicks).

- **Test coverage**: Comprehensive tests for orphan detection, dry-run behavior, nested TODO movement, subtree preservation, and block type auto-detection.

## Implementation Details

- Orphan detection uses `exclude(parent__page_id=F("page_id"))` to find cross-page parent pointers
- Block movement uses a set-based approach to track which blocks are being moved, avoiding unnecessary updates
- Descendants are discovered via `get_block_descendants()` and dragged along to maintain tree structure
- Terminal block type detection mirrors `UpdateBlockCommand` for consistency across creation and update paths
- Property chip extraction uses placeholder tokens to prevent markdown transforms from affecting chip values

https://claude.ai/code/session_01V4k7i3JgQKgUWjkZBAN9De