### PR TITLE
Add rich property filtering and sorting to query engine

### DIFF
--- a/packages/django-app/app/knowledge/services/query_engine.py
+++ b/packages/django-app/app/knowledge/services/query_engine.py
@@ -15,6 +15,12 @@ Date tokens (``today``, ``tomorrow``, ``yesterday``, ``N days ago``,
 ``N days from now``, ISO ``YYYY-MM-DD``) are resolved at execute time
 against ``user.today()`` so views stay relative.
 
+``key:: value`` block properties are queryable through ``has_property``
+(key existence) and ``property_eq`` (op-dict against the value). Values
+are stringly-typed today — the inline parser stores ``value.strip()`` —
+so all comparisons are string-vs-string. Sort by a JSONB key with
+``{"field": "properties.<key>", "dir": ...}``.
+
 ``has_tag`` compiles to an ``Exists()`` subquery against the Block.pages
 through table, which makes multi-tag AND/OR composition Just Work under
 arbitrary combinator nesting (a single ``filter(pages__slug__in=[...])``
@@ -277,31 +283,132 @@ def _has_tag_q(value: Any, user) -> Q:
     return page_membership | Q(Exists(sub))
 
 
+# Property keys are constrained to the same charset the parser accepts in
+# ``Block.extract_properties_from_content`` (``[a-zA-Z0-9_-]+``). Once we're
+# inside ``properties__<key>`` Django interprets further ``__`` segments as
+# nested JSON-path lookups, not as model traversals, so the validation is
+# mainly a hygiene check — keep query keys to the same shape the inline
+# parser produces, since those are the only keys real blocks will have.
+_PROPERTY_KEY_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+_PROPERTY_OPS = {
+    "eq",
+    "ne",
+    "in",
+    "not_in",
+    "contains",
+    "starts_with",
+    "ends_with",
+    "lt",
+    "lte",
+    "gt",
+    "gte",
+}
+
+
+def _validate_property_key(key: Any, predicate: str) -> str:
+    if not isinstance(key, str) or not key:
+        raise QueryEngineError(f"{predicate}.key must be a string: {key!r}")
+    if not _PROPERTY_KEY_RE.match(key):
+        raise QueryEngineError(f"{predicate}.key must match [a-zA-Z0-9_-]+: {key!r}")
+    return key
+
+
 def _has_property_q(value: Any, user) -> Q:
     if isinstance(value, dict):
         value = value.get("eq")
-    if not isinstance(value, str) or not value:
-        raise QueryEngineError(f"has_property must be a key string: {value!r}")
-    return Q(properties__has_key=value)
+    key = _validate_property_key(value, "has_property")
+    return Q(properties__has_key=key)
 
 
 def _property_eq_q(value: Any, user) -> Q:
-    """Exact-match predicate against ``Block.properties[key]``.
+    """Op-dict predicate against ``Block.properties[key]``.
 
-    Property values are stringly-typed today (the inline ``key:: value``
-    parser stores ``value.strip()`` as a string) — so this matches a
-    string-vs-string. Numeric / typed comparisons are out of scope until
-    typed properties land.
+    Shorthand ``{"key": K, "value": V}`` is treated as ``{"key": K,
+    "eq": V}`` for backwards compatibility with the original ``eq``-only
+    shape. The general form is ``{"key": K, <op>: <arg>, ...}`` where
+    multiple ops AND together (e.g. ``{"gte": "2h", "lte": "5h"}``).
+
+    Property values are stringly-typed today — the inline ``key:: value``
+    parser stores ``value.strip()`` as a string — so all comparisons are
+    string-vs-string. That's intentionally good enough for ISO date
+    strings (``due:: 2026-05-01`` compares lexicographically the way
+    you'd want) and dollar-prefixed money (``cost:: $042``), but it
+    does mean ``estimate:: 10`` sorts before ``estimate:: 2``. Numeric
+    coercion lands when typed properties do.
+
+    ``ne`` / ``not_in`` match blocks that have the key set to something
+    other than the given value(s); blocks that don't have the key at
+    all are *not* matched (SQL ``NULL <> 'x'`` is NULL). Use
+    ``{"any": [{"property_eq": {...ne...}}, {"not": {"has_property":
+    "K"}}]}`` if you also want missing-key blocks.
     """
     if not isinstance(value, dict):
-        raise QueryEngineError(f"property_eq must be {{key, value}}: {value!r}")
-    key = value.get("key")
-    val = value.get("value")
-    if not isinstance(key, str) or not key:
-        raise QueryEngineError(f"property_eq.key must be a string: {key!r}")
-    if val is None:
-        raise QueryEngineError("property_eq.value is required")
-    return Q(**{f"properties__{key}": val})
+        raise QueryEngineError(f"property_eq must be a dict: {value!r}")
+    key = _validate_property_key(value.get("key"), "property_eq")
+
+    ops = {k: v for k, v in value.items() if k != "key"}
+    if "value" in ops:
+        # Legacy shorthand: {"key": K, "value": V} == {"key": K, "eq": V}.
+        # Reject collision with an explicit eq so the spec stays unambiguous.
+        if "eq" in ops:
+            raise QueryEngineError("property_eq cannot specify both 'value' and 'eq'")
+        ops["eq"] = ops.pop("value")
+
+    if not ops:
+        raise QueryEngineError(
+            "property_eq requires at least one op (eq/ne/in/not_in/"
+            "contains/starts_with/ends_with/lt/lte/gt/gte) or 'value'"
+        )
+
+    lookup = f"properties__{key}"
+    q = Q()
+    for op, arg in ops.items():
+        if op not in _PROPERTY_OPS:
+            raise QueryEngineError(f"Unsupported op {op!r} on property_eq")
+        if op == "eq":
+            if arg is None:
+                raise QueryEngineError("property_eq.eq must not be null")
+            q &= Q(**{lookup: arg})
+        elif op == "ne":
+            if arg is None:
+                raise QueryEngineError("property_eq.ne must not be null")
+            q &= ~Q(**{lookup: arg})
+        elif op == "in":
+            if not isinstance(arg, list) or not arg:
+                raise QueryEngineError(
+                    f"property_eq.in must be a non-empty list: {arg!r}"
+                )
+            q &= Q(**{f"{lookup}__in": arg})
+        elif op == "not_in":
+            if not isinstance(arg, list) or not arg:
+                raise QueryEngineError(
+                    f"property_eq.not_in must be a non-empty list: {arg!r}"
+                )
+            q &= ~Q(**{f"{lookup}__in": arg})
+        elif op == "contains":
+            if not isinstance(arg, str) or not arg:
+                raise QueryEngineError(
+                    f"property_eq.contains must be a non-empty string: {arg!r}"
+                )
+            q &= Q(**{f"{lookup}__icontains": arg})
+        elif op == "starts_with":
+            if not isinstance(arg, str) or not arg:
+                raise QueryEngineError(
+                    f"property_eq.starts_with must be a non-empty string: {arg!r}"
+                )
+            q &= Q(**{f"{lookup}__istartswith": arg})
+        elif op == "ends_with":
+            if not isinstance(arg, str) or not arg:
+                raise QueryEngineError(
+                    f"property_eq.ends_with must be a non-empty string: {arg!r}"
+                )
+            q &= Q(**{f"{lookup}__iendswith": arg})
+        else:  # lt / lte / gt / gte
+            if not isinstance(arg, (str, int, float)):
+                raise QueryEngineError(f"property_eq.{op} must be a scalar: {arg!r}")
+            q &= Q(**{f"{lookup}__{op}": arg})
+    return q
 
 
 def _content_contains_q(value: Any, user) -> Q:
@@ -393,6 +500,28 @@ _SORT_FIELDS = {
 }
 
 
+def _resolve_sort_field(raw: Any) -> str:
+    """Validate a sort field and return the Django ORM expression for it.
+
+    Accepts:
+      - any name in ``_SORT_FIELDS`` (real model field)
+      - ``properties.<key>`` to sort by a JSONB key. ``<key>`` must
+        match the same charset the property parser accepts so we
+        can safely interpolate it into the ORM lookup. Blocks that
+        don't have ``<key>`` set sort as NULL (Postgres default:
+        last in ASC, first in DESC).
+    """
+    if not isinstance(raw, str) or not raw:
+        raise QueryEngineError(f"Sort field must be a non-empty string: {raw!r}")
+    if raw in _SORT_FIELDS:
+        return raw
+    if raw.startswith("properties."):
+        key = raw.split(".", 1)[1]
+        _validate_property_key(key, "sort.properties")
+        return f"properties__{key}"
+    raise QueryEngineError(f"Unsupported sort field: {raw!r}")
+
+
 def _compile_sort(sort_spec: Any) -> List[str]:
     if not sort_spec:
         return []
@@ -403,13 +532,11 @@ def _compile_sort(sort_spec: Any) -> List[str]:
     for item in sort_spec:
         if not isinstance(item, dict) or "field" not in item:
             raise QueryEngineError(f"Sort item must be {{field, dir}}: {item!r}")
-        f = item["field"]
-        if f not in _SORT_FIELDS:
-            raise QueryEngineError(f"Unsupported sort field: {f!r}")
+        resolved = _resolve_sort_field(item["field"])
         direction = item.get("dir", "asc")
         if direction not in ("asc", "desc"):
             raise QueryEngineError(f"Sort dir must be 'asc' or 'desc': {direction!r}")
-        parts.append(f"-{f}" if direction == "desc" else f)
+        parts.append(f"-{resolved}" if direction == "desc" else resolved)
     return parts
 
 

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -7290,6 +7290,25 @@ a.hashtag-mention:hover,
   font-size: 0.85rem;
 }
 
+.saved-view-editor .prefill-match-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding: 0.6rem 0.75rem;
+  margin-bottom: 0.75rem;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 3px;
+  color: var(--text-primary);
+  font-size: 0.85rem;
+}
+
+.saved-view-editor .prefill-match-banner > span {
+  flex: 1;
+  min-width: 0;
+}
+
 .saved-view-help {
   margin-top: 1rem;
   padding-top: 0.75rem;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
@@ -37,6 +37,11 @@ const SavedViewsPage = {
 
       // Inline "new view" toggle on the index.
       creating: false,
+
+      // Set when ``_maybePrefillFromQuery`` found an existing view whose
+      // filter matches the clicked property — drives the dismissible
+      // "you already have a view for this" banner above the editor.
+      prefillMatch: null,
     };
   },
 
@@ -459,12 +464,46 @@ const SavedViewsPage = {
       );
       this.editorErrors = {};
       this.saveError = null;
+      this.prefillMatch = this._findPropertyEqView(key, value);
+    },
+
+    _findPropertyEqView(key, value) {
+      // Match an existing view whose top-level filter is a single
+      // ``property_eq`` on (key, value). Handles both the legacy
+      // ``{key, value}`` shorthand and the op-dict ``{key, eq}`` shape
+      // so views saved either way are detected. Deeper structural
+      // matches (e.g. a ``property_eq`` nested inside an ``all``) aren't
+      // worth the complexity — the chip-click path produces top-level
+      // ``property_eq``, so that's what's most likely to duplicate.
+      if (!Array.isArray(this.views)) return null;
+      for (const v of this.views) {
+        const f = v && v.filter;
+        if (!f || typeof f !== "object" || Array.isArray(f)) continue;
+        const pe = f.property_eq;
+        if (!pe || typeof pe !== "object" || pe.key !== key) continue;
+        const eqVal = "eq" in pe ? pe.eq : pe.value;
+        if (eqVal === value) return v;
+      }
+      return null;
+    },
+
+    openPrefillMatch() {
+      if (!this.prefillMatch) return;
+      const slug = this.prefillMatch.slug;
+      this.prefillMatch = null;
+      this.creating = false;
+      this.selectSlug(slug);
+    },
+
+    dismissPrefillMatch() {
+      this.prefillMatch = null;
     },
 
     cancelCreate() {
       this.creating = false;
       this.saveError = null;
       this.editorErrors = {};
+      this.prefillMatch = null;
     },
 
     blockHref(block) {
@@ -496,6 +535,13 @@ const SavedViewsPage = {
 
         <div v-if="creating" class="saved-view-editor">
           <h2>New view</h2>
+          <div v-if="prefillMatch" class="prefill-match-banner">
+            <span>
+              View <strong>{{ prefillMatch.name }}</strong> already filters this property.
+            </span>
+            <button class="btn btn-primary" @click="openPrefillMatch">Open it</button>
+            <button class="btn" @click="dismissPrefillMatch">Dismiss</button>
+          </div>
           <div class="form-row">
             <label>Name</label>
             <input v-model="editor.name" type="text" maxlength="200" />

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
@@ -535,8 +535,14 @@ const SavedViewsPage = {
     { "completed_at": { "is_null": true } }
   ]
 }</pre>
+            <p>Querying <code>key:: value</code> properties — match high or critical priority:</p>
+            <pre>{ "property_eq": { "key": "priority", "in": ["high", "critical"] } }</pre>
+            <p>String comparison is lexicographic, which works for ISO dates stored as properties (e.g. <code>due:: 2026-05-01</code>):</p>
+            <pre>{ "property_eq": { "key": "due", "lt": "2026-05-01" } }</pre>
             <p>Predicates: block_type, scheduled_for, completed_at, has_tag, has_property, property_eq, content_contains. Combinators: all, any, not. Date tokens: today, tomorrow, yesterday, "N days ago", "N days from now", or YYYY-MM-DD.</p>
+            <p><strong>property_eq</strong> ops: eq, ne, in, not_in, contains, starts_with, ends_with, lt, lte, gt, gte. Multiple ops on one predicate AND together. Values are stringly-typed (the parser stores everything as strings), so comparisons are string-vs-string.</p>
             <p><strong>has_tag</strong> matches blocks that live on a page with that slug <em>or</em> blocks that explicitly link to that page with #tag / [[link]].</p>
+            <p>Sort by a property: <code>[{ "field": "properties.priority", "dir": "asc" }]</code>. Blocks without the key sort last in asc, first in desc.</p>
           </div>
         </div>
 

--- a/packages/django-app/app/knowledge/test/services/test_query_engine.py
+++ b/packages/django-app/app/knowledge/test/services/test_query_engine.py
@@ -293,7 +293,9 @@ class HasPropertyTests(_EngineTestBase):
 
 
 class PropertyEqTests(_EngineTestBase):
-    def test_match(self):
+    def test_value_shorthand_match(self):
+        """Legacy ``{"key": K, "value": V}`` shape — kept working so old
+        saved views (and the SavedViewsPage chip-prefill) still compile."""
         a = BlockFactory(
             user=self.user, page=self.page, properties={"priority": "high"}
         )
@@ -301,9 +303,133 @@ class PropertyEqTests(_EngineTestBase):
         out = self.run_query({"property_eq": {"key": "priority", "value": "high"}})
         self.assertEqual([b.id for b in out], [a.id])
 
-    def test_missing_value_rejected(self):
+    def test_eq_op_match(self):
+        a = BlockFactory(
+            user=self.user, page=self.page, properties={"priority": "high"}
+        )
+        BlockFactory(user=self.user, page=self.page, properties={"priority": "low"})
+        out = self.run_query({"property_eq": {"key": "priority", "eq": "high"}})
+        self.assertEqual([b.id for b in out], [a.id])
+
+    def test_ne_excludes_match_but_not_missing(self):
+        """``ne`` matches blocks with the key set to anything else — but
+        *not* blocks without the key (SQL ``NULL <> 'x'`` is NULL)."""
+        a = BlockFactory(
+            user=self.user, page=self.page, properties={"priority": "high"}
+        )
+        BlockFactory(user=self.user, page=self.page, properties={"priority": "low"})
+        BlockFactory(user=self.user, page=self.page, properties={})  # no priority
+        out = self.run_query({"property_eq": {"key": "priority", "ne": "low"}})
+        self.assertEqual([b.id for b in out], [a.id])
+
+    def test_in_op(self):
+        a = BlockFactory(
+            user=self.user, page=self.page, properties={"priority": "high"}
+        )
+        b = BlockFactory(
+            user=self.user, page=self.page, properties={"priority": "critical"}
+        )
+        BlockFactory(user=self.user, page=self.page, properties={"priority": "low"})
+        out = self.run_query(
+            {"property_eq": {"key": "priority", "in": ["high", "critical"]}}
+        )
+        self.assertEqual({blk.id for blk in out}, {a.id, b.id})
+
+    def test_not_in_op(self):
+        a = BlockFactory(
+            user=self.user, page=self.page, properties={"priority": "high"}
+        )
+        BlockFactory(user=self.user, page=self.page, properties={"priority": "low"})
+        BlockFactory(user=self.user, page=self.page, properties={"priority": "trivial"})
+        out = self.run_query(
+            {"property_eq": {"key": "priority", "not_in": ["low", "trivial"]}}
+        )
+        self.assertEqual([blk.id for blk in out], [a.id])
+
+    def test_contains_icontains(self):
+        a = BlockFactory(user=self.user, page=self.page, properties={"area": "Health"})
+        BlockFactory(user=self.user, page=self.page, properties={"area": "Work"})
+        out = self.run_query({"property_eq": {"key": "area", "contains": "heal"}})
+        self.assertEqual([blk.id for blk in out], [a.id])
+
+    def test_starts_with(self):
+        a = BlockFactory(
+            user=self.user, page=self.page, properties={"project": "roadmap-q1"}
+        )
+        BlockFactory(
+            user=self.user, page=self.page, properties={"project": "ops-roadmap"}
+        )
+        out = self.run_query(
+            {"property_eq": {"key": "project", "starts_with": "roadmap"}}
+        )
+        self.assertEqual([blk.id for blk in out], [a.id])
+
+    def test_ends_with(self):
+        a = BlockFactory(user=self.user, page=self.page, properties={"file": "a.md"})
+        BlockFactory(user=self.user, page=self.page, properties={"file": "a.txt"})
+        out = self.run_query({"property_eq": {"key": "file", "ends_with": ".md"}})
+        self.assertEqual([blk.id for blk in out], [a.id])
+
+    def test_lt_lexicographic(self):
+        """String comparison on ISO date-shaped values — useful for
+        ``due:: 2026-05-01`` until typed properties land."""
+        a = BlockFactory(
+            user=self.user, page=self.page, properties={"due": "2026-04-30"}
+        )
+        BlockFactory(user=self.user, page=self.page, properties={"due": "2026-05-05"})
+        out = self.run_query({"property_eq": {"key": "due", "lt": "2026-05-01"}})
+        self.assertEqual([blk.id for blk in out], [a.id])
+
+    def test_range_with_gte_and_lte(self):
+        a = BlockFactory(
+            user=self.user, page=self.page, properties={"due": "2026-05-03"}
+        )
+        BlockFactory(user=self.user, page=self.page, properties={"due": "2026-04-30"})
+        BlockFactory(user=self.user, page=self.page, properties={"due": "2026-05-10"})
+        out = self.run_query(
+            {
+                "property_eq": {
+                    "key": "due",
+                    "gte": "2026-05-01",
+                    "lte": "2026-05-05",
+                }
+            }
+        )
+        self.assertEqual([blk.id for blk in out], [a.id])
+
+    def test_missing_ops_rejected(self):
         with self.assertRaises(query_engine.QueryEngineError):
             query_engine.compile({"property_eq": {"key": "priority"}}, user=self.user)
+
+    def test_value_and_eq_collision_rejected(self):
+        with self.assertRaises(query_engine.QueryEngineError):
+            query_engine.compile(
+                {"property_eq": {"key": "priority", "value": "high", "eq": "low"}},
+                user=self.user,
+            )
+
+    def test_unknown_op_rejected(self):
+        with self.assertRaises(query_engine.QueryEngineError):
+            query_engine.compile(
+                {"property_eq": {"key": "priority", "like": "high"}}, user=self.user
+            )
+
+    def test_in_empty_list_rejected(self):
+        with self.assertRaises(query_engine.QueryEngineError):
+            query_engine.compile(
+                {"property_eq": {"key": "priority", "in": []}}, user=self.user
+            )
+
+    def test_bad_key_charset_rejected(self):
+        """Keys are constrained to the parser's charset so query keys
+        match what the inline ``key:: value`` parser will actually
+        produce — spaces, dots, slashes etc. never appear in real blocks."""
+        for bad_key in ("with space", "priority.x", "key/foo", "k;drop"):
+            with self.assertRaises(query_engine.QueryEngineError):
+                query_engine.compile(
+                    {"property_eq": {"key": bad_key, "eq": "high"}},
+                    user=self.user,
+                )
 
 
 class ContentContainsTests(_EngineTestBase):
@@ -497,6 +623,45 @@ class SortTests(_EngineTestBase):
         with self.assertRaises(query_engine.QueryEngineError):
             query_engine.compile(
                 {}, user=self.user, sort=[{"field": "uuid", "dir": "asc"}]
+            )
+
+    def test_sort_by_property_asc(self):
+        """``properties.<key>`` sorts by JSONB value. Strings compare
+        lexicographically, so a/b/c ordering is by raw string."""
+        b = BlockFactory(user=self.user, page=self.page, properties={"priority": "b"})
+        a = BlockFactory(user=self.user, page=self.page, properties={"priority": "a"})
+        c = BlockFactory(user=self.user, page=self.page, properties={"priority": "c"})
+        out = self.run_query(
+            {"has_property": "priority"},
+            sort=[{"field": "properties.priority", "dir": "asc"}],
+        )
+        self.assertEqual([blk.id for blk in out], [a.id, b.id, c.id])
+
+    def test_sort_by_property_desc(self):
+        b = BlockFactory(user=self.user, page=self.page, properties={"priority": "b"})
+        a = BlockFactory(user=self.user, page=self.page, properties={"priority": "a"})
+        c = BlockFactory(user=self.user, page=self.page, properties={"priority": "c"})
+        out = self.run_query(
+            {"has_property": "priority"},
+            sort=[{"field": "properties.priority", "dir": "desc"}],
+        )
+        self.assertEqual([blk.id for blk in out], [c.id, b.id, a.id])
+
+    def test_sort_property_bad_key_rejected(self):
+        for bad_field in (
+            "properties.with space",
+            "properties.priority.nested",
+            "properties.k/x",
+        ):
+            with self.assertRaises(query_engine.QueryEngineError):
+                query_engine.compile(
+                    {}, user=self.user, sort=[{"field": bad_field, "dir": "asc"}]
+                )
+
+    def test_sort_property_empty_key_rejected(self):
+        with self.assertRaises(query_engine.QueryEngineError):
+            query_engine.compile(
+                {}, user=self.user, sort=[{"field": "properties.", "dir": "asc"}]
             )
 
 


### PR DESCRIPTION
Extends the query engine to support advanced filtering and sorting on block properties (the `key:: value` inline syntax).

## Summary

The `property_eq` predicate now supports a full suite of comparison operators (eq, ne, in, not_in, contains, starts_with, ends_with, lt, lte, gt, gte) via an op-dict syntax, replacing the previous single-value shape. Blocks can now be sorted by property values using `{"field": "properties.<key>", "dir": "asc/desc"}` in sort specs. The legacy `{"key": K, "value": V}` shorthand is preserved for backwards compatibility with saved views.

## Key Changes

- **property_eq operator expansion**: Replaced single-value matching with a flexible op-dict that supports multiple comparison operators. Multiple ops in a single dict AND together (e.g., `{"gte": "2h", "lte": "5h"}` for range queries). Maintains backwards compatibility by treating `"value"` as an alias for `"eq"`.

- **Property key validation**: Introduced `_validate_property_key()` to enforce the same charset (`[a-zA-Z0-9_-]+`) that the inline parser accepts, ensuring query keys match what real blocks will have.

- **Sort by properties**: Added `_resolve_sort_field()` to parse and validate `properties.<key>` sort fields. Blocks without the key sort as NULL (Postgres default: last in ASC, first in DESC).

- **String-based comparisons**: All property values remain stringly-typed (as stored by the inline parser), making lexicographic comparison work naturally for ISO date strings (e.g., `due:: 2026-05-01`) and other string-shaped values. Numeric coercion deferred to when typed properties land.

- **Null handling for ne/not_in**: Documented that `ne` and `not_in` match blocks with the key set to something other than the given value(s), but *not* blocks without the key (SQL `NULL <> 'x'` is NULL). Users can combine with `{"not": {"has_property": "K"}}` if they also want missing-key blocks.

- **Documentation updates**: Added module-level docstring explaining property querying, updated `property_eq` docstring with examples and caveats, and added UI examples in SavedViewsPage.js showing property filtering and date-range queries.

## Testing

Comprehensive test coverage added for all new operators, edge cases (empty lists, null values, bad charsets), and sort functionality. Legacy `"value"` shorthand tested for backwards compatibility.

https://claude.ai/code/session_019pKLXrgnLv4g5QTAje5vyC