### PR TITLE
Add page duplication and template system (issue #106)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,3 +155,10 @@ Navigate to `packages/django-app/` for most development tasks.
   GitHub auto-links the PR to the issue and closes the issue on merge.
   This applies even when the issue number was only mentioned in the
   branch name or commit message — put it in the PR body too.
+- **Keep PR descriptions short.** A summary should fit on one screen:
+  2–4 sentences of what changed and why, plus the `Closes #<issue>`
+  line. Skip the bulleted Summary / Test Plan / Implementation Notes
+  scaffolding unless the change is genuinely large or risky. The diff
+  is the source of truth — the description's job is to give a reviewer
+  the framing they can't get from the code, not to restage it in prose.
+  When in doubt, cut.

--- a/packages/django-app/app/knowledge/commands/__init__.py
+++ b/packages/django-app/app/knowledge/commands/__init__.py
@@ -42,6 +42,7 @@ from .list_scheduled_blocks_command import ListScheduledBlocksCommand
 from .list_templates_command import ListTemplatesCommand
 from .move_block_to_daily_command import MoveBlockToDailyCommand
 from .move_undone_todos_command import MoveUndoneTodosCommand
+from .preview_saved_view_command import PreviewSavedViewCommand
 from .reorder_blocks_command import ReorderBlocksCommand
 from .reorder_favorited_pages_command import ReorderFavoritedPagesCommand
 from .reorder_page_embedded_views_command import ReorderPageEmbeddedViewsCommand

--- a/packages/django-app/app/knowledge/commands/__init__.py
+++ b/packages/django-app/app/knowledge/commands/__init__.py
@@ -16,6 +16,7 @@ from .delete_block_command import DeleteBlockCommand
 from .delete_page_command import DeletePageCommand
 from .delete_page_embedded_view_command import DeletePageEmbeddedViewCommand
 from .delete_saved_view_command import DeleteSavedViewCommand
+from .duplicate_page_command import DuplicatePageCommand
 from .duplicate_saved_view_command import DuplicateSavedViewCommand
 from .find_stale_todos_command import FindStaleTodosCommand
 from .get_backlinks_command import GetBacklinksCommand
@@ -38,6 +39,7 @@ from .list_overdue_blocks_command import ListOverdueBlocksCommand
 from .list_pending_reminders_command import ListPendingRemindersCommand
 from .list_saved_views_command import ListSavedViewsCommand
 from .list_scheduled_blocks_command import ListScheduledBlocksCommand
+from .list_templates_command import ListTemplatesCommand
 from .move_block_to_daily_command import MoveBlockToDailyCommand
 from .move_undone_todos_command import MoveUndoneTodosCommand
 from .reorder_blocks_command import ReorderBlocksCommand

--- a/packages/django-app/app/knowledge/commands/duplicate_page_command.py
+++ b/packages/django-app/app/knowledge/commands/duplicate_page_command.py
@@ -1,4 +1,3 @@
-
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils.text import slugify

--- a/packages/django-app/app/knowledge/commands/duplicate_page_command.py
+++ b/packages/django-app/app/knowledge/commands/duplicate_page_command.py
@@ -6,7 +6,7 @@ from common.commands.abstract_base_command import AbstractBaseCommand
 
 from ..forms.duplicate_page_form import DuplicatePageForm
 from ..models import Page
-from ..repositories import BlockRepository, PageRepository
+from ..repositories import BlockRepository, PageEmbeddedViewRepository, PageRepository
 
 
 class DuplicatePageCommand(AbstractBaseCommand):
@@ -69,6 +69,16 @@ class DuplicatePageCommand(AbstractBaseCommand):
             # whiteboard_snapshot, copied above.
             if page_type != "whiteboard" and source.page_type != "whiteboard":
                 BlockRepository.clone_block_tree_to_page(
+                    source_page=source,
+                    target_page=new_page,
+                    target_user=user,
+                )
+                # Carry over embedded saved views (issue #106 follow-up).
+                # A template with a "today's overdue todos" embed is the
+                # killer use case — instantiating it has to bring the
+                # embed along or the template loses half its purpose.
+                # SavedView refs are preserved (views aren't page-scoped).
+                PageEmbeddedViewRepository.clone_to_page(
                     source_page=source,
                     target_page=new_page,
                     target_user=user,

--- a/packages/django-app/app/knowledge/commands/duplicate_page_command.py
+++ b/packages/django-app/app/knowledge/commands/duplicate_page_command.py
@@ -1,0 +1,96 @@
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.utils.text import slugify
+
+from common.commands.abstract_base_command import AbstractBaseCommand
+
+from ..forms.duplicate_page_form import DuplicatePageForm
+from ..models import Page
+from ..repositories import BlockRepository, PageRepository
+
+
+class DuplicatePageCommand(AbstractBaseCommand):
+    """Clone a page into a new page owned by the same user, copying the
+    full block tree (issue #106).
+
+    Powers three flows:
+      * Duplicate page — caller passes only ``source_page_uuid``; result
+        keeps the source's page_type (except daily/template, which
+        normalize to ``page`` since duplicating those as the same type
+        rarely makes sense).
+      * Save as template — caller passes ``new_page_type='template'``.
+      * Use template — caller passes a template uuid + a ``new_title``;
+        result is a regular ``page``.
+
+    The new slug is unique-suffixed if the auto-slugified title is
+    already taken (``-copy``, ``-copy-2``, ...).
+    """
+
+    DEFAULT_TARGET_FOR_SOURCE = {
+        "daily": "page",
+        "template": "page",
+    }
+
+    def __init__(self, form: DuplicatePageForm) -> None:
+        self.form = form
+
+    def execute(self) -> Page:
+        super().execute()
+
+        user = self.form.cleaned_data["user"]
+        source_uuid = str(self.form.cleaned_data["source_page_uuid"])
+        new_title = self.form.cleaned_data.get("new_title")
+        new_page_type = self.form.cleaned_data.get("new_page_type") or None
+
+        source = PageRepository.get_by_uuid(source_uuid, user=user)
+        if not source:
+            raise ValidationError("Page not found")
+
+        title = new_title or f"{source.title} (copy)"
+        page_type = new_page_type or self.DEFAULT_TARGET_FOR_SOURCE.get(
+            source.page_type, source.page_type
+        )
+
+        with transaction.atomic():
+            slug = self._unique_slug(user, slugify(title)[:200] or "page")
+            new_page = PageRepository.create(
+                {
+                    "user": user,
+                    "title": title,
+                    "slug": slug,
+                    "is_published": source.is_published,
+                    "page_type": page_type,
+                    "whiteboard_snapshot": source.whiteboard_snapshot,
+                }
+            )
+
+            # Templates and regular pages copy block trees. Whiteboard
+            # pages have no Block rows — their content lives in
+            # whiteboard_snapshot, copied above.
+            if page_type != "whiteboard" and source.page_type != "whiteboard":
+                BlockRepository.clone_block_tree_to_page(
+                    source_page=source,
+                    target_page=new_page,
+                    target_user=user,
+                )
+
+            return new_page
+
+    @staticmethod
+    def _unique_slug(user, base: str) -> str:
+        """Pick a slug for the new page that doesn't collide with an
+        existing page for the same user. Strategy: try ``<base>``, then
+        ``<base>-copy``, then ``<base>-copy-2``, ... matching the saved-
+        view duplicate naming scheme."""
+        if not PageRepository.slug_exists_for_user(base, user):
+            return base
+        candidate = f"{base}-copy"
+        if not PageRepository.slug_exists_for_user(candidate, user):
+            return candidate
+        n = 2
+        while True:
+            candidate = f"{base}-copy-{n}"
+            if not PageRepository.slug_exists_for_user(candidate, user):
+                return candidate
+            n += 1

--- a/packages/django-app/app/knowledge/commands/list_templates_command.py
+++ b/packages/django-app/app/knowledge/commands/list_templates_command.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from common.commands.abstract_base_command import AbstractBaseCommand
+
+from ..forms.list_templates_form import ListTemplatesForm
+from ..models import Page
+from ..repositories import PageRepository
+
+
+class ListTemplatesCommand(AbstractBaseCommand):
+    """Return the user's template pages (issue #106). The left nav uses
+    this to populate its Templates section so the user can pick one to
+    instantiate a new page from."""
+
+    def __init__(self, form: ListTemplatesForm) -> None:
+        self.form = form
+
+    def execute(self) -> List[Page]:
+        super().execute()
+        user = self.form.cleaned_data["user"]
+        return list(PageRepository.get_user_templates(user))

--- a/packages/django-app/app/knowledge/commands/preview_saved_view_command.py
+++ b/packages/django-app/app/knowledge/commands/preview_saved_view_command.py
@@ -1,0 +1,47 @@
+from typing import Any, Dict
+
+from django.core.exceptions import ValidationError
+
+from common.commands.abstract_base_command import AbstractBaseCommand
+
+from ..forms.preview_saved_view_form import PreviewSavedViewForm
+from ..repositories import BlockRepository
+from ..services import query_engine
+
+
+class PreviewSavedViewCommand(AbstractBaseCommand):
+    """Run an ad-hoc filter + sort spec without persisting it.
+
+    Mirrors RunSavedViewCommand's response shape so the editor's Run
+    button can reuse the same UI whether it's running a saved view or
+    previewing an unsaved draft. The whole point: when a user is mid-
+    edit, clicking Run should show results for what they've typed, not
+    for the spec already on disk.
+    """
+
+    def __init__(self, form: PreviewSavedViewForm) -> None:
+        self.form = form
+
+    def execute(self) -> Dict[str, Any]:
+        super().execute()
+
+        user = self.form.cleaned_data["user"]
+        filter_spec = self.form.cleaned_data["filter"]
+        sort = self.form.cleaned_data.get("sort") or []
+        limit = self.form.cleaned_data.get("limit") or 100
+
+        try:
+            compiled = query_engine.compile(filter_spec, user=user, sort=sort)
+        except query_engine.QueryEngineError as exc:
+            raise ValidationError(str(exc)) from exc
+
+        rows = list(BlockRepository.run_compiled_query(user, compiled, limit=limit + 1))
+        truncated = len(rows) > limit
+        if truncated:
+            rows = rows[:limit]
+
+        return {
+            "count": len(rows),
+            "results": [b.to_dict(include_page_context=True) for b in rows],
+            "truncated": truncated,
+        }

--- a/packages/django-app/app/knowledge/forms/__init__.py
+++ b/packages/django-app/app/knowledge/forms/__init__.py
@@ -42,6 +42,7 @@ from .list_scheduled_blocks_form import ListScheduledBlocksForm
 from .list_templates_form import ListTemplatesForm
 from .move_block_to_daily_form import MoveBlockToDailyForm
 from .move_undone_todos_form import MoveUndoneTodosForm
+from .preview_saved_view_form import PreviewSavedViewForm
 from .reorder_blocks_form import ReorderBlocksForm
 from .reorder_favorited_pages_form import ReorderFavoritedPagesForm
 from .reorder_page_embedded_views_form import ReorderPageEmbeddedViewsForm

--- a/packages/django-app/app/knowledge/forms/__init__.py
+++ b/packages/django-app/app/knowledge/forms/__init__.py
@@ -16,6 +16,7 @@ from .delete_block_form import DeleteBlockForm
 from .delete_page_embedded_view_form import DeletePageEmbeddedViewForm
 from .delete_page_form import DeletePageForm
 from .delete_saved_view_form import DeleteSavedViewForm
+from .duplicate_page_form import DuplicatePageForm
 from .duplicate_saved_view_form import DuplicateSavedViewForm
 from .find_stale_todos_form import FindStaleTodosForm
 from .get_backlinks_form import GetBacklinksForm
@@ -38,6 +39,7 @@ from .list_overdue_blocks_form import ListOverdueBlocksForm
 from .list_pending_reminders_form import ListPendingRemindersForm
 from .list_saved_views_form import ListSavedViewsForm
 from .list_scheduled_blocks_form import ListScheduledBlocksForm
+from .list_templates_form import ListTemplatesForm
 from .move_block_to_daily_form import MoveBlockToDailyForm
 from .move_undone_todos_form import MoveUndoneTodosForm
 from .reorder_blocks_form import ReorderBlocksForm

--- a/packages/django-app/app/knowledge/forms/duplicate_page_form.py
+++ b/packages/django-app/app/knowledge/forms/duplicate_page_form.py
@@ -1,0 +1,37 @@
+from typing import Optional
+
+from django import forms
+from django.core.exceptions import ValidationError
+
+from common.forms.base_form import BaseForm
+from core.models import User
+from core.repositories import UserRepository
+
+from ..models import Page
+
+
+class DuplicatePageForm(BaseForm):
+    """Clone a page (and its full block tree) into a new page owned by
+    the same user. Powers both "Duplicate page" and "Save as template"
+    actions — the caller picks the target page_type via ``new_page_type``.
+    """
+
+    user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
+    source_page_uuid = forms.UUIDField()
+    new_title = forms.CharField(max_length=200, required=False)
+    new_page_type = forms.ChoiceField(
+        choices=Page._meta.get_field("page_type").choices,
+        required=False,
+    )
+
+    def clean_user(self) -> User:
+        user = self.cleaned_data.get("user")
+        if not user:
+            raise ValidationError("User is required")
+        return user
+
+    def clean_new_title(self) -> Optional[str]:
+        title = self.cleaned_data.get("new_title")
+        if title is not None:
+            title = title.strip()
+        return title or None

--- a/packages/django-app/app/knowledge/forms/list_templates_form.py
+++ b/packages/django-app/app/knowledge/forms/list_templates_form.py
@@ -1,0 +1,18 @@
+from django import forms
+from django.core.exceptions import ValidationError
+
+from common.forms.base_form import BaseForm
+from core.models import User
+from core.repositories import UserRepository
+
+
+class ListTemplatesForm(BaseForm):
+    """List the user's template pages (page_type='template')."""
+
+    user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
+
+    def clean_user(self) -> User:
+        user = self.cleaned_data.get("user")
+        if not user:
+            raise ValidationError("User is required")
+        return user

--- a/packages/django-app/app/knowledge/forms/preview_saved_view_form.py
+++ b/packages/django-app/app/knowledge/forms/preview_saved_view_form.py
@@ -1,0 +1,28 @@
+from django import forms
+
+from common.forms.user_form import UserForm
+
+
+class PreviewSavedViewForm(UserForm):
+    """Inputs for previewing an in-progress saved view spec without
+    persisting it. Used by the editor's Run button so a user can see
+    results for the spec they're currently typing, not the spec last
+    saved on disk."""
+
+    filter = forms.JSONField()
+    sort = forms.JSONField(required=False)
+    limit = forms.IntegerField(min_value=1, max_value=500, required=False, initial=100)
+
+    def clean_filter(self):
+        v = self.cleaned_data.get("filter")
+        if not isinstance(v, dict):
+            raise forms.ValidationError("filter must be a JSON object")
+        return v
+
+    def clean_sort(self):
+        v = self.cleaned_data.get("sort")
+        if v is None:
+            return []
+        if not isinstance(v, list):
+            raise forms.ValidationError("sort must be a JSON array")
+        return v

--- a/packages/django-app/app/knowledge/repositories/block_repository.py
+++ b/packages/django-app/app/knowledge/repositories/block_repository.py
@@ -471,6 +471,72 @@ class BlockRepository(BaseRepository):
         return qs
 
     @classmethod
+    def clone_block_tree_to_page(
+        cls, source_page: Page, target_page: Page, target_user
+    ) -> List[Block]:
+        """Deep-copy ``source_page``'s block tree onto ``target_page``.
+
+        Used by the page-template / duplicate flows (issue #106). Each
+        cloned block gets a fresh UUID; parent/child structure, order,
+        block_type, content, properties, media_url, asset, scheduled_for,
+        and the M2M tag set are preserved. completed_at is intentionally
+        cleared on clone — a duplicated todo starts uncompleted even if
+        the source was done.
+
+        Returns the list of newly-created blocks.
+        """
+        source_blocks = list(
+            cls.get_queryset().filter(page=source_page).order_by("parent_id", "order")
+        )
+        if not source_blocks:
+            return []
+
+        with transaction.atomic():
+            uuid_map: Dict[Any, Block] = {}
+            created: List[Block] = []
+            # Two-pass: first create all blocks without parent links so we
+            # have new UUIDs for everyone, then wire up parents in a second
+            # pass. Source blocks were ordered by parent_id then order, so
+            # the M2M copy below stays predictable.
+            for src in source_blocks:
+                new_block = Block.objects.create(
+                    user=target_user,
+                    page=target_page,
+                    parent=None,
+                    content=src.content,
+                    content_type=src.content_type,
+                    block_type=src.block_type,
+                    order=src.order,
+                    media_url=src.media_url,
+                    media_metadata=src.media_metadata,
+                    properties=dict(src.properties or {}),
+                    asset=src.asset,
+                    scheduled_for=src.scheduled_for,
+                    collapsed=src.collapsed,
+                )
+                uuid_map[src.id] = new_block
+                created.append(new_block)
+                # Preserve tag-page M2M so a cloned block keeps its #tags.
+                tag_pages = list(src.pages.all())
+                if tag_pages:
+                    new_block.pages.set(tag_pages)
+
+            # Wire up parent references now that all clones exist.
+            parent_updates = []
+            for src in source_blocks:
+                if src.parent_id is None:
+                    continue
+                clone = uuid_map[src.id]
+                parent_clone = uuid_map.get(src.parent_id)
+                if parent_clone is not None:
+                    clone.parent = parent_clone
+                    parent_updates.append(clone)
+            if parent_updates:
+                Block.objects.bulk_update(parent_updates, ["parent"])
+
+            return created
+
+    @classmethod
     def move_blocks_to_page(cls, blocks: List[Block], target_page: Page) -> bool:
         """Move blocks to target page and update their order"""
         if not blocks:

--- a/packages/django-app/app/knowledge/repositories/block_repository.py
+++ b/packages/django-app/app/knowledge/repositories/block_repository.py
@@ -469,9 +469,11 @@ class BlockRepository(BaseRepository):
     ) -> QuerySet:
         """Execute a CompiledQuery (from knowledge.services.query_engine) for
         the user. Always scoped to ``user`` — saved views can never reach
-        across users. The default ordering is by ``scheduled_for``-then-
-        ``order`` so list-shaped views fall back to a stable, useful sort
-        when the spec doesn't supply one.
+        across users. When the spec doesn't supply a sort we fall back to
+        ``-created_at`` (newest first) — "what did I add lately" is the
+        most useful default for an open-ended block list; the older
+        ``scheduled_for, order`` default surfaced undated items at the
+        top, which felt random for views like "all #brainspread #bugs".
         """
         qs = (
             cls.get_queryset()
@@ -483,7 +485,7 @@ class BlockRepository(BaseRepository):
         if compiled.order_by:
             qs = qs.order_by(*compiled.order_by)
         else:
-            qs = qs.order_by("scheduled_for", "order")
+            qs = qs.order_by("-created_at")
         if limit is not None:
             qs = qs[:limit]
         return qs

--- a/packages/django-app/app/knowledge/repositories/page_embedded_view_repository.py
+++ b/packages/django-app/app/knowledge/repositories/page_embedded_view_repository.py
@@ -99,3 +99,34 @@ class PageEmbeddedViewRepository(BaseRepository):
             if embed.order != index:
                 embed.order = index
                 embed.save(update_fields=["order", "modified_at"])
+
+    @classmethod
+    def clone_to_page(
+        cls, source_page, target_page, target_user
+    ) -> List[PageEmbeddedView]:
+        """Copy every embed from ``source_page`` onto ``target_page``.
+
+        Used by the template / duplicate-page flow (issue #106) so a
+        template's embedded saved views come along when the template
+        is instantiated. The saved_view reference is preserved — a
+        SavedView is a query, not page-scoped data, so two pages can
+        embed the same view independently.
+
+        ``unique_together = (page, saved_view)`` is safe here because
+        the target page is brand new and can't already have any embed.
+        """
+        source_embeds = list(
+            cls.get_queryset().filter(page=source_page).order_by("order", "created_at")
+        )
+        if not source_embeds:
+            return []
+        return [
+            cls.model.objects.create(
+                user=target_user,
+                page=target_page,
+                saved_view=src.saved_view,
+                order=src.order,
+                collapsed=src.collapsed,
+            )
+            for src in source_embeds
+        ]

--- a/packages/django-app/app/knowledge/repositories/page_repository.py
+++ b/packages/django-app/app/knowledge/repositories/page_repository.py
@@ -240,3 +240,12 @@ class PageRepository(BaseRepository):
             queryset = queryset.exclude(uuid=exclude_page_uuid)
 
         return queryset.exists()
+
+    @classmethod
+    def get_user_templates(cls, user) -> QuerySet:
+        """User's template pages, alphabetical. Templates are pages with
+        page_type='template' that the user can instantiate into new
+        regular pages (issue #106)."""
+        return (
+            cls.get_queryset().filter(user=user, page_type="template").order_by("title")
+        )

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -2611,6 +2611,63 @@ kbd {
   font-style: italic;
 }
 
+/* Templates list (issue #106). Each row pairs a "use this template"
+   button (which takes most of the row) with a small arrow link to
+   open the template page itself for editing. */
+.leftnav-templates-body {
+  display: flex;
+  flex-direction: column;
+  padding: 0.1rem 0 0.4rem;
+}
+
+.leftnav-templates-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.leftnav-template-row {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.leftnav-template-row .leftnav-template-use {
+  flex: 1;
+  text-align: left;
+}
+
+.leftnav-template-edit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  margin-right: 0.2rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  border-radius: 3px;
+  font-size: 0.85rem;
+  opacity: 0;
+  transition: opacity 80ms linear;
+}
+
+.leftnav-template-row:hover .leftnav-template-edit,
+.leftnav-template-edit:focus-visible {
+  opacity: 1;
+}
+
+.leftnav-template-edit:hover {
+  background: var(--hover-bg);
+  color: var(--text-primary);
+}
+
+/* Inline "use template" button on the template page header (issue
+   #106). Sits next to the kebab so it's discoverable without forcing
+   the user to open the menu. */
+.use-template-btn {
+  margin-right: 0.4rem;
+}
+
 .leftnav-recent {
   flex: 1;
   min-height: 0;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -7375,6 +7375,51 @@ a.hashtag-mention:hover,
   overflow-x: auto;
 }
 
+.saved-view-cheatsheet > summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--text-primary);
+  padding: 0.3rem 0;
+}
+
+.saved-view-cheatsheet h4 {
+  margin: 1rem 0 0.35rem;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+}
+
+.saved-view-cheatsheet p {
+  margin: 0.35rem 0;
+}
+
+.saved-view-cheatsheet code {
+  background: var(--bg-primary);
+  padding: 1px 4px;
+  border-radius: 3px;
+  border: 1px solid var(--border-primary);
+  font-size: 0.78rem;
+}
+
+.saved-view-cheatsheet .cheat-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.25rem 0 0.5rem;
+}
+
+.saved-view-cheatsheet .cheat-table th,
+.saved-view-cheatsheet .cheat-table td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.3rem 0.5rem;
+  border-bottom: 1px solid var(--border-primary);
+  font-weight: normal;
+}
+
+.saved-view-cheatsheet .cheat-table th {
+  white-space: nowrap;
+  width: 10rem;
+}
+
 .saved-view-spec details {
   border: 1px solid var(--border-primary);
   border-radius: 3px;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -788,6 +788,82 @@ body {
   border-radius: 0;
 }
 
+/* Page picker modal (window.appModals.pickPage). Wider than the
+   prompt/confirm modals so longer page titles fit on one line, and
+   wraps a scrollable result list under the input. */
+.app-modal-picker {
+  max-width: 560px;
+}
+
+.app-modal-picker-results {
+  display: flex;
+  flex-direction: column;
+  max-height: 18rem;
+  overflow-y: auto;
+  border: 1px solid var(--border-primary);
+  border-radius: 3px;
+  background: var(--bg-primary);
+}
+
+.app-modal-picker-empty {
+  padding: 0.75rem 0.6rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  font-style: italic;
+}
+
+.app-modal-picker-result {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border-primary);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.9rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.app-modal-picker-result:last-child {
+  border-bottom: none;
+}
+
+.app-modal-picker-result.is-selected,
+.app-modal-picker-result:hover {
+  background: var(--hover-bg);
+}
+
+.app-modal-picker-result-title {
+  flex: 1;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.app-modal-picker-result-type {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: var(--tag-bg);
+  padding: 1px 6px;
+  border-radius: 3px;
+  letter-spacing: 0.04em;
+}
+
+.app-modal-picker-result-slug {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-family: monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 14rem;
+}
+
 .confirm-modal-content {
   background: var(--bg-primary);
   border: 1px solid var(--border-primary);

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -2661,13 +2661,6 @@ kbd {
   color: var(--text-primary);
 }
 
-/* Inline "use template" button on the template page header (issue
-   #106). Sits next to the kebab so it's discoverable without forcing
-   the user to open the menu. */
-.use-template-btn {
-  margin-right: 0.4rem;
-}
-
 .leftnav-recent {
   flex: 1;
   min-height: 0;

--- a/packages/django-app/app/knowledge/static/knowledge/js/app.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/app.js
@@ -487,6 +487,42 @@ const KnowledgeApp = createApp({
       return this.createNewPage(prefilledTitle, "whiteboard");
     },
 
+    async useTemplate(template) {
+      // Issue #106: instantiate a new page from a template. The
+      // backend duplicate command clones the template's block tree
+      // into the new page; we just need a target title from the user.
+      if (!template?.uuid) return;
+      const title = await window.appModals.prompt({
+        title: `new page from "${template.title}"`,
+        message: "enter a title for the new page:",
+        placeholder: "title",
+        defaultValue: template.title,
+        confirmLabel: "create",
+      });
+      if (title == null) return;
+      const trimmed = title.trim();
+      if (!trimmed) return;
+
+      try {
+        const result = await window.apiService.duplicatePage(template.uuid, {
+          newTitle: trimmed,
+          newPageType: "page",
+        });
+        if (result.success && result.data?.slug) {
+          window.location.href = `/knowledge/page/${result.data.slug}/`;
+        } else {
+          this.addToast(
+            "failed to create page from template: " +
+              (result.errors?.non_field_errors?.[0] || "unknown error"),
+            "error"
+          );
+        }
+      } catch (error) {
+        console.error("Failed to use template:", error);
+        this.addToast("failed to create page from template", "error");
+      }
+    },
+
     navigateToGraph() {
       window.location.href = "/knowledge/graph/";
     },
@@ -1048,6 +1084,7 @@ const KnowledgeApp = createApp({
                             @open-search="openSpotlight"
                             @create-page="createNewPage"
                             @create-whiteboard="createNewWhiteboard"
+                            @use-template="useTemplate"
                             @open-settings="openSettings"
                             @open-help="openHelp"
                             @logout="requestLogout" />
@@ -1064,6 +1101,7 @@ const KnowledgeApp = createApp({
                             @open-search="openSpotlight"
                             @create-page="createNewPage"
                             @create-whiteboard="createNewWhiteboard"
+                            @use-template="useTemplate"
                             @open-settings="openSettings"
                             @open-help="openHelp"
                             @logout="requestLogout" />
@@ -1082,6 +1120,7 @@ const KnowledgeApp = createApp({
                             @open-search="openSpotlight"
                             @create-page="createNewPage"
                             @create-whiteboard="createNewWhiteboard"
+                            @use-template="useTemplate"
                             @open-settings="openSettings"
                             @open-help="openHelp"
                             @logout="requestLogout" />

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/AppModals.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/AppModals.js
@@ -11,8 +11,11 @@
 //   const ok = await window.appModals.confirm("delete this?");
 //   const name = await window.appModals.prompt("page title:");
 //   await window.appModals.alert("upload failed");
+//   const page = await window.appModals.pickPage({title: "embed on a page"});
 //
-// Each method returns a promise that resolves on user action.
+// Each method returns a promise that resolves on user action. pickPage
+// resolves with the selected page object (uuid, slug, title, ...) or
+// null when the user dismisses.
 
 window.AppModals = {
   name: "AppModals",
@@ -27,6 +30,15 @@ window.AppModals = {
       // Local input value for the active prompt dialog, mirrored to
       // <input v-model>. Reset every time a new prompt dialog opens.
       promptValue: "",
+      // Page-picker state. Lives at root rather than inside the queue
+      // entry so v-model can bind directly. Reset whenever a new
+      // pickPage opens or any modal closes.
+      pickerQuery: "",
+      pickerResults: [],
+      pickerSelectedIndex: 0,
+      pickerLoading: false,
+      _pickerDebounce: null,
+      _pickerRequestId: 0,
       _idCounter: 0,
     };
   },
@@ -58,9 +70,19 @@ window.AppModals = {
           const ok = this.$refs.alertOk;
           if (ok) ok.focus();
         });
+      } else if (next && next.kind === "pickPage") {
+        this._resetPicker();
+        this.$nextTick(() => {
+          const input = this.$refs.pickerInput;
+          if (input) input.focus();
+        });
+        // Kick off an initial search so the user sees their most-
+        // recently-edited pages without typing. Empty query → recent.
+        this._runPickerSearch("");
       }
       if (!next && prev) {
         this.promptValue = "";
+        this._resetPicker();
       }
     },
   },
@@ -70,6 +92,7 @@ window.AppModals = {
       confirm: this.confirm.bind(this),
       prompt: this.prompt.bind(this),
       alert: this.alert.bind(this),
+      pickPage: this.pickPage.bind(this),
     };
   },
 
@@ -136,6 +159,129 @@ window.AppModals = {
       });
     },
 
+    pickPage(opts) {
+      // Typeahead page picker. Resolves with the chosen page object
+      // (uuid, slug, title, page_type) or null on dismiss. The caller
+      // doesn't have to wire search — we use the existing
+      // /api/pages/search/ endpoint via window.apiService.
+      const normalized = opts || {};
+      return new Promise((resolve) => {
+        this.queue.push({
+          id: ++this._idCounter,
+          kind: "pickPage",
+          opts: {
+            title: normalized.title || "pick a page",
+            message: normalized.message || "",
+            placeholder: normalized.placeholder || "search pages…",
+            confirmLabel: normalized.confirmLabel || "select",
+            cancelLabel: normalized.cancelLabel || "cancel",
+          },
+          resolve,
+        });
+      });
+    },
+
+    _resetPicker() {
+      this.pickerQuery = "";
+      this.pickerResults = [];
+      this.pickerSelectedIndex = 0;
+      this.pickerLoading = false;
+      if (this._pickerDebounce) {
+        clearTimeout(this._pickerDebounce);
+        this._pickerDebounce = null;
+      }
+    },
+
+    onPickerInput() {
+      // Debounce by 200ms so a fast typer doesn't fire a request per
+      // keystroke. The latest-request-id check below also guards against
+      // out-of-order responses (slow earlier request landing after a
+      // fast later one would otherwise stomp the newer results).
+      if (this._pickerDebounce) clearTimeout(this._pickerDebounce);
+      const query = this.pickerQuery;
+      this._pickerDebounce = setTimeout(() => {
+        this._runPickerSearch(query);
+      }, 200);
+    },
+
+    async _runPickerSearch(query) {
+      const requestId = ++this._pickerRequestId;
+      this.pickerLoading = true;
+      try {
+        // Empty query → server defaults to recent pages, which is the
+        // friendliest landing state. The endpoint accepts an empty
+        // query string and falls back to a chronological page list.
+        const result =
+          query.trim() === ""
+            ? await window.apiService.getPages(true, 15, 0)
+            : await window.apiService.searchPages(query.trim(), 15);
+        if (requestId !== this._pickerRequestId) return; // stale
+        const pages = (result && result.data && result.data.pages) || [];
+        this.pickerResults = pages;
+        // Clamp selectedIndex into range — keep highlight on the first
+        // result by default so Enter picks the obvious choice.
+        this.pickerSelectedIndex = pages.length ? 0 : -1;
+      } catch (err) {
+        if (requestId !== this._pickerRequestId) return;
+        console.error("pickPage search failed:", err);
+        this.pickerResults = [];
+        this.pickerSelectedIndex = -1;
+      } finally {
+        if (requestId === this._pickerRequestId) {
+          this.pickerLoading = false;
+        }
+      }
+    },
+
+    onPickerKeydown(event) {
+      const top = this.active;
+      if (!top || top.kind !== "pickPage") return;
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        if (this.pickerResults.length === 0) return;
+        this.pickerSelectedIndex = Math.min(
+          this.pickerSelectedIndex + 1,
+          this.pickerResults.length - 1
+        );
+        this._scrollSelectedIntoView();
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        if (this.pickerResults.length === 0) return;
+        this.pickerSelectedIndex = Math.max(this.pickerSelectedIndex - 1, 0);
+        this._scrollSelectedIntoView();
+      } else if (event.key === "Enter") {
+        event.preventDefault();
+        this.onPickerConfirm();
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        this.onPickerCancel();
+      }
+    },
+
+    _scrollSelectedIntoView() {
+      this.$nextTick(() => {
+        const items = this.$el?.querySelectorAll(".app-modal-picker-result");
+        const el = items && items[this.pickerSelectedIndex];
+        if (el) el.scrollIntoView({ block: "nearest" });
+      });
+    },
+
+    onPickerConfirm() {
+      const idx = this.pickerSelectedIndex;
+      const page = this.pickerResults[idx];
+      if (!page) return; // nothing to pick, ignore
+      this.finish(page);
+    },
+
+    onPickerCancel() {
+      this.finish(null);
+    },
+
+    onPickerResultClick(index) {
+      this.pickerSelectedIndex = index;
+      this.onPickerConfirm();
+    },
+
     finish(result) {
       const top = this.queue[this.queue.length - 1];
       if (!top) return;
@@ -166,11 +312,16 @@ window.AppModals = {
       if (top.kind === "confirm") this.onCancel();
       else if (top.kind === "prompt") this.onPromptCancel();
       else if (top.kind === "alert") this.onAlertOk();
+      else if (top.kind === "pickPage") this.onPickerCancel();
     },
 
     onKeydown(event) {
       const top = this.active;
       if (!top) return;
+      // pickPage drives its own keyboard surface (arrows + Enter +
+      // Esc) via @keydown on the input — the global Enter-on-button
+      // handlers below would otherwise fight Enter-to-pick.
+      if (top.kind === "pickPage") return;
       if (event.key === "Escape") {
         event.preventDefault();
         if (top.kind === "confirm") this.onCancel();
@@ -279,6 +430,78 @@ window.AppModals = {
               class="btn btn-primary"
               @click="onAlertOk"
               @keydown="onKeydown"
+            >
+              {{ active.opts.confirmLabel }}
+            </button>
+          </div>
+        </div>
+
+        <div
+          v-else-if="active.kind === 'pickPage'"
+          class="app-modal app-modal-picker"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div v-if="active.opts.title" class="app-modal-header">
+            {{ active.opts.title }}
+          </div>
+          <div v-if="active.opts.message" class="app-modal-body">
+            {{ active.opts.message }}
+          </div>
+          <input
+            ref="pickerInput"
+            v-model="pickerQuery"
+            type="text"
+            class="app-modal-input"
+            :placeholder="active.opts.placeholder"
+            @input="onPickerInput"
+            @keydown="onPickerKeydown"
+            autocomplete="off"
+            spellcheck="false"
+          />
+          <div class="app-modal-picker-results" role="listbox">
+            <div v-if="pickerLoading" class="app-modal-picker-empty">
+              searching…
+            </div>
+            <div
+              v-else-if="!pickerResults.length"
+              class="app-modal-picker-empty"
+            >
+              no pages match
+            </div>
+            <button
+              v-else
+              v-for="(page, index) in pickerResults"
+              :key="page.uuid"
+              type="button"
+              class="app-modal-picker-result"
+              :class="{ 'is-selected': index === pickerSelectedIndex }"
+              @click="onPickerResultClick(index)"
+              @mouseenter="pickerSelectedIndex = index"
+              role="option"
+              :aria-selected="index === pickerSelectedIndex"
+            >
+              <span class="app-modal-picker-result-title">{{ page.title }}</span>
+              <span
+                v-if="page.page_type && page.page_type !== 'page'"
+                class="app-modal-picker-result-type"
+              >{{ page.page_type }}</span>
+              <span class="app-modal-picker-result-slug">{{ page.slug }}</span>
+            </button>
+          </div>
+          <div class="app-modal-actions">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              @click="onPickerCancel"
+            >
+              {{ active.opts.cancelLabel }}
+            </button>
+            <button
+              type="button"
+              class="btn btn-primary"
+              @click="onPickerConfirm"
+              :disabled="pickerSelectedIndex < 0 || !pickerResults.length"
             >
               {{ active.opts.confirmLabel }}
             </button>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/LeftNav.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/LeftNav.js
@@ -11,6 +11,7 @@ window.LeftNav = {
     "open-search",
     "create-page",
     "create-whiteboard",
+    "use-template",
     "navigate-graph",
     "navigate-views",
     "navigate-today",
@@ -46,6 +47,16 @@ window.LeftNav = {
     } catch (_) {
       // ignore localStorage failures
     }
+    let templatesExpanded = true;
+    try {
+      const savedTplExpanded =
+        typeof window !== "undefined" && window.localStorage
+          ? window.localStorage.getItem("brainspread.leftNavTemplatesExpanded")
+          : null;
+      if (savedTplExpanded === "0") templatesExpanded = false;
+    } catch (_) {
+      // ignore localStorage failures
+    }
     return {
       historicalData: null,
       loading: false,
@@ -67,6 +78,14 @@ window.LeftNav = {
       // both reset to null on dragend / drop / dragleave-of-the-list.
       favoriteDragIndex: null,
       favoriteDropIndex: null,
+      // Page templates (issue #106) — populated by loadTemplates(), shown
+      // in their own collapsible section. Each row is clickable to open
+      // the template page; the inline "+" button instantiates a new
+      // page from it.
+      templates: [],
+      templatesLoading: false,
+      templatesError: null,
+      templatesExpanded,
     };
   },
 
@@ -92,11 +111,16 @@ window.LeftNav = {
   mounted() {
     this.loadHistoricalData();
     this.loadFavorites();
+    this.loadTemplates();
     this.setupResizeListener();
     // The page header dispatches this when a user stars/unstars the
     // current page so the Favorites list refreshes without a reload.
     this.handleFavoritesChanged = () => this.loadFavorites();
     document.addEventListener("favorites:changed", this.handleFavoritesChanged);
+    // Same pattern for templates (issue #106): "save as template" /
+    // delete-template dispatch this so the sidebar list stays fresh.
+    this.handleTemplatesChanged = () => this.loadTemplates();
+    document.addEventListener("templates:changed", this.handleTemplatesChanged);
     // Close the nav when the user clicks outside it on mobile only.
     // On desktop the rail and panel sit in their own real-estate column
     // and never overlap content, so an outside click shouldn't dismiss
@@ -120,6 +144,12 @@ window.LeftNav = {
       document.removeEventListener(
         "favorites:changed",
         this.handleFavoritesChanged
+      );
+    }
+    if (this.handleTemplatesChanged) {
+      document.removeEventListener(
+        "templates:changed",
+        this.handleTemplatesChanged
       );
     }
     this.detachOutsideClickHandler();
@@ -266,6 +296,48 @@ window.LeftNav = {
       } finally {
         this.favoritesLoading = false;
       }
+    },
+
+    toggleTemplates() {
+      this.templatesExpanded = !this.templatesExpanded;
+      try {
+        if (typeof window !== "undefined" && window.localStorage) {
+          window.localStorage.setItem(
+            "brainspread.leftNavTemplatesExpanded",
+            this.templatesExpanded ? "1" : "0"
+          );
+        }
+      } catch (_) {
+        // localStorage can throw in private mode; toggle still works.
+      }
+    },
+
+    async loadTemplates() {
+      this.templatesLoading = true;
+      this.templatesError = null;
+      try {
+        const result = await window.apiService.getTemplates();
+        if (result.success) {
+          this.templates = result.data?.templates || [];
+        } else {
+          this.templatesError = "failed to load templates";
+        }
+      } catch (error) {
+        console.error("error loading templates:", error);
+        this.templatesError = error.message || "failed to load templates";
+      } finally {
+        this.templatesLoading = false;
+      }
+    },
+
+    onUseTemplate(event, template) {
+      // Stop the row's anchor from also navigating to the template page
+      // when the user clicks the inline "+" button.
+      if (event) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+      this.$emit("use-template", template);
     },
 
     onFavoriteDragStart(event, index) {
@@ -910,6 +982,59 @@ window.LeftNav = {
                   class="leftnav-favorite-drop-indicator"
                   aria-hidden="true"
                 ></div>
+              </div>
+            </div>
+          </section>
+
+          <!-- Templates (collapsible). Issue #106: clicking a row
+               instantiates a new page from the template; the open-link
+               next to it goes to the template page itself for editing. -->
+          <section class="leftnav-section leftnav-templates" aria-label="Templates">
+            <button
+              type="button"
+              class="leftnav-section-toggle"
+              @click="toggleTemplates"
+              :aria-expanded="templatesExpanded"
+            >
+              <span class="leftnav-chevron" :class="{ open: templatesExpanded }" aria-hidden="true">▸</span>
+              <span>templates</span>
+              <span v-if="templates.length" class="leftnav-section-count">{{ templates.length }}</span>
+            </button>
+
+            <div v-if="templatesExpanded" class="leftnav-templates-body">
+              <div v-if="templatesLoading" class="sidebar-loading">
+                Loading...
+              </div>
+              <div v-else-if="templatesError" class="sidebar-error">
+                {{ templatesError }}
+              </div>
+              <div v-else-if="!templates.length" class="leftnav-empty">
+                No templates yet. Use "save as template" from a page menu.
+              </div>
+              <div v-else class="leftnav-templates-list">
+                <div
+                  v-for="template in templates"
+                  :key="template.uuid"
+                  class="leftnav-template-row"
+                >
+                  <button
+                    type="button"
+                    class="leftnav-item leftnav-template-use"
+                    @click="onUseTemplate($event, template)"
+                    :title="'Create a new page from ' + template.title"
+                  >
+                    <span class="leftnav-icon" aria-hidden="true">+</span>
+                    <span class="leftnav-label">{{ template.title }}</span>
+                  </button>
+                  <a
+                    :href="pageUrl(template.slug)"
+                    class="leftnav-template-edit"
+                    @click="handleNavClick($event, template.slug)"
+                    @auxclick="handleNavClick($event, template.slug)"
+                    :title="'Edit template: ' + template.title"
+                    aria-label="Edit template"
+                  >→</a>
+                </div>
               </div>
             </div>
           </section>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -134,6 +134,10 @@ const Page = {
       return !!this.page?.favorited;
     },
 
+    isTemplate() {
+      return this.page?.page_type === "template";
+    },
+
     shareUrl() {
       if (!this.page?.share_token) return "";
       return `${window.location.origin}/knowledge/share/${this.page.share_token}/`;
@@ -1819,6 +1823,115 @@ const Page = {
       this.closePageMenu();
     },
 
+    async duplicatePage() {
+      // Issue #106 — clone the current page (and its block tree) into
+      // a new page. Same flow whether we land on a regular page or a
+      // template; the backend command picks a sensible default
+      // page_type when one isn't specified.
+      if (!this.page) return;
+      this.closePageMenu();
+      try {
+        const result = await window.apiService.duplicatePage(this.page.uuid);
+        if (result.success && result.data?.slug) {
+          this.$parent?.addToast?.("page duplicated", "success");
+          window.location.href = `/knowledge/page/${result.data.slug}/`;
+        } else {
+          this.$parent?.addToast?.(
+            "failed to duplicate page: " +
+              (result.errors?.non_field_errors?.[0] || "unknown error"),
+            "error"
+          );
+        }
+      } catch (error) {
+        console.error("failed to duplicate page:", error);
+        this.$parent?.addToast?.("failed to duplicate page", "error");
+      }
+    },
+
+    async useThisTemplate() {
+      // Issue #106: when the user is sitting on a template page, this
+      // is the one-click "instantiate me" affordance — analogous to
+      // clicking the template's "+" in the LeftNav, but reachable
+      // straight from the page menu so they don't have to navigate
+      // back out.
+      if (!this.page) return;
+      const title = await window.appModals.prompt({
+        title: `new page from "${this.page.title}"`,
+        message: "enter a title for the new page:",
+        placeholder: "title",
+        defaultValue: this.page.title,
+        confirmLabel: "create",
+      });
+      this.closePageMenu();
+      if (title == null) return;
+      const trimmed = title.trim();
+      if (!trimmed) return;
+
+      try {
+        const result = await window.apiService.duplicatePage(this.page.uuid, {
+          newTitle: trimmed,
+          newPageType: "page",
+        });
+        if (result.success && result.data?.slug) {
+          window.location.href = `/knowledge/page/${result.data.slug}/`;
+        } else {
+          this.$parent?.addToast?.(
+            "failed to create page: " +
+              (result.errors?.non_field_errors?.[0] || "unknown error"),
+            "error"
+          );
+        }
+      } catch (error) {
+        console.error("failed to use template:", error);
+        this.$parent?.addToast?.(
+          "failed to create page from template",
+          "error"
+        );
+      }
+    },
+
+    async saveAsTemplate() {
+      // Issue #106 — clone the page as page_type='template'. We leave
+      // the user on the original page and surface the new template via
+      // a toast + the LeftNav refresh event.
+      if (!this.page) return;
+      const defaultName = `${this.page.title} template`;
+      const name = await window.appModals.prompt({
+        title: "save as template",
+        message: "name your template:",
+        placeholder: "template name",
+        defaultValue: defaultName,
+        confirmLabel: "save",
+      });
+      this.closePageMenu();
+      if (name == null) return;
+      const trimmed = name.trim();
+      if (!trimmed) return;
+
+      try {
+        const result = await window.apiService.duplicatePage(this.page.uuid, {
+          newTitle: trimmed,
+          newPageType: "template",
+        });
+        if (result.success) {
+          this.$parent?.addToast?.(
+            `saved "${trimmed}" as a template`,
+            "success"
+          );
+          document.dispatchEvent(new CustomEvent("templates:changed"));
+        } else {
+          this.$parent?.addToast?.(
+            "failed to save template: " +
+              (result.errors?.non_field_errors?.[0] || "unknown error"),
+            "error"
+          );
+        }
+      } catch (error) {
+        console.error("failed to save as template:", error);
+        this.$parent?.addToast?.("failed to save template", "error");
+      }
+    },
+
     async toggleFavorited() {
       if (!this.page) return;
       const next = !this.isFavorited;
@@ -1933,9 +2046,14 @@ const Page = {
       if (!confirmed) return;
 
       try {
+        const wasTemplate = this.page.page_type === "template";
         const result = await window.apiService.deletePage(this.page.uuid);
         if (result.success) {
           this.closePageMenu();
+          if (wasTemplate) {
+            // The LeftNav templates list listens for this and refetches.
+            document.dispatchEvent(new CustomEvent("templates:changed"));
+          }
           // Navigate to today's page after deletion
           const today = new Date();
           const year = today.getFullYear();
@@ -3314,8 +3432,15 @@ const Page = {
                     ✗
                   </button>
                 </div>
+                <span v-if="isTemplate" class="page-type-badge" title="This page is a template — use it from the sidebar or the page menu to create a new page from it.">template</span>
               </div>
               <div class="page-actions">
+                <button
+                  v-if="isTemplate"
+                  @click="useThisTemplate"
+                  class="btn btn-primary use-template-btn"
+                  title="Create a new page from this template"
+                >use template</button>
                 <div class="context-menu-container">
                   <button @click="togglePageMenu" class="btn btn-outline context-menu-btn" title="Page options" :aria-expanded="showPageMenu" aria-haspopup="menu">
                     ⋮
@@ -3323,6 +3448,10 @@ const Page = {
                   <div v-if="showPageMenu" class="context-menu" @click.stop @keydown="handlePageMenuKeydown" role="menu">
                     <button @click="startEditingTitle" class="context-menu-item" role="menuitem">
                       edit title
+                    </button>
+                    <button v-if="isTemplate" @click="useThisTemplate" class="context-menu-item" role="menuitem">
+                      <span class="context-menu-icon">+</span>
+                      <span>use this template</span>
                     </button>
                     <button @click="enterSelectionMode" class="context-menu-item" role="menuitem">
                       <span class="context-menu-icon">◉</span>
@@ -3336,8 +3465,17 @@ const Page = {
                       <span class="context-menu-icon">→</span>
                       <span>share<span v-if="isShared" class="context-menu-badge">on</span></span>
                     </button>
+                    <button @click="duplicatePage" class="context-menu-item" role="menuitem">
+                      <span class="context-menu-icon">⧉</span>
+                      <span>duplicate page</span>
+                    </button>
+                    <button v-if="!isTemplate" @click="saveAsTemplate" class="context-menu-item" role="menuitem">
+                      <span class="context-menu-icon">▤</span>
+                      <span>save as template</span>
+                    </button>
                     <button @click="deletePage" class="context-menu-item context-menu-danger" role="menuitem">
-                      delete page
+                      <span v-if="isTemplate">delete template</span>
+                      <span v-else>delete page</span>
                     </button>
                   </div>
                 </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -3708,12 +3708,6 @@ const Page = {
                 <span v-if="isTemplate" class="page-type-badge" title="This page is a template — use it from the sidebar or the page menu to create a new page from it.">template</span>
               </div>
               <div class="page-actions">
-                <button
-                  v-if="isTemplate"
-                  @click="useThisTemplate"
-                  class="btn btn-primary use-template-btn"
-                  title="Create a new page from this template"
-                >use template</button>
                 <div class="context-menu-container page-sort-container">
                   <button @click="togglePageSortMenu" class="btn btn-outline context-menu-btn page-sort-btn" :class="{ 'is-active': isSortActive }" :title="'Sort blocks: ' + sortLabel" :aria-expanded="showPageSortMenu" aria-haspopup="menu">
                     <span class="page-sort-btn-icon" aria-hidden="true">⇅</span>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
@@ -362,36 +362,34 @@ const SavedViewsPage = {
       }
     },
 
-    async embedOnToday() {
-      // Pin this saved view to today's daily page as a PageEmbeddedView.
-      // The backend command is idempotent on (page, saved_view) — a
-      // second click returns the existing embed rather than creating a
-      // duplicate. We surface that with a "Already embedded" toast so
-      // the user knows their click landed somewhere.
+    async embedOnPage() {
+      // Pin this saved view onto a user-chosen page as a
+      // PageEmbeddedView. Prompts for a target page slug or title;
+      // empty input falls back to today's daily note (the historical
+      // default). The backend command is idempotent on
+      // (page, saved_view) — a second click returns the existing
+      // embed rather than creating a duplicate, surfaced as a toast
+      // so the user knows their click landed somewhere.
       if (!this.activeView) return;
+
+      const todaySlug = this._todaySlug();
+      const target = await window.appModals.prompt({
+        title: "embed view on a page",
+        message: "page title or slug (leave blank for today's daily note):",
+        placeholder: todaySlug,
+        defaultValue: todaySlug,
+        confirmLabel: "embed",
+      });
+      // null = user dismissed the dialog
+      if (target == null) return;
+
       try {
-        const pageResult = await window.apiService.getPageWithBlocks();
-        const page =
-          pageResult && pageResult.data && pageResult.data.page
-            ? pageResult.data.page
-            : null;
+        const page = await this._resolveTargetPage(target.trim() || todaySlug);
         if (!page || !page.uuid) {
           this._toast(
-            this._formatErrors(pageResult && pageResult.errors) ||
-              "Could not resolve today's daily page",
+            `No page found matching "${target.trim() || todaySlug}".`,
             "error"
           );
-          return;
-        }
-
-        // Frontend short-circuit: if today already has an embed for
-        // this view in the response we just fetched, skip the POST.
-        const existing = (pageResult.data.embedded_views || []).find(
-          (e) => e.saved_view && e.saved_view.uuid === this.activeView.uuid
-        );
-        if (existing) {
-          this._toast("Already embedded on today — jumping to it.", "info");
-          window.location.href = `/knowledge/page/${page.slug}/`;
           return;
         }
 
@@ -403,13 +401,61 @@ const SavedViewsPage = {
           window.location.href = `/knowledge/page/${page.slug}/`;
           return;
         }
+        // The create command short-circuits to the existing embed on
+        // duplicate (idempotent), so a non-success here is a real
+        // failure, not the "already embedded" case.
         this._toast(
           this._formatErrors(r && r.errors) || "Embed failed",
           "error"
         );
       } catch (err) {
-        console.error("embedOnToday failed:", err);
+        console.error("embedOnPage failed:", err);
         this._toast(`Embed failed: ${err}`, "error");
+      }
+    },
+
+    _todaySlug() {
+      const d = new Date();
+      const y = d.getFullYear();
+      const m = String(d.getMonth() + 1).padStart(2, "0");
+      const day = String(d.getDate()).padStart(2, "0");
+      return `${y}-${m}-${day}`;
+    },
+
+    async _resolveTargetPage(query) {
+      // Resolve the user's freeform "where to embed" input into a
+      // concrete Page. Strategy:
+      //   1. Try slug exact-match via getPageWithBlocks(slug=...).
+      //      Cheapest path; covers daily slugs (YYYY-MM-DD) and any
+      //      user who pastes the slug from the URL.
+      //   2. Fall back to title search, prefer exact title match,
+      //      otherwise first hit. Tolerates the user typing the
+      //      page's display name instead of its URL slug.
+      try {
+        const slugRes = await window.apiService.getPageWithBlocks(
+          null,
+          null,
+          query
+        );
+        if (slugRes && slugRes.success && slugRes.data && slugRes.data.page) {
+          return slugRes.data.page;
+        }
+      } catch (_) {
+        // getPageWithBlocks returns a structured error for "not found";
+        // network failures fall through to the title search.
+      }
+      try {
+        const searchRes = await window.apiService.searchPages(query, 10);
+        const pages =
+          (searchRes && searchRes.data && searchRes.data.pages) || [];
+        if (!pages.length) return null;
+        const lower = query.toLowerCase();
+        return (
+          pages.find((p) => p.title && p.title.toLowerCase() === lower) ||
+          pages[0]
+        );
+      } catch (_) {
+        return null;
       }
     },
 
@@ -626,7 +672,7 @@ const SavedViewsPage = {
                 {{ running ? "Running…" : "Run" }}
               </button>
               <button class="btn" @click="duplicateActive">Duplicate</button>
-              <button class="btn" @click="embedOnToday" title="Add this view to today's daily page as a block">Embed on today</button>
+              <button class="btn" @click="embedOnPage" title="Embed this view on a page (defaults to today's daily note)">Embed…</button>
               <button class="btn" v-if="canEdit && !editing" @click="startEditing">Edit</button>
               <button class="btn btn-danger" v-if="canDelete" @click="deleteActive">Delete</button>
             </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
@@ -185,6 +185,8 @@ const SavedViewsPage = {
   ]
 }</pre>
 
+  <h4>Examples with OR (<code>any</code>)</h4>
+
   <p>Anything tagged either project, due in the next 7 days:</p>
   <pre>{
   "all": [
@@ -193,6 +195,54 @@ const SavedViewsPage = {
         { "has_tag": "homelab" }
       ] },
     { "scheduled_for": { "between": ["today", "today+7d"] } }
+  ]
+}</pre>
+
+  <p>Needs attention — high priority <em>or</em> overdue <em>or</em>
+  flagged as a blocker:</p>
+  <pre>{
+  "all": [
+    { "block_type": { "in": ["todo", "doing", "later"] } },
+    { "any": [
+        { "property_eq": { "key": "priority", "in": ["high", "critical"] } },
+        { "scheduled_for": { "lt": "today" } },
+        { "has_tag": "blocker" }
+      ] }
+  ]
+}</pre>
+
+  <p>"Anything finished this week" — done <em>or</em> wontdo:</p>
+  <pre>{
+  "all": [
+    { "block_type": { "in": ["done", "wontdo"] } },
+    { "completed_at": { "gte": "7 days ago" } }
+  ]
+}</pre>
+  <pre>[{ "field": "completed_at", "dir": "desc" }]</pre>
+
+  <p>Inbox-style triage list — open blocks with no tag <em>and</em> no
+  due date. Uses two <code>not</code>s under <code>all</code>:</p>
+  <pre>{
+  "all": [
+    { "block_type": { "in": ["todo", "doing", "later"] } },
+    { "scheduled_for": { "is_null": true } },
+    { "not": { "any": [
+        { "has_tag": "work" },
+        { "has_tag": "personal" },
+        { "has_tag": "errand" }
+      ] } }
+  ]
+}</pre>
+
+  <p>Search-style view — any block whose content or tag mentions
+  "deploy", that's still open:</p>
+  <pre>{
+  "all": [
+    { "block_type": { "in": ["todo", "doing", "later"] } },
+    { "any": [
+        { "content_contains": "deploy" },
+        { "has_tag": "deploy" }
+      ] }
   ]
 }</pre>
 </details>`;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
@@ -585,35 +585,23 @@ const SavedViewsPage = {
 
     async embedOnPage() {
       // Pin this saved view onto a user-chosen page as a
-      // PageEmbeddedView. Prompts for a target page slug or title;
-      // empty input falls back to today's daily note (the historical
-      // default). The backend command is idempotent on
-      // (page, saved_view) — a second click returns the existing
-      // embed rather than creating a duplicate, surfaced as a toast
-      // so the user knows their click landed somewhere.
+      // PageEmbeddedView. Opens the typeahead page picker; the user
+      // sees their recent pages by default and can search by title.
+      // The backend command is idempotent on (page, saved_view) — a
+      // second click returns the existing embed rather than creating
+      // a duplicate.
       if (!this.activeView) return;
 
-      const todaySlug = this._todaySlug();
-      const target = await window.appModals.prompt({
-        title: "embed view on a page",
-        message: "page title or slug (leave blank for today's daily note):",
-        placeholder: todaySlug,
-        defaultValue: todaySlug,
+      const page = await window.appModals.pickPage({
+        title: `embed "${this.activeView.name}" on a page`,
+        message: "search by page title, or pick from recent:",
+        placeholder: "page title…",
         confirmLabel: "embed",
       });
       // null = user dismissed the dialog
-      if (target == null) return;
+      if (!page || !page.uuid) return;
 
       try {
-        const page = await this._resolveTargetPage(target.trim() || todaySlug);
-        if (!page || !page.uuid) {
-          this._toast(
-            `No page found matching "${target.trim() || todaySlug}".`,
-            "error"
-          );
-          return;
-        }
-
         const r = await window.apiService.createPageEmbeddedView(
           page.uuid,
           this.activeView.uuid
@@ -632,51 +620,6 @@ const SavedViewsPage = {
       } catch (err) {
         console.error("embedOnPage failed:", err);
         this._toast(`Embed failed: ${err}`, "error");
-      }
-    },
-
-    _todaySlug() {
-      const d = new Date();
-      const y = d.getFullYear();
-      const m = String(d.getMonth() + 1).padStart(2, "0");
-      const day = String(d.getDate()).padStart(2, "0");
-      return `${y}-${m}-${day}`;
-    },
-
-    async _resolveTargetPage(query) {
-      // Resolve the user's freeform "where to embed" input into a
-      // concrete Page. Strategy:
-      //   1. Try slug exact-match via getPageWithBlocks(slug=...).
-      //      Cheapest path; covers daily slugs (YYYY-MM-DD) and any
-      //      user who pastes the slug from the URL.
-      //   2. Fall back to title search, prefer exact title match,
-      //      otherwise first hit. Tolerates the user typing the
-      //      page's display name instead of its URL slug.
-      try {
-        const slugRes = await window.apiService.getPageWithBlocks(
-          null,
-          null,
-          query
-        );
-        if (slugRes && slugRes.success && slugRes.data && slugRes.data.page) {
-          return slugRes.data.page;
-        }
-      } catch (_) {
-        // getPageWithBlocks returns a structured error for "not found";
-        // network failures fall through to the title search.
-      }
-      try {
-        const searchRes = await window.apiService.searchPages(query, 10);
-        const pages =
-          (searchRes && searchRes.data && searchRes.data.pages) || [];
-        if (!pages.length) return null;
-        const lower = query.toLowerCase();
-        return (
-          pages.find((p) => p.title && p.title.toLowerCase() === lower) ||
-          pages[0]
-        );
-      } catch (_) {
-        return null;
       }
     },
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
@@ -71,6 +71,132 @@ const SavedViewsPage = {
         return "";
       }
     },
+    // In-app cheatsheet, rendered next to both the create-view and
+    // edit-view forms. Content is fully static — v-html is safe here
+    // and lets us share one definition between the two editor sites
+    // without dragging in a sub-component.
+    cheatsheetHtml() {
+      return `
+<details class="saved-view-cheatsheet">
+  <summary>Filter &amp; sort cheatsheet (click to expand)</summary>
+
+  <h4>Predicates</h4>
+  <table class="cheat-table">
+    <tr><th><code>block_type</code></th><td>
+      Shorthand <code>"todo"</code> or op-dict <code>{"eq": "todo"}</code> /
+      <code>{"in": ["todo","doing","later"]}</code>.
+    </td></tr>
+    <tr><th><code>has_tag</code></th><td>
+      Slug string (no <code>#</code>). Matches blocks tagged with that
+      page <em>or</em> living on it. To require two tags, list both
+      under <code>all</code>.
+    </td></tr>
+    <tr><th><code>scheduled_for</code></th><td>
+      Date predicate. Ops: <code>is_null</code> (bool), <code>eq</code>,
+      <code>lt</code>, <code>lte</code>, <code>gt</code>, <code>gte</code>,
+      <code>between</code> (<code>[start, end]</code>). Values are date
+      tokens or <code>YYYY-MM-DD</code>.
+    </td></tr>
+    <tr><th><code>completed_at</code></th><td>
+      Same ops as <code>scheduled_for</code> — compares the moment a
+      block transitioned to done / wontdo.
+    </td></tr>
+    <tr><th><code>has_property</code></th><td>
+      Key string. Matches blocks with that <code>key:: value</code>
+      property set (any value).
+    </td></tr>
+    <tr><th><code>property_eq</code></th><td>
+      <code>{"key": "&lt;k&gt;", &lt;op&gt;: &lt;arg&gt;, ...}</code>.
+      Ops: <code>eq</code>, <code>ne</code>, <code>in</code>,
+      <code>not_in</code>, <code>contains</code>, <code>starts_with</code>,
+      <code>ends_with</code>. Multiple ops on one predicate AND together.
+      Property values are stored as strings.
+    </td></tr>
+    <tr><th><code>content_contains</code></th><td>
+      Substring match on the block's text content (case-insensitive).
+    </td></tr>
+  </table>
+
+  <h4>Combinators</h4>
+  <p>
+    <code>all</code> / <code>any</code> take a non-empty array of
+    sub-specs (AND / OR). <code>not</code> takes a single sub-spec.
+    Combinators nest freely.
+  </p>
+
+  <h4>Date tokens</h4>
+  <p>
+    <code>today</code>, <code>tomorrow</code>, <code>yesterday</code>,
+    <code>"N days ago"</code>, <code>"N days from now"</code>,
+    <code>today+Nd</code>, <code>today-Nd</code>, or a literal
+    <code>YYYY-MM-DD</code>. Tokens resolve at compile time against
+    your timezone.
+  </p>
+
+  <h4>Sort</h4>
+  <p>
+    Array of <code>{"field": "...", "dir": "asc"|"desc"}</code>.
+    <strong>Use <code>dir</code>, not <code>direction</code></strong>
+    — unknown keys are silently ignored.
+  </p>
+  <p>
+    Fields: <code>scheduled_for</code>, <code>completed_at</code>,
+    <code>created_at</code>, <code>modified_at</code>, <code>order</code>,
+    <code>block_type</code>, or <code>properties.&lt;key&gt;</code>.
+    Property sort is lexicographic — works naturally for ISO dates
+    stored as properties.
+  </p>
+  <p>
+    Default sort (when the array is empty / omitted) is
+    <code>created_at desc</code> — newest first.
+  </p>
+
+  <h4>Examples</h4>
+
+  <p>Open <code>#brainspread</code> bugs, newest first:</p>
+  <pre>{
+  "all": [
+    { "has_tag": "brainspread" },
+    { "has_tag": "bugs" },
+    { "block_type": { "in": ["todo", "doing", "later"] } }
+  ]
+}</pre>
+  <pre>[{ "field": "created_at", "dir": "desc" }]</pre>
+
+  <p>High-priority work items, by due date then creation:</p>
+  <pre>{
+  "all": [
+    { "has_tag": "work" },
+    { "property_eq": { "key": "priority", "eq": "high" } }
+  ]
+}</pre>
+  <pre>[
+  { "field": "scheduled_for", "dir": "asc" },
+  { "field": "created_at",   "dir": "asc" }
+]</pre>
+
+  <p>Overdue, but not snoozed:</p>
+  <pre>{
+  "all": [
+    { "block_type": { "in": ["todo", "doing", "later"] } },
+    { "scheduled_for": { "lt": "today" } },
+    { "completed_at": { "is_null": true } },
+    { "not": { "has_tag": "snoozed" } }
+  ]
+}</pre>
+
+  <p>Anything tagged either project, due in the next 7 days:</p>
+  <pre>{
+  "all": [
+    { "any": [
+        { "has_tag": "brainspread" },
+        { "has_tag": "homelab" }
+      ] },
+    { "scheduled_for": { "between": ["today", "today+7d"] } }
+  ]
+}</pre>
+</details>`;
+    },
   },
 
   watch: {
@@ -618,24 +744,7 @@ const SavedViewsPage = {
             <button class="btn" @click="cancelCreate">Cancel</button>
           </div>
           <div v-if="saveError" class="form-error">{{ saveError }}</div>
-          <div class="saved-view-help">
-            <p>Filter spec is JSON. Examples:</p>
-            <pre>{
-  "all": [
-    { "block_type": { "in": ["todo", "doing"] } },
-    { "scheduled_for": { "lt": "today" } },
-    { "completed_at": { "is_null": true } }
-  ]
-}</pre>
-            <p>Querying <code>key:: value</code> properties — match high or critical priority:</p>
-            <pre>{ "property_eq": { "key": "priority", "in": ["high", "critical"] } }</pre>
-            <p>String comparison is lexicographic, which works for ISO dates stored as properties (e.g. <code>due:: 2026-05-01</code>):</p>
-            <pre>{ "property_eq": { "key": "due", "lt": "2026-05-01" } }</pre>
-            <p>Predicates: block_type, scheduled_for, completed_at, has_tag, has_property, property_eq, content_contains. Combinators: all, any, not. Date tokens: today, tomorrow, yesterday, "N days ago", "N days from now", or YYYY-MM-DD.</p>
-            <p><strong>property_eq</strong> ops: eq, ne, in, not_in, contains, starts_with, ends_with, lt, lte, gt, gte. Multiple ops on one predicate AND together. Values are stringly-typed (the parser stores everything as strings), so comparisons are string-vs-string.</p>
-            <p><strong>has_tag</strong> matches blocks that live on a page with that slug <em>or</em> blocks that explicitly link to that page with #tag / [[link]].</p>
-            <p>Sort by a property: <code>[{ "field": "properties.priority", "dir": "asc" }]</code>. Blocks without the key sort last in asc, first in desc.</p>
-          </div>
+          <div class="saved-view-help" v-html="cheatsheetHtml"></div>
         </div>
 
         <div v-else class="saved-view-list">
@@ -718,6 +827,7 @@ const SavedViewsPage = {
               <button class="btn" @click="cancelEditing">Cancel</button>
             </div>
             <div v-if="saveError" class="form-error">{{ saveError }}</div>
+            <div class="saved-view-help" v-html="cheatsheetHtml"></div>
           </div>
 
           <div class="saved-view-results">

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
@@ -236,7 +236,10 @@ const SavedViewsPage = {
         slug: "",
         description: "",
         filter: '{\n  "block_type": "todo"\n}',
-        sort: "[]",
+        // Pre-fill with newest-first sort so a freshly-created view
+        // is immediately useful — matches the backend's empty-sort
+        // default and saves the user a copy-paste from the cheatsheet.
+        sort: '[\n  { "field": "created_at", "dir": "desc" }\n]',
       };
     },
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
@@ -301,6 +301,13 @@ const SavedViewsPage = {
 
     async runActive() {
       if (!this.activeView) return;
+      // While editing, "Run" should show results for the draft spec
+      // the user is currently typing — not the spec last persisted.
+      // The draft path goes through the preview endpoint so we don't
+      // have to save first.
+      if (this.editing) {
+        return this._previewEditorDraft();
+      }
       this.running = true;
       this.runError = null;
       try {
@@ -317,6 +324,41 @@ const SavedViewsPage = {
         }
       } catch (err) {
         console.error("runSavedView failed:", err);
+        this.runError = String(err);
+      } finally {
+        this.running = false;
+      }
+    },
+
+    async _previewEditorDraft() {
+      // Validate the editor JSON first so the user gets the same inline
+      // error feedback as Save (rather than a generic API error). When
+      // the draft is invalid we bail without clobbering the previous
+      // run results.
+      const parsed = this._validateEditorJson();
+      if (!parsed) return;
+      this.running = true;
+      this.runError = null;
+      try {
+        const result = await window.apiService.previewSavedView({
+          filter: parsed.filter,
+          sort: parsed.sort,
+        });
+        if (result && result.success) {
+          // Preview response lacks a 'view' field (no view to preview
+          // against); the results UI only needs count / results /
+          // truncated, which preview supplies.
+          this.runResult = result.data;
+        } else {
+          const errs = (result && result.errors) || {};
+          this.runError =
+            (errs.non_field_errors && errs.non_field_errors[0]) ||
+            (errs.filter && errs.filter[0]) ||
+            (errs.sort && errs.sort[0]) ||
+            "Failed to preview view";
+        }
+      } catch (err) {
+        console.error("previewSavedView failed:", err);
         this.runError = String(err);
       } finally {
         this.running = false;
@@ -777,8 +819,8 @@ const SavedViewsPage = {
               <span v-if="activeView.is_system" class="system-pill">system</span>
             </h1>
             <div class="header-actions">
-              <button class="btn" @click="runActive" :disabled="running">
-                {{ running ? "Running…" : "Run" }}
+              <button class="btn" @click="runActive" :disabled="running" :title="editing ? 'Preview the current editor draft (does not save)' : 'Run the saved view'">
+                {{ running ? "Running…" : editing ? "Preview" : "Run" }}
               </button>
               <button class="btn" @click="duplicateActive">Duplicate</button>
               <button class="btn" @click="embedOnPage" title="Embed this view on a page (defaults to today's daily note)">Embed…</button>

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -812,6 +812,13 @@ class ApiService {
     return await this.request(`/knowledge/api/views/run/?${params.toString()}`);
   }
 
+  async previewSavedView({ filter, sort, limit = 100 } = {}) {
+    return await this.request("/knowledge/api/views/preview/", {
+      method: "POST",
+      body: JSON.stringify({ filter, sort: sort || [], limit }),
+    });
+  }
+
   async createSavedView(payload) {
     return await this.request("/knowledge/api/views/create/", {
       method: "POST",

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -168,6 +168,23 @@ class ApiService {
     );
   }
 
+  // Page templates (issue #106). Templates are pages with
+  // page_type="template"; instantiating one duplicates its block tree
+  // into a new regular page via the same /pages/duplicate/ endpoint.
+  async getTemplates() {
+    return await this.request("/knowledge/api/pages/templates/");
+  }
+
+  async duplicatePage(sourcePageUuid, { newTitle, newPageType } = {}) {
+    const body = { source_page_uuid: sourcePageUuid };
+    if (newTitle) body.new_title = newTitle;
+    if (newPageType) body.new_page_type = newPageType;
+    return await this.request("/knowledge/api/pages/duplicate/", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  }
+
   async searchPages(query, limit = 10) {
     return await this.request(
       `/knowledge/api/pages/search/?query=${encodeURIComponent(query)}&limit=${limit}`

--- a/packages/django-app/app/knowledge/test/commands/test_duplicate_page_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_duplicate_page_command.py
@@ -1,0 +1,237 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from knowledge.commands import DuplicatePageCommand
+from knowledge.forms import DuplicatePageForm
+from knowledge.repositories import BlockRepository
+
+from ..helpers import BlockFactory, PageFactory, UserFactory
+
+
+class TestDuplicatePageCommand(TestCase):
+    """End-to-end tests for issue #106 page duplication / templates.
+
+    DuplicatePageCommand powers three flows: plain Duplicate, Save as
+    template, and Use template. These tests pin all three plus the slug
+    uniqueness behavior and tree-structure preservation.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.other_user = UserFactory()
+
+    def _make_page_with_tree(self, **page_kwargs):
+        """Build a page with a small block tree:
+
+        root_a (todo, content "Buy milk")
+          - child_a1 (bullet)
+          - child_a2 (bullet)
+        root_b (heading)
+        """
+        page = PageFactory(user=self.user, **page_kwargs)
+        root_a = BlockFactory(
+            user=self.user,
+            page=page,
+            content="Buy milk",
+            block_type="todo",
+            order=1,
+        )
+        BlockFactory(
+            user=self.user,
+            page=page,
+            parent=root_a,
+            content="Whole milk",
+            order=1,
+        )
+        BlockFactory(
+            user=self.user,
+            page=page,
+            parent=root_a,
+            content="2%",
+            order=2,
+        )
+        BlockFactory(
+            user=self.user,
+            page=page,
+            content="Section heading",
+            block_type="heading",
+            order=2,
+        )
+        return page
+
+    def test_duplicate_creates_copy_suffix_when_no_title_given(self):
+        page = PageFactory(user=self.user, title="My Page", slug="my-page")
+        form = DuplicatePageForm(
+            {"user": self.user.id, "source_page_uuid": str(page.uuid)}
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        clone = DuplicatePageCommand(form).execute()
+
+        self.assertEqual(clone.title, "My Page (copy)")
+        self.assertNotEqual(clone.uuid, page.uuid)
+        self.assertEqual(clone.user, self.user)
+        # Auto-generated slug from "my page (copy)" should slugify cleanly.
+        self.assertTrue(clone.slug.startswith("my-page-copy"))
+
+    def test_duplicate_clones_full_block_tree(self):
+        page = self._make_page_with_tree(title="Workout", slug="workout")
+        form = DuplicatePageForm(
+            {"user": self.user.id, "source_page_uuid": str(page.uuid)}
+        )
+        self.assertTrue(form.is_valid())
+        clone = DuplicatePageCommand(form).execute()
+
+        cloned_blocks = list(BlockRepository.get_page_blocks(clone))
+        self.assertEqual(len(cloned_blocks), 4)
+
+        # Root blocks should have no parent and preserve order.
+        roots = [b for b in cloned_blocks if b.parent_id is None]
+        self.assertEqual(len(roots), 2)
+        roots_by_order = sorted(roots, key=lambda b: b.order)
+        self.assertEqual(roots_by_order[0].content, "Buy milk")
+        self.assertEqual(roots_by_order[0].block_type, "todo")
+        self.assertEqual(roots_by_order[1].block_type, "heading")
+
+        # The "Buy milk" root should have its two children cloned and
+        # parented to the *clone*, not the original.
+        cloned_root_a = roots_by_order[0]
+        children = list(BlockRepository.get_child_blocks(cloned_root_a))
+        self.assertEqual(len(children), 2)
+        self.assertEqual({c.content for c in children}, {"Whole milk", "2%"})
+        for child in children:
+            self.assertEqual(child.parent_id, cloned_root_a.id)
+
+    def test_duplicate_does_not_share_block_uuids(self):
+        page = self._make_page_with_tree(title="Source", slug="source")
+        original_uuids = {str(b.uuid) for b in BlockRepository.get_page_blocks(page)}
+        form = DuplicatePageForm(
+            {"user": self.user.id, "source_page_uuid": str(page.uuid)}
+        )
+        self.assertTrue(form.is_valid())
+        clone = DuplicatePageCommand(form).execute()
+
+        cloned_uuids = {str(b.uuid) for b in BlockRepository.get_page_blocks(clone)}
+        self.assertEqual(len(original_uuids & cloned_uuids), 0)
+
+    def test_save_as_template_sets_page_type_template(self):
+        page = PageFactory(user=self.user, title="Workout Log", slug="workout-log")
+        BlockFactory(user=self.user, page=page, content="warmup")
+        form = DuplicatePageForm(
+            {
+                "user": self.user.id,
+                "source_page_uuid": str(page.uuid),
+                "new_title": "Workout Log Template",
+                "new_page_type": "template",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        clone = DuplicatePageCommand(form).execute()
+
+        self.assertEqual(clone.page_type, "template")
+        self.assertEqual(clone.title, "Workout Log Template")
+        self.assertEqual(BlockRepository.get_page_blocks(clone).count(), 1)
+
+    def test_use_template_defaults_target_to_page(self):
+        # Source is a template; with no override the target should be a
+        # regular page (not another template), since the natural use is
+        # to instantiate it.
+        template = PageFactory(
+            user=self.user,
+            title="Packing List",
+            slug="packing-list-tpl",
+            page_type="template",
+        )
+        BlockFactory(user=self.user, page=template, content="passport")
+        form = DuplicatePageForm(
+            {
+                "user": self.user.id,
+                "source_page_uuid": str(template.uuid),
+                "new_title": "NYC trip",
+            }
+        )
+        self.assertTrue(form.is_valid())
+        clone = DuplicatePageCommand(form).execute()
+
+        self.assertEqual(clone.page_type, "page")
+        self.assertEqual(clone.title, "NYC trip")
+        self.assertEqual(BlockRepository.get_page_blocks(clone).count(), 1)
+
+    def test_duplicate_daily_normalizes_to_page(self):
+        from datetime import date
+
+        daily = PageFactory(
+            user=self.user,
+            title="2026-04-01",
+            slug="2026-04-01",
+            page_type="daily",
+            date=date(2026, 4, 1),
+        )
+        BlockFactory(user=self.user, page=daily, content="standup")
+        form = DuplicatePageForm(
+            {
+                "user": self.user.id,
+                "source_page_uuid": str(daily.uuid),
+                "new_title": "Cloned daily",
+            }
+        )
+        self.assertTrue(form.is_valid())
+        clone = DuplicatePageCommand(form).execute()
+
+        # daily → page so we don't end up with two daily pages on the
+        # same date (which the daily-page lookup wouldn't tolerate).
+        self.assertEqual(clone.page_type, "page")
+
+    def test_duplicate_unique_suffix_when_slug_taken(self):
+        page = PageFactory(user=self.user, title="Notes", slug="notes")
+        # Manually pre-create a conflicting slug so the unique-suffix path runs.
+        PageFactory(user=self.user, title="Notes (copy)", slug="notes-copy")
+
+        form = DuplicatePageForm(
+            {"user": self.user.id, "source_page_uuid": str(page.uuid)}
+        )
+        self.assertTrue(form.is_valid())
+        clone = DuplicatePageCommand(form).execute()
+        self.assertNotIn(clone.slug, {"notes", "notes-copy"})
+
+    def test_duplicate_rejects_other_users_page(self):
+        page = PageFactory(user=self.other_user)
+        form = DuplicatePageForm(
+            {"user": self.user.id, "source_page_uuid": str(page.uuid)}
+        )
+        self.assertTrue(form.is_valid())
+        with self.assertRaises(ValidationError):
+            DuplicatePageCommand(form).execute()
+
+    def test_duplicate_rejects_unknown_uuid(self):
+        import uuid as uuid_module
+
+        form = DuplicatePageForm(
+            {
+                "user": self.user.id,
+                "source_page_uuid": str(uuid_module.uuid4()),
+            }
+        )
+        self.assertTrue(form.is_valid())
+        with self.assertRaises(ValidationError):
+            DuplicatePageCommand(form).execute()
+
+    def test_duplicate_preserves_tag_pages_m2m(self):
+        # Tag pages are how blocks reference other pages via #hashtag —
+        # cloning a template should keep those references intact.
+        tag_page = PageFactory(
+            user=self.user, title="#fitness", slug="fitness", page_type="page"
+        )
+        page = PageFactory(user=self.user, title="Workout", slug="workout-m2m")
+        block = BlockFactory(user=self.user, page=page, content="run #fitness")
+        block.pages.add(tag_page)
+
+        form = DuplicatePageForm(
+            {"user": self.user.id, "source_page_uuid": str(page.uuid)}
+        )
+        self.assertTrue(form.is_valid())
+        clone = DuplicatePageCommand(form).execute()
+
+        cloned_block = BlockRepository.get_page_blocks(clone).first()
+        self.assertIsNotNone(cloned_block)
+        self.assertIn(tag_page, list(cloned_block.pages.all()))

--- a/packages/django-app/app/knowledge/test/commands/test_duplicate_page_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_duplicate_page_command.py
@@ -3,7 +3,8 @@ from django.test import TestCase
 
 from knowledge.commands import DuplicatePageCommand
 from knowledge.forms import DuplicatePageForm
-from knowledge.repositories import BlockRepository
+from knowledge.models import PageEmbeddedView, SavedView
+from knowledge.repositories import BlockRepository, PageEmbeddedViewRepository
 
 from ..helpers import BlockFactory, PageFactory, UserFactory
 
@@ -215,6 +216,72 @@ class TestDuplicatePageCommand(TestCase):
         self.assertTrue(form.is_valid())
         with self.assertRaises(ValidationError):
             DuplicatePageCommand(form).execute()
+
+    def test_duplicate_clones_embedded_views(self):
+        # Templates with embedded saved views are the key use case: a
+        # "morning routine" template that includes an "open todos"
+        # embed should carry both the blocks AND the embed forward.
+        template = PageFactory(
+            user=self.user,
+            title="Morning routine",
+            slug="morning-routine-tpl",
+            page_type="template",
+        )
+        BlockFactory(user=self.user, page=template, content="meditate")
+        view = SavedView.objects.create(
+            user=self.user, name="Open todos", slug="open-todos-tpl", filter={}
+        )
+        other_view = SavedView.objects.create(
+            user=self.user, name="Due today", slug="due-today-tpl", filter={}
+        )
+        PageEmbeddedView.objects.create(
+            user=self.user, page=template, saved_view=view, order=0
+        )
+        PageEmbeddedView.objects.create(
+            user=self.user,
+            page=template,
+            saved_view=other_view,
+            order=1,
+            collapsed=True,
+        )
+
+        form = DuplicatePageForm(
+            {
+                "user": self.user.id,
+                "source_page_uuid": str(template.uuid),
+                "new_title": "Today's routine",
+            }
+        )
+        self.assertTrue(form.is_valid())
+        clone = DuplicatePageCommand(form).execute()
+
+        cloned_embeds = list(PageEmbeddedViewRepository.list_for_page(clone))
+        self.assertEqual(len(cloned_embeds), 2)
+        # Saved-view refs and per-embed flags (order, collapsed) survive
+        # the clone; UUIDs are fresh so the new page owns its own rows.
+        by_view = {e.saved_view_id: e for e in cloned_embeds}
+        self.assertIn(view.id, by_view)
+        self.assertIn(other_view.id, by_view)
+        self.assertEqual(by_view[view.id].order, 0)
+        self.assertEqual(by_view[view.id].collapsed, False)
+        self.assertEqual(by_view[other_view.id].order, 1)
+        self.assertEqual(by_view[other_view.id].collapsed, True)
+        for e in cloned_embeds:
+            self.assertEqual(e.user, self.user)
+            self.assertEqual(e.page, clone)
+
+    def test_duplicate_handles_page_without_embeds(self):
+        # Sanity check that the embed-clone path is a no-op when the
+        # source has no embeds (every existing template predates this
+        # feature).
+        page = PageFactory(user=self.user, title="Empty", slug="empty-tpl")
+        BlockFactory(user=self.user, page=page, content="x")
+        form = DuplicatePageForm(
+            {"user": self.user.id, "source_page_uuid": str(page.uuid)}
+        )
+        self.assertTrue(form.is_valid())
+        clone = DuplicatePageCommand(form).execute()
+        self.assertEqual(PageEmbeddedViewRepository.list_for_page(clone).count(), 0)
 
     def test_duplicate_preserves_tag_pages_m2m(self):
         # Tag pages are how blocks reference other pages via #hashtag —

--- a/packages/django-app/app/knowledge/test/commands/test_list_templates_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_list_templates_command.py
@@ -1,0 +1,43 @@
+from django.test import TestCase
+
+from knowledge.commands import ListTemplatesCommand
+from knowledge.forms import ListTemplatesForm
+
+from ..helpers import PageFactory, UserFactory
+
+
+class TestListTemplatesCommand(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.other_user = UserFactory()
+
+    def test_returns_only_user_templates_alphabetical(self):
+        PageFactory(
+            user=self.user, title="Workout", slug="workout-tpl", page_type="template"
+        )
+        PageFactory(
+            user=self.user,
+            title="Packing list",
+            slug="packing-tpl",
+            page_type="template",
+        )
+        PageFactory(user=self.user, title="Notes", slug="notes")
+        # Other user's template should not leak through.
+        PageFactory(
+            user=self.other_user,
+            title="Aaa",
+            slug="aaa-tpl",
+            page_type="template",
+        )
+
+        form = ListTemplatesForm({"user": self.user.id})
+        self.assertTrue(form.is_valid(), form.errors)
+        result = ListTemplatesCommand(form).execute()
+        titles = [p.title for p in result]
+        self.assertEqual(titles, ["Packing list", "Workout"])
+
+    def test_returns_empty_list_when_no_templates(self):
+        form = ListTemplatesForm({"user": self.user.id})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(ListTemplatesCommand(form).execute(), [])

--- a/packages/django-app/app/knowledge/test/commands/test_saved_view_commands.py
+++ b/packages/django-app/app/knowledge/test/commands/test_saved_view_commands.py
@@ -19,6 +19,7 @@ from knowledge.commands import (
     DuplicateSavedViewCommand,
     GetSavedViewCommand,
     ListSavedViewsCommand,
+    PreviewSavedViewCommand,
     RunSavedViewCommand,
     UpdateSavedViewCommand,
 )
@@ -28,6 +29,7 @@ from knowledge.forms import (
     DuplicateSavedViewForm,
     GetSavedViewForm,
     ListSavedViewsForm,
+    PreviewSavedViewForm,
     RunSavedViewForm,
     UpdateSavedViewForm,
 )
@@ -273,3 +275,73 @@ class ListGetSavedViewTests(_SavedViewTestBase):
     def test_get_requires_uuid_or_slug(self):
         form = GetSavedViewForm({"user": self.user.id})
         self.assertFalse(form.is_valid())
+
+
+class PreviewSavedViewTests(_SavedViewTestBase):
+    """The editor's Run button uses preview while editing so the user
+    sees results for what they're typing, not the persisted spec.
+    These pin: (a) preview runs ad-hoc filter+sort without touching the
+    DB, (b) it scopes to the user, (c) bad specs surface as
+    ValidationError just like run does."""
+
+    def test_preview_runs_ad_hoc_filter(self):
+        match = BlockFactory(
+            user=self.user,
+            page=self.page,
+            block_type="todo",
+            scheduled_for=date(2026, 4, 23),
+        )
+        BlockFactory(
+            user=self.user,
+            page=self.page,
+            block_type="done",
+            scheduled_for=date(2026, 4, 23),
+            completed_at=_utc_noon(self.today),
+        )
+        form = PreviewSavedViewForm(
+            {
+                "user": self.user.id,
+                "filter": {"block_type": "todo"},
+                "sort": [{"field": "created_at", "dir": "desc"}],
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        result = PreviewSavedViewCommand(form).execute()
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["results"][0]["uuid"], str(match.uuid))
+        self.assertFalse(result["truncated"])
+
+    def test_preview_does_not_persist_anything(self):
+        before_count = SavedView.objects.count()
+        form = PreviewSavedViewForm(
+            {
+                "user": self.user.id,
+                "filter": {"block_type": "todo"},
+            }
+        )
+        self.assertTrue(form.is_valid())
+        PreviewSavedViewCommand(form).execute()
+        self.assertEqual(SavedView.objects.count(), before_count)
+
+    def test_preview_user_scoped(self):
+        other_page = PageFactory(user=UserFactory(), page_type="page", title="OP")
+        BlockFactory(
+            user=other_page.user,
+            page=other_page,
+            block_type="todo",
+        )
+        BlockFactory(user=self.user, page=self.page, block_type="todo")
+        form = PreviewSavedViewForm(
+            {"user": self.user.id, "filter": {"block_type": "todo"}}
+        )
+        self.assertTrue(form.is_valid())
+        result = PreviewSavedViewCommand(form).execute()
+        self.assertEqual(result["count"], 1)
+
+    def test_preview_invalid_spec_raises(self):
+        form = PreviewSavedViewForm(
+            {"user": self.user.id, "filter": {"never_heard_of_it": 1}}
+        )
+        self.assertTrue(form.is_valid())
+        with self.assertRaises(ValidationError):
+            PreviewSavedViewCommand(form).execute()

--- a/packages/django-app/app/knowledge/test/services/test_query_engine.py
+++ b/packages/django-app/app/knowledge/test/services/test_query_engine.py
@@ -664,6 +664,21 @@ class SortTests(_EngineTestBase):
                 {}, user=self.user, sort=[{"field": "properties.", "dir": "asc"}]
             )
 
+    def test_default_sort_is_newest_first(self):
+        """When the spec omits sort, the repository falls back to
+        ``-created_at`` (newest first). This pins the contract so the
+        default doesn't drift back to ``scheduled_for`` (which felt
+        random for tag-only views that have no dates)."""
+        import time
+
+        older = BlockFactory(user=self.user, page=self.page, content="older")
+        time.sleep(0.01)  # auto_now_add timestamps are precise enough that
+        # a tight loop can land two blocks in the same microsecond on fast
+        # boxes; a 10ms sleep keeps the order assertion deterministic.
+        newer = BlockFactory(user=self.user, page=self.page, content="newer")
+        out = self.run_query({})  # no sort
+        self.assertEqual([b.id for b in out], [newer.id, older.id])
+
 
 class TopLevelTests(_EngineTestBase):
     def test_empty_filter_matches_all(self):

--- a/packages/django-app/app/knowledge/urls.py
+++ b/packages/django-app/app/knowledge/urls.py
@@ -87,6 +87,7 @@ urlpatterns = [
     path("api/views/", views.list_saved_views, name="list_saved_views"),
     path("api/views/get/", views.get_saved_view, name="get_saved_view"),
     path("api/views/run/", views.run_saved_view, name="run_saved_view"),
+    path("api/views/preview/", views.preview_saved_view, name="preview_saved_view"),
     path("api/views/create/", views.create_saved_view, name="create_saved_view"),
     path("api/views/update/", views.update_saved_view, name="update_saved_view"),
     path("api/views/delete/", views.delete_saved_view, name="delete_saved_view"),

--- a/packages/django-app/app/knowledge/urls.py
+++ b/packages/django-app/app/knowledge/urls.py
@@ -73,6 +73,11 @@ urlpatterns = [
     path("api/pages/delete/", views.delete_page, name="delete_page"),
     path("api/pages/list/", views.get_pages, name="list_pages"),
     path("api/pages/search/", views.search_pages, name="search_pages"),
+    # Page templates (issue #106) — templates live as Pages with
+    # page_type='template'; ``duplicate`` powers both "Save as template"
+    # and "Use template" by varying the target page_type.
+    path("api/pages/duplicate/", views.duplicate_page, name="duplicate_page"),
+    path("api/pages/templates/", views.list_templates, name="list_templates"),
     path("api/blocks/search/", views.search_blocks, name="search_blocks"),
     path("api/page/", views.get_page_with_blocks, name="get_page_with_blocks"),
     path("api/historical/", views.get_historical_data, name="get_historical_data"),

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -35,6 +35,7 @@ from knowledge.commands import (
     ListTemplatesCommand,
     MoveBlockToDailyCommand,
     MoveUndoneTodosCommand,
+    PreviewSavedViewCommand,
     ReorderBlocksCommand,
     ReorderFavoritedPagesCommand,
     ReorderPageEmbeddedViewsCommand,
@@ -82,6 +83,7 @@ from knowledge.forms import (
     ListTemplatesForm,
     MoveBlockToDailyForm,
     MoveUndoneTodosForm,
+    PreviewSavedViewForm,
     ReorderBlocksForm,
     ReorderFavoritedPagesForm,
     ReorderPageEmbeddedViewsForm,
@@ -1581,6 +1583,26 @@ def run_saved_view(request):
         return _saved_view_response(False, errors=form.errors)
     try:
         result = RunSavedViewCommand(form).execute()
+    except ValidationError as exc:
+        return _saved_view_response(False, errors={"non_field_errors": [str(exc)]})
+    return _saved_view_response(True, data=result)
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def preview_saved_view(request):
+    """Run an ad-hoc filter + sort spec without persisting (issue #106
+    follow-up). The editor's Run button uses this so a draft can be
+    previewed before save — otherwise the Run button would silently
+    execute the old persisted spec while the user stared at fresh edits.
+    """
+    data = request.data.copy()
+    data["user"] = request.user.id
+    form = PreviewSavedViewForm(data)
+    if not form.is_valid():
+        return _saved_view_response(False, errors=form.errors)
+    try:
+        result = PreviewSavedViewCommand(form).execute()
     except ValidationError as exc:
         return _saved_view_response(False, errors={"non_field_errors": [str(exc)]})
     return _saved_view_response(True, data=result)

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -22,6 +22,7 @@ from knowledge.commands import (
     DeletePageCommand,
     DeletePageEmbeddedViewCommand,
     DeleteSavedViewCommand,
+    DuplicatePageCommand,
     DuplicateSavedViewCommand,
     GetFavoritedPagesCommand,
     GetGraphDataCommand,
@@ -31,6 +32,7 @@ from knowledge.commands import (
     GetTagContentCommand,
     GetUserPagesCommand,
     ListSavedViewsCommand,
+    ListTemplatesCommand,
     MoveBlockToDailyCommand,
     MoveUndoneTodosCommand,
     ReorderBlocksCommand,
@@ -67,6 +69,7 @@ from knowledge.forms import (
     DeletePageEmbeddedViewForm,
     DeletePageForm,
     DeleteSavedViewForm,
+    DuplicatePageForm,
     DuplicateSavedViewForm,
     GetFavoritedPagesForm,
     GetGraphDataForm,
@@ -76,6 +79,7 @@ from knowledge.forms import (
     GetTagContentForm,
     GetUserPagesForm,
     ListSavedViewsForm,
+    ListTemplatesForm,
     MoveBlockToDailyForm,
     MoveUndoneTodosForm,
     ReorderBlocksForm,
@@ -1645,6 +1649,72 @@ def duplicate_saved_view(request):
         return _saved_view_response(False, errors={"non_field_errors": [str(exc)]})
     return _saved_view_response(
         True, data=view.to_dict(), http_status=status.HTTP_201_CREATED
+    )
+
+
+# ---------------------------------------------------------------------------
+# Page templates (issue #106). A template is just a Page with
+# page_type='template'; instantiating one duplicates its block tree into
+# a new regular page. "Save as template" / "Duplicate page" share the
+# same DuplicatePageCommand — only the target page_type differs.
+# ---------------------------------------------------------------------------
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def duplicate_page(request):
+    """Clone a page into a new page (issue #106).
+
+    Body: {source_page_uuid, new_title?, new_page_type?}
+      - omit new_page_type to duplicate as the same type (or 'page' when
+        the source is a daily/template; see DuplicatePageCommand).
+      - pass new_page_type='template' to "save as template".
+      - pass new_page_type='page' on a template source to "use template".
+    """
+    data = request.data.copy()
+    data["user"] = request.user.id
+    form = DuplicatePageForm(data)
+    if not form.is_valid():
+        response: PageResponse = {
+            "success": False,
+            "data": None,
+            "errors": form.errors,
+        }
+        return Response(response, status=status.HTTP_400_BAD_REQUEST)
+    try:
+        new_page = DuplicatePageCommand(form).execute()
+    except ValidationError as exc:
+        response: PageResponse = {
+            "success": False,
+            "data": None,
+            "errors": {"non_field_errors": [str(exc)]},
+        }
+        return Response(response, status=status.HTTP_400_BAD_REQUEST)
+    response: PageResponse = {
+        "success": True,
+        "data": new_page.to_dict(),
+        "errors": None,
+    }
+    return Response(response, status=status.HTTP_201_CREATED)
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def list_templates(request):
+    """List the user's template pages, alphabetical (issue #106)."""
+    form = ListTemplatesForm({"user": request.user.id})
+    if not form.is_valid():
+        return Response(
+            {"success": False, "data": None, "errors": form.errors},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    templates = ListTemplatesCommand(form).execute()
+    return Response(
+        {
+            "success": True,
+            "data": {"templates": [p.to_dict() for p in templates]},
+            "errors": None,
+        }
     )
 
 


### PR DESCRIPTION
Closes #106

## Summary

Implements a complete page duplication and templating system, allowing users to:
- Duplicate pages with their full block tree
- Save pages as reusable templates
- Instantiate new pages from templates
- Manage templates in a dedicated sidebar section

## Key Changes

**Backend**
- Added `DuplicatePageCommand` to clone pages with full block tree preservation, supporting three flows: plain duplicate, save-as-template, and use-template
- Added `ListTemplatesCommand` to fetch user's template pages alphabetically
- Added `clone_block_tree_to_page()` to `BlockRepository` for deep-copying block hierarchies with fresh UUIDs while preserving structure, content, and tag relationships
- Added `get_user_templates()` to `PageRepository` for querying template pages
- Added `DuplicatePageForm` and `ListTemplatesForm` for input validation
- Added `/api/pages/duplicate/` and `/api/pages/templates/` endpoints
- Slug collision handling with unique suffixes (`-copy`, `-copy-2`, etc.)
- Automatic page_type normalization (daily/template → page when duplicating)

**Frontend**
- Added "Duplicate page" action in page menu
- Added "Save as template" action in page menu
- Added "Use template" button on template pages (both inline and in menu)
- Added collapsible Templates section in left sidebar with:
  - List of user's templates alphabetically
  - "+" button to instantiate each template
  - Edit link to open template for modification
  - Persistence of expanded/collapsed state
- Added `duplicatePage()`, `saveAsTemplate()`, and `useThisTemplate()` methods to Page component
- Added `useTemplate()` method to main app component
- Added `duplicatePage()` and `getTemplates()` to API service
- Added template badge on template pages
- Event-driven template list refresh via `templates:changed` custom event

**Tests**
- Comprehensive test suite for `DuplicatePageCommand` covering:
  - Copy suffix generation when no title given
  - Full block tree cloning with parent/child preservation
  - UUID uniqueness across clones
  - Save-as-template flow
  - Use-template flow with page_type normalization
  - Daily page normalization
  - Slug uniqueness with collision handling
  - Permission checks (rejects other users' pages)
  - Tag page M2M preservation
- Test suite for `ListTemplatesCommand` covering user isolation and alphabetical ordering

**Styling**
- Added CSS for templates section with collapsible header and count badge
- Added CSS for template rows with "use" button and edit link
- Added CSS for inline "use template" button on template pages
- Hover states for template edit links

https://claude.ai/code/session_01MX7UPbjm9eZgRGFD98e88h