### PR TITLE
Mermaid open-in-tab, per-page sort, nested copy-link fix

### DIFF
--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4337,6 +4337,35 @@ a.sidebar-item:visited {
   cursor: not-allowed;
 }
 
+/* Page block-sort menu. Reuses .context-menu / .context-menu-item but
+   the trigger button shows a label ("sort" or the active sort name)
+   instead of the ⋮ glyph, and gains an `.is-active` accent when sort
+   isn't on manual so users can spot at a glance that the page isn't
+   in its authored order. */
+.page-sort-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  text-transform: lowercase;
+  white-space: nowrap;
+}
+
+.page-sort-btn-icon {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.page-sort-btn.is-active {
+  background: var(--tag-bg);
+  border-color: var(--border-primary);
+}
+
+.page-sort-menu .context-menu-item.is-selected {
+  font-weight: 600;
+  background: var(--hover-bg);
+}
+
 /* Message Menu Styles */
 .message-footer {
   display: flex;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -5478,6 +5478,42 @@ kbd {
   max-width: 100%;
 }
 
+/* "Open diagram in new tab" overlay on .block-mermaid-wrapper. Same
+   reveal pattern as .block-resize-handle but pinned to the top-right
+   so the two hover affordances don't overlap. The button opens the
+   rendered SVG as a blob in a new tab so users can zoom natively. */
+.block-mermaid-open {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  line-height: 1;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 0;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms ease;
+  z-index: 1;
+}
+
+.block-mermaid-wrapper:hover .block-mermaid-open,
+.block-mermaid-open:focus-visible {
+  opacity: 0.85;
+}
+
+.block-mermaid-open:hover {
+  opacity: 1;
+  background: var(--hover-bg);
+}
+
 .block-resize-handle {
   position: absolute;
   right: 2px;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -237,7 +237,7 @@ const BlockComponent = {
           .replace(/</g, "&lt;")
           .replace(/>/g, "&gt;")
           .replace(/"/g, "&quot;");
-        return `<div class="block-mermaid-wrapper block-resizable"><div class="block-mermaid" data-mermaid-source="${attr}"></div><div class="block-resize-handle" aria-hidden="true"></div></div>`;
+        return `<div class="block-mermaid-wrapper block-resizable"><div class="block-mermaid" data-mermaid-source="${attr}"></div><button type="button" class="block-mermaid-open" title="Open diagram in new tab" aria-label="Open diagram in new tab">↗</button><div class="block-resize-handle" aria-hidden="true"></div></div>`;
       }
       if (this.detectedAssetType === "markdown") {
         if (!window.marked || !window.DOMPurify) return "";

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -1947,6 +1947,7 @@ const BlockComponent = {
           :onBlockDrop="onBlockDrop"
           :onBlockAttachPick="onBlockAttachPick"
           :scheduleBlock="scheduleBlock"
+          :copyBlockLink="copyBlockLink"
           :openBlockChatPopover="openBlockChatPopover"
           :onBlockSelectClick="onBlockSelectClick"
           :selectedBlockCount="selectedBlockCount"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -9,18 +9,18 @@
 // keyed by page uuid.
 const PAGE_SORT_OPTIONS = [
   { mode: "manual", label: "manual order", group: "manual" },
-  { mode: "created-desc", label: "created · newest first", group: "created" },
-  { mode: "created-asc", label: "created · oldest first", group: "created" },
-  { mode: "updated-desc", label: "updated · newest first", group: "updated" },
-  { mode: "updated-asc", label: "updated · oldest first", group: "updated" },
+  { mode: "created-desc", label: "created · newest", group: "created" },
+  { mode: "created-asc", label: "created · oldest", group: "created" },
+  { mode: "updated-desc", label: "updated · newest", group: "updated" },
+  { mode: "updated-asc", label: "updated · oldest", group: "updated" },
   {
     mode: "scheduled-asc",
-    label: "scheduled · soonest first",
+    label: "scheduled · soonest",
     group: "scheduled",
   },
   {
     mode: "scheduled-desc",
-    label: "scheduled · latest first",
+    label: "scheduled · latest",
     group: "scheduled",
   },
   { mode: "type", label: "type · A to Z", group: "type" },
@@ -139,7 +139,7 @@ const Page = {
     // reference stays identity-stable in the common case. Nulls
     // always sort last regardless of direction (a block with no
     // scheduled_for date shouldn't pop to the top when listing
-    // scheduled · latest first). Manual `order` is used as the
+    // scheduled · latest). Manual `order` is used as the
     // stable tiebreaker so equal keys preserve their curated layout.
     displayBlocks() {
       if (this.sortMode === "manual" || this.directBlocks.length <= 1) {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -1,4 +1,28 @@
 // Page Component - Complete page handler with data loading and rendering
+
+// Ordered list of available sort modes for the page's top-level blocks.
+// Order matters: the dropdown renders entries in this sequence, with a
+// separator before each new sort key. `manual` is the default and means
+// "leave directBlocks alone" — drag-and-drop and move-up/down still
+// write the real `order` field, so toggling back to manual restores
+// the user-curated arrangement. Persisted per-page in localStorage
+// keyed by page uuid.
+const PAGE_SORT_OPTIONS = [
+  { mode: "manual", label: "manual order", group: "manual" },
+  { mode: "created-desc", label: "created · newest first", group: "created" },
+  { mode: "created-asc", label: "created · oldest first", group: "created" },
+  { mode: "updated-desc", label: "updated · newest first", group: "updated" },
+  { mode: "updated-asc", label: "updated · oldest first", group: "updated" },
+  { mode: "scheduled-asc", label: "scheduled · soonest first", group: "scheduled" },
+  { mode: "scheduled-desc", label: "scheduled · latest first", group: "scheduled" },
+  { mode: "type", label: "type · A to Z", group: "type" },
+];
+const PAGE_SORT_MODES = new Set(PAGE_SORT_OPTIONS.map((o) => o.mode));
+const PAGE_SORT_LABELS = Object.fromEntries(
+  PAGE_SORT_OPTIONS.map((o) => [o.mode, o.label])
+);
+const PAGE_SORT_STORAGE_PREFIX = "bs:page-sort:";
+
 const Page = {
   components: {
     BlockComponent: window.BlockComponent || {},
@@ -47,6 +71,12 @@ const Page = {
       newTitle: "",
       // Page menu
       showPageMenu: false,
+      // Sort menu for the page's top-level blocks. "manual" preserves
+      // the user-managed `order`; other modes sort displayBlocks (the
+      // computed) without touching the persisted order. The selected
+      // mode is restored per-page from localStorage in loadPage().
+      showPageSortMenu: false,
+      sortMode: "manual",
       // Date selector for daily pages
       selectedDate: null,
       // Track blocks being deleted to prevent save conflicts
@@ -93,6 +123,72 @@ const Page = {
 
     totalDirectBlocks() {
       return this.directBlocks.length;
+    },
+
+    // Display-only sort of the page's top-level blocks. Returns a new
+    // array (so we never mutate directBlocks) keyed by the active
+    // sortMode. Falls back to directBlocks for "manual" so the v-for
+    // reference stays identity-stable in the common case. Nulls
+    // always sort last regardless of direction (a block with no
+    // scheduled_for date shouldn't pop to the top when listing
+    // scheduled · latest first). Manual `order` is used as the
+    // stable tiebreaker so equal keys preserve their curated layout.
+    displayBlocks() {
+      if (this.sortMode === "manual" || this.directBlocks.length <= 1) {
+        return this.directBlocks;
+      }
+      const cmpNullsLast = (a, b) => {
+        if (a === b) return 0;
+        if (a == null) return 1;
+        if (b == null) return -1;
+        return a < b ? -1 : a > b ? 1 : 0;
+      };
+      const byOrder = (a, b) => (a.order || 0) - (b.order || 0);
+      const mode = this.sortMode;
+      const compare = (a, b) => {
+        switch (mode) {
+          case "created-asc":
+            return cmpNullsLast(a.created_at, b.created_at);
+          case "created-desc":
+            return cmpNullsLast(b.created_at, a.created_at);
+          case "updated-asc":
+            return cmpNullsLast(a.modified_at, b.modified_at);
+          case "updated-desc":
+            return cmpNullsLast(b.modified_at, a.modified_at);
+          case "scheduled-asc":
+            return cmpNullsLast(a.scheduled_for, b.scheduled_for);
+          case "scheduled-desc": {
+            if (a.scheduled_for == null && b.scheduled_for == null) return 0;
+            if (a.scheduled_for == null) return 1;
+            if (b.scheduled_for == null) return -1;
+            return cmpNullsLast(b.scheduled_for, a.scheduled_for);
+          }
+          case "type": {
+            const t = cmpNullsLast(a.block_type, b.block_type);
+            if (t !== 0) return t;
+            const ac = (a.content || "").toLowerCase();
+            const bc = (b.content || "").toLowerCase();
+            return cmpNullsLast(ac, bc);
+          }
+          default:
+            return 0;
+        }
+      };
+      return [...this.directBlocks].sort(
+        (a, b) => compare(a, b) || byOrder(a, b)
+      );
+    },
+
+    sortLabel() {
+      return PAGE_SORT_LABELS[this.sortMode] || "manual order";
+    },
+
+    isSortActive() {
+      return this.sortMode !== "manual";
+    },
+
+    pageSortOptions() {
+      return PAGE_SORT_OPTIONS;
     },
 
     totalReferencedBlocks() {
@@ -374,6 +470,7 @@ const Page = {
 
         if (result.success) {
           this.page = result.data.page;
+          this.hydrateSortMode();
           this.directBlocks = this.setupParentReferences(
             result.data.direct_blocks || []
           );
@@ -1774,9 +1871,111 @@ const Page = {
       }
     },
 
+    togglePageSortMenu() {
+      this.showPageSortMenu = !this.showPageSortMenu;
+      if (this.showPageSortMenu) {
+        this.showPageMenu = false;
+        this.$nextTick(() => {
+          const firstItem = this.$el?.querySelector(
+            ".page-sort-container .context-menu .context-menu-item"
+          );
+          if (firstItem) firstItem.focus();
+        });
+      }
+    },
+
+    closePageSortMenu() {
+      this.showPageSortMenu = false;
+    },
+
+    closePageSortMenuAndRestoreFocus() {
+      this.closePageSortMenu();
+      this.$nextTick(() => {
+        const btn = this.$el?.querySelector(".page-sort-container .page-sort-btn");
+        if (btn) btn.focus();
+      });
+    },
+
+    handlePageSortMenuKeydown(event) {
+      const items = Array.from(
+        this.$el?.querySelectorAll(
+          ".page-sort-container .context-menu .context-menu-item"
+        ) || []
+      );
+      if (!items.length) return;
+      const currentIndex = items.indexOf(document.activeElement);
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          items[Math.min(currentIndex + 1, items.length - 1)].focus();
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          items[Math.max(currentIndex - 1, 0)].focus();
+          break;
+        case "Escape":
+        case "Tab":
+          event.preventDefault();
+          this.closePageSortMenuAndRestoreFocus();
+          break;
+        case "Home":
+          event.preventDefault();
+          items[0].focus();
+          break;
+        case "End":
+          event.preventDefault();
+          items[items.length - 1].focus();
+          break;
+      }
+    },
+
+    setSortMode(mode) {
+      if (!PAGE_SORT_MODES.has(mode)) return;
+      this.sortMode = mode;
+      this.persistSortMode();
+      this.closePageSortMenuAndRestoreFocus();
+    },
+
+    sortStorageKey() {
+      return this.page?.uuid
+        ? `${PAGE_SORT_STORAGE_PREFIX}${this.page.uuid}`
+        : null;
+    },
+
+    persistSortMode() {
+      const key = this.sortStorageKey();
+      if (!key) return;
+      try {
+        if (this.sortMode === "manual") {
+          localStorage.removeItem(key);
+        } else {
+          localStorage.setItem(key, this.sortMode);
+        }
+      } catch (e) {
+        // Safari private mode / storage quota — silently degrade.
+      }
+    },
+
+    hydrateSortMode() {
+      const key = this.sortStorageKey();
+      if (!key) {
+        this.sortMode = "manual";
+        return;
+      }
+      try {
+        const saved = localStorage.getItem(key);
+        this.sortMode =
+          saved && PAGE_SORT_MODES.has(saved) ? saved : "manual";
+      } catch (e) {
+        this.sortMode = "manual";
+      }
+    },
+
     handlePageGlobalKeydown(event) {
       if (event.key === "Escape") {
-        if (this.showPageMenu) {
+        if (this.showPageSortMenu) {
+          this.closePageSortMenuAndRestoreFocus();
+        } else if (this.showPageMenu) {
           this.closePageMenuAndRestoreFocus();
         } else if (this.selectionMode) {
           this.exitSelectionMode();
@@ -1835,7 +2034,21 @@ const Page = {
       const contextMenuContainer = event.target.closest(
         ".context-menu-container"
       );
+      const inSortContainer = event.target.closest(".page-sort-container");
+      // Both menus share `.context-menu-container`, so when one is open
+      // and the other's button is clicked, the closest() check would
+      // keep both open. Discriminate by the more-specific
+      // `.page-sort-container` to close the non-active sibling.
       if (!contextMenuContainer && this.showPageMenu) {
+        this.closePageMenu();
+      }
+      if (!contextMenuContainer && this.showPageSortMenu) {
+        this.closePageSortMenu();
+      }
+      if (contextMenuContainer && !inSortContainer && this.showPageSortMenu) {
+        this.closePageSortMenu();
+      }
+      if (inSortContainer && this.showPageMenu) {
         this.closePageMenu();
       }
       // Clear block selection when clicking outside any block
@@ -3293,6 +3506,21 @@ const Page = {
                 />
               </div>
               <div class="header-controls">
+                <div class="context-menu-container page-sort-container">
+                  <button @click="togglePageSortMenu" class="btn btn-outline context-menu-btn page-sort-btn" :class="{ 'is-active': isSortActive }" :title="'Sort blocks: ' + sortLabel" :aria-expanded="showPageSortMenu" aria-haspopup="menu">
+                    <span class="page-sort-btn-icon" aria-hidden="true">⇅</span>
+                    <span class="page-sort-btn-label">{{ isSortActive ? sortLabel : 'sort' }}</span>
+                  </button>
+                  <div v-if="showPageSortMenu" class="context-menu page-sort-menu" @click.stop @keydown="handlePageSortMenuKeydown" role="menu">
+                    <template v-for="(opt, i) in pageSortOptions" :key="opt.mode">
+                      <div v-if="i > 0 && opt.group !== pageSortOptions[i-1].group" class="context-menu-separator"></div>
+                      <button @click="setSortMode(opt.mode)" class="context-menu-item" :class="{ 'is-selected': sortMode === opt.mode }" role="menuitemradio" :aria-checked="sortMode === opt.mode">
+                        <span class="context-menu-icon">{{ sortMode === opt.mode ? '✓' : '' }}</span>
+                        <span>{{ opt.label }}</span>
+                      </button>
+                    </template>
+                  </div>
+                </div>
                 <div class="context-menu-container">
                   <button @click="togglePageMenu" class="btn btn-outline context-menu-btn" title="Daily note options" :aria-expanded="showPageMenu" aria-haspopup="menu">
                     ⋮
@@ -3350,6 +3578,21 @@ const Page = {
                 </div>
               </div>
               <div class="page-actions">
+                <div class="context-menu-container page-sort-container">
+                  <button @click="togglePageSortMenu" class="btn btn-outline context-menu-btn page-sort-btn" :class="{ 'is-active': isSortActive }" :title="'Sort blocks: ' + sortLabel" :aria-expanded="showPageSortMenu" aria-haspopup="menu">
+                    <span class="page-sort-btn-icon" aria-hidden="true">⇅</span>
+                    <span class="page-sort-btn-label">{{ isSortActive ? sortLabel : 'sort' }}</span>
+                  </button>
+                  <div v-if="showPageSortMenu" class="context-menu page-sort-menu" @click.stop @keydown="handlePageSortMenuKeydown" role="menu">
+                    <template v-for="(opt, i) in pageSortOptions" :key="opt.mode">
+                      <div v-if="i > 0 && opt.group !== pageSortOptions[i-1].group" class="context-menu-separator"></div>
+                      <button @click="setSortMode(opt.mode)" class="context-menu-item" :class="{ 'is-selected': sortMode === opt.mode }" role="menuitemradio" :aria-checked="sortMode === opt.mode">
+                        <span class="context-menu-icon">{{ sortMode === opt.mode ? '✓' : '' }}</span>
+                        <span>{{ opt.label }}</span>
+                      </button>
+                    </template>
+                  </div>
+                </div>
                 <div class="context-menu-container">
                   <button @click="togglePageMenu" class="btn btn-outline context-menu-btn" title="Page options" :aria-expanded="showPageMenu" aria-haspopup="menu">
                     ⋮
@@ -3473,7 +3716,7 @@ const Page = {
             @dragover="handleUrlDragOver"
             @drop="handleUrlDrop"
           >
-            <template v-for="block in directBlocks" :key="block.uuid">
+            <template v-for="block in displayBlocks" :key="block.uuid">
               <BlockComponent
                 :block="block"
                 :onBlockContentChange="onBlockContentChange"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -1379,7 +1379,9 @@ const Page = {
           const handle = resizable
             ? '<div class="block-resize-handle" aria-hidden="true"></div>'
             : "";
-          return `<div class="${wrapperClass}">${langBadge}<div class="block-mermaid" data-mermaid-source="${attrEscaped}"></div>${handle}</div>`;
+          const openBtn =
+            '<button type="button" class="block-mermaid-open" title="Open diagram in new tab" aria-label="Open diagram in new tab">↗</button>';
+          return `<div class="${wrapperClass}">${langBadge}<div class="block-mermaid" data-mermaid-source="${attrEscaped}"></div>${openBtn}${handle}</div>`;
         }
         if (
           !forceRaw &&

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -13,8 +13,16 @@ const PAGE_SORT_OPTIONS = [
   { mode: "created-asc", label: "created · oldest first", group: "created" },
   { mode: "updated-desc", label: "updated · newest first", group: "updated" },
   { mode: "updated-asc", label: "updated · oldest first", group: "updated" },
-  { mode: "scheduled-asc", label: "scheduled · soonest first", group: "scheduled" },
-  { mode: "scheduled-desc", label: "scheduled · latest first", group: "scheduled" },
+  {
+    mode: "scheduled-asc",
+    label: "scheduled · soonest first",
+    group: "scheduled",
+  },
+  {
+    mode: "scheduled-desc",
+    label: "scheduled · latest first",
+    group: "scheduled",
+  },
   { mode: "type", label: "type · A to Z", group: "type" },
 ];
 const PAGE_SORT_MODES = new Set(PAGE_SORT_OPTIONS.map((o) => o.mode));
@@ -1893,7 +1901,9 @@ const Page = {
     closePageSortMenuAndRestoreFocus() {
       this.closePageSortMenu();
       this.$nextTick(() => {
-        const btn = this.$el?.querySelector(".page-sort-container .page-sort-btn");
+        const btn = this.$el?.querySelector(
+          ".page-sort-container .page-sort-btn"
+        );
         if (btn) btn.focus();
       });
     },
@@ -1966,8 +1976,7 @@ const Page = {
       }
       try {
         const saved = localStorage.getItem(key);
-        this.sortMode =
-          saved && PAGE_SORT_MODES.has(saved) ? saved : "manual";
+        this.sortMode = saved && PAGE_SORT_MODES.has(saved) ? saved : "manual";
       } catch (e) {
         this.sortMode = "manual";
       }

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/mermaid.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/mermaid.js
@@ -241,4 +241,62 @@
     renderIn,
     rerenderAll,
   };
+
+  // Hover-overlay "open in new tab" button. The button HTML is emitted
+  // by the formatters (BlockComponent.assetRenderHtml + Page.js's
+  // formatContentWithTags) inside the `.block-mermaid-wrapper`; we
+  // listen on the document so the same handler works for both the
+  // asset path and the inline-code path, and so newly-rendered blocks
+  // pick it up without re-binding.
+  function serializeStandaloneSvg(svgEl) {
+    // Clone so we can ensure required xmlns attributes without mutating
+    // the live DOM. The rendered SVG should already have xmlns set, but
+    // not every mermaid version is consistent about xmlns:xlink.
+    const clone = svgEl.cloneNode(true);
+    if (!clone.getAttribute("xmlns")) {
+      clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+    }
+    if (!clone.getAttribute("xmlns:xlink")) {
+      clone.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
+    }
+    const markup = new XMLSerializer().serializeToString(clone);
+    return '<?xml version="1.0" encoding="UTF-8"?>\n' + markup;
+  }
+
+  function openSvgInNewTab(svgEl) {
+    if (!svgEl) return;
+    let url;
+    try {
+      const xml = serializeStandaloneSvg(svgEl);
+      const blob = new Blob([xml], { type: "image/svg+xml" });
+      url = URL.createObjectURL(blob);
+    } catch (e) {
+      console.warn("failed to serialize mermaid svg:", e);
+      return;
+    }
+    // Leak-tolerant: the blob is tiny (one SVG) and lives only for the
+    // current tab's lifetime. Revoking immediately can race the new
+    // tab's load; revoke after a generous delay so the new tab has
+    // settled.
+    window.open(url, "_blank", "noopener,noreferrer");
+    setTimeout(() => URL.revokeObjectURL(url), 60000);
+  }
+
+  // Capture phase so we run before the inline-code path's
+  // .block-content-display @click (which starts editing) and before the
+  // asset path's .block-asset @click.stop (which would otherwise
+  // swallow the bubble-phase event entirely).
+  document.addEventListener(
+    "click",
+    (event) => {
+      const btn = event.target.closest(".block-mermaid-open");
+      if (!btn) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const wrapper = btn.closest(".block-mermaid-wrapper");
+      const svg = wrapper && wrapper.querySelector(".block-mermaid svg");
+      openSvgInNewTab(svg);
+    },
+    true
+  );
 })();

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/mermaid.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/mermaid.js
@@ -299,4 +299,22 @@
     },
     true
   );
+
+  // Mirror the click capture for keyboard activation. The button is a
+  // child of .block-content-display, whose @keydown handler enters
+  // edit mode on Enter / Space — that fires before the browser's
+  // native button activation, so without this the block would start
+  // editing instead of opening the diagram. We stop propagation but
+  // do NOT preventDefault, so the browser still synthesizes the click
+  // that our click listener above handles.
+  document.addEventListener(
+    "keydown",
+    (event) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      const btn = event.target.closest(".block-mermaid-open");
+      if (!btn) return;
+      event.stopPropagation();
+    },
+    true
+  );
 })();


### PR DESCRIPTION
## Summary

This branch grew well past its original scope. It now bundles four user-visible changes plus one fixup:

1. **Fix `copyBlockLink` on nested blocks** — `Closes #` (the original branch goal). The handler was a prop on `BlockComponent` and only wired up on top-level instances; the recursive child render didn't pass it down, so right-clicking a nested block and choosing "copy link to block" silently wrote nothing to the clipboard.
2. **Per-page block sort dropdown** — new control next to the page `⋮` menu (on both daily-note and regular page headers). Sort top-level blocks by created date, updated date, scheduled date, or `type · A to Z` — each with both directions where it makes sense. Sorting is display-only: `directBlocks` and the underlying `order` field are untouched, so manual ordering and drag-and-drop are preserved and "manual order" restores the authored layout. Nulls always sort last regardless of direction; manual `order` is the stable tiebreaker. Selected mode is persisted per-page in `localStorage` keyed by page uuid. The trigger gets an `.is-active` accent when the page isn't in its authored order so users can spot at a glance.
3. **Open rendered mermaid diagrams in a new tab** — a small hover-overlay `↗` button on every rendered mermaid diagram (both inline ` ```mermaid ` blocks and attached `.mmd` / `.mermaid` asset blocks) serializes the live SVG to a Blob and opens it in a new tab, so users can zoom natively. Fully client-side; the blob is revoked after 60s. Capture-phase click + keydown listeners are required because the inline path's `.block-content-display` has click-to-edit and Enter/Space-to-edit handlers, and the asset path's `.block-asset` has `@click.stop` — both would otherwise swallow the activation.
4. **Drop redundant "first" from sort labels** — labels now read "created · newest", "scheduled · soonest", etc. The direction word already implies which end is on top.

Plus one cleanup commit (`b23d3d6`) that ran `prettier --write` on `Page.js` after the sort-dropdown commit left a few lines misformatted.

## Test plan

See the test checklist in the PR conversation. Highlights:

- [ ] Right-click a nested block → "copy link to block" → URL is on the clipboard (this was the broken case).
- [ ] Sort dropdown: each mode reorders top-level blocks correctly; nulls sort last; selection persists per-page across reloads; manual `order` is preserved.
- [ ] Mermaid `↗` button: appears on hover, opens SVG in a new tab, doesn't enter block edit mode on click or on keyboard Enter/Space.
- [ ] Themes (light / dark / earthy / forest) all look correct for the new controls.
- [ ] Mobile (≤768px): sort menu and mermaid button still work.

https://claude.ai/code/session_012YVWeC9Cz8UX1edPhxRAju