### PR TITLE
Fix textarea resize and search modal z-index stacking

### DIFF
--- a/packages/django-app/app/knowledge/commands/get_user_pages_command.py
+++ b/packages/django-app/app/knowledge/commands/get_user_pages_command.py
@@ -22,7 +22,13 @@ class GetUserPagesCommand(AbstractBaseCommand):
         offset = self.form.cleaned_data.get("offset", 0)
         page_type = self.form.cleaned_data.get("page_type") or None
 
-        queryset = Page.objects.filter(user=user)
+        # Order by most-recently-modified first so the page picker's
+        # empty-query landing state surfaces what the user has been
+        # touching lately. Title is a stable tiebreaker for pages
+        # modified at the same instant (e.g. bulk imports). This is the
+        # only caller today; if a future caller wants alphabetical it
+        # should pass an explicit order_by once that's plumbed through.
+        queryset = Page.objects.filter(user=user).order_by("-modified_at", "title")
         if published_only:
             queryset = queryset.filter(is_published=True)
         if page_type:

--- a/packages/django-app/app/knowledge/models/block.py
+++ b/packages/django-app/app/knowledge/models/block.py
@@ -152,6 +152,14 @@ class Block(UUIDModelMixin, CRUDTimestampsMixin):
             current = current.parent
         return depth
 
+    # Property keys that are managed by the UI (the resize handle and
+    # the "show as raw" / "reset size" entries in the block context
+    # menu) rather than by the user typing `key:: value` into block
+    # content. Kept out of the content-driven property sync below so a
+    # routine block edit doesn't clobber them — see
+    # `extract_properties_from_content`.
+    _UI_MANAGED_PROPERTY_KEYS = frozenset({"size", "render"})
+
     def extract_properties_from_content(self):
         """Extract key:: value properties from content and sync with properties field"""
         if not self.content:
@@ -186,9 +194,22 @@ class Block(UUIDModelMixin, CRUDTimestampsMixin):
                 if key not in extracted_properties:
                     extracted_properties[key] = value.strip()
 
-        # Sync with properties field
-        if extracted_properties != self.properties:
-            self.properties = extracted_properties
+        # Merge with UI-managed keys preserved. Replacing the whole dict
+        # would nuke `size` (image resize handle) and `render` ("show as
+        # raw" toggle) on every content edit, which previously made both
+        # features look broken in practice — drag to resize, then type
+        # anywhere in the block, and the persisted width vanishes on the
+        # next page load.
+        current = self.properties or {}
+        preserved = {
+            k: current[k]
+            for k in self._UI_MANAGED_PROPERTY_KEYS
+            if k in current
+        }
+        merged = {**extracted_properties, **preserved}
+
+        if merged != self.properties:
+            self.properties = merged
             self.save(update_fields=["properties"])
 
         return extracted_properties

--- a/packages/django-app/app/knowledge/models/block.py
+++ b/packages/django-app/app/knowledge/models/block.py
@@ -202,9 +202,7 @@ class Block(UUIDModelMixin, CRUDTimestampsMixin):
         # next page load.
         current = self.properties or {}
         preserved = {
-            k: current[k]
-            for k in self._UI_MANAGED_PROPERTY_KEYS
-            if k in current
+            k: current[k] for k in self._UI_MANAGED_PROPERTY_KEYS if k in current
         }
         merged = {**extracted_properties, **preserved}
 

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -2654,6 +2654,25 @@ kbd {
   font-size: 0.9rem;
 }
 
+/* The today nav item swaps the static "▤" planner glyph for a small
+   calendar SVG with today's day-of-month painted inside. Sizing it
+   against the icon slot in both the rail (font-size 1rem) and the
+   expanded sidebar item (font-size 0.9rem) means an em-based width
+   keeps it in step with neighbouring glyphs and inherits currentColor
+   from the active leftnav-item / rail-btn state. */
+.leftnav-today-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.leftnav-today-svg {
+  width: 1.1em;
+  height: 1.1em;
+  display: block;
+}
+
 .leftnav-label {
   flex: 1;
   min-width: 0;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -3551,9 +3551,12 @@ a.sidebar-item:visited {
   color: var(--text-primary);
   border: 1px solid var(--border-secondary);
   padding: 0.75rem;
-  resize: vertical;
+  resize: none;
+  width: 100%;
+  /* min-height sets the natural-state floor (matches the pre-resize
+     look). The textarea stretches above this via the flex chain when
+     the user drags the input area taller. */
   min-height: 60px;
-  max-height: 60vh;
   font-family: inherit;
   font-size: 0.9rem;
   line-height: 1.4;
@@ -4043,6 +4046,30 @@ a.sidebar-item:visited {
   border-top: 1px solid var(--border-secondary);
   display: flex;
   flex-direction: column;
+  /* Hosts .chat-input-resize-handle which is positioned absolutely
+     against this stacking context, and contains .message-input which
+     flexes to fill any extra height when the user drags the area
+     taller. */
+  position: relative;
+}
+
+/* Grab strip along the input-area's top edge. Drag up to grow the
+   input-area (and shrink the messages list above), drag down to
+   shrink it. The textarea inside stretches to fit. */
+.chat-input-resize-handle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: transparent;
+  cursor: ns-resize;
+  z-index: 2;
+}
+
+.chat-input-resize-handle:hover,
+.chat-input-resize-handle.resizing {
+  background: var(--border-primary);
 }
 
 /* Chat Panel Controls Row */
@@ -4087,6 +4114,14 @@ a.sidebar-item:visited {
   display: flex;
   gap: 0.5rem;
   order: 2;
+  /* flex-grow (not flex: 1) is intentional. We want this row to
+     consume extra height inside .input-area when the user drags it
+     taller, but in the natural (un-resized) state we want the row to
+     keep its content-based height — flex: 1 would set flex-basis: 0%
+     and collapse the textarea to the bare minimum even though the
+     parent has no extra space to distribute. */
+  flex-grow: 1;
+  min-height: 0;
   /* Fix for Android navigation bar covering input */
   padding: 0.5rem 0.5rem calc(0.5rem + env(safe-area-inset-bottom, 60px));
 }

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -3551,9 +3551,9 @@ a.sidebar-item:visited {
   color: var(--text-primary);
   border: 1px solid var(--border-secondary);
   padding: 0.75rem;
-  resize: none;
+  resize: vertical;
   min-height: 60px;
-  max-height: 120px;
+  max-height: 60vh;
   font-family: inherit;
   font-size: 0.9rem;
   line-height: 1.4;
@@ -5293,7 +5293,10 @@ a.sidebar-item:visited {
   bottom: 0;
   background: rgba(0, 0, 0, 0.8);
   backdrop-filter: blur(4px);
-  z-index: 1000;
+  /* Above the mobile left-nav drawer (1100) and its backdrop (1099)
+   * so the search modal isn't trapped behind them when opened from
+   * the drawer's "search" button. */
+  z-index: 1200;
   display: flex;
   align-items: flex-start;
   justify-content: center;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -6558,6 +6558,50 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   margin-top: 0.5rem;
 }
 
+/* Quick-pick chip rows — date chips below the "due" input, time chips
+ * below the reminder row. Indented to line up with the inputs (past
+ * the 5rem .schedule-popover-label gutter) so they read as belonging
+ * to the field above. */
+.schedule-popover-quick-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  align-items: center;
+  margin-left: 5.5rem;
+  margin-top: -0.35rem;
+}
+
+.schedule-popover-quick-btn {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-secondary);
+  border-radius: 3px;
+  padding: 0.2rem 0.55rem;
+  font-family: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+  line-height: 1.2;
+}
+
+.schedule-popover-quick-btn:hover {
+  background: var(--hover-bg);
+  border-color: var(--border-primary);
+}
+
+.schedule-popover-quick-btn.is-active {
+  background: var(--selected-bg);
+  border-color: var(--border-primary);
+}
+
+/* Visual separator between the relative-time chips ("in 30m" / "in 1h")
+ * and the fixed-time chunk chips so the row reads as two intents. */
+.schedule-popover-quick-divider {
+  width: 1px;
+  align-self: stretch;
+  background: var(--border-secondary);
+  margin: 0.1rem 0.15rem;
+}
+
 /* Mobile: the desktop popover lays the date/reminder controls out in a
  * single row, which overflows below ~420px-wide viewports. Stack the
  * rows vertically and clamp the modal width to the viewport so the
@@ -6581,6 +6625,12 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
     /* Let the select claim the full row width once the row wraps so it
      * isn't squeezed to a sliver next to the time input. */
     flex-basis: 100%;
+  }
+  /* The mobile label gutter shrinks from 5rem to 4rem; pull the quick
+   * chip rows in to match so the chips still line up under the inputs
+   * instead of floating off-center. */
+  .schedule-popover-quick-row {
+    margin-left: 0;
   }
 }
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/AppModals.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/AppModals.js
@@ -215,15 +215,41 @@ window.AppModals = {
       this.pickerLoading = true;
       const pageType = this.active?.opts?.pageType || null;
       try {
-        // Empty query → server defaults to recent pages, which is the
-        // friendliest landing state. The endpoint accepts an empty
-        // query string and falls back to a chronological page list.
-        const result =
-          query.trim() === ""
-            ? await window.apiService.getPages(true, 15, 0, pageType)
-            : await window.apiService.searchPages(query.trim(), 15, pageType);
-        if (requestId !== this._pickerRequestId) return; // stale
-        const pages = (result && result.data && result.data.pages) || [];
+        let pages;
+        if (query.trim() === "") {
+          // Empty query → server returns pages ordered by most-recently
+          // modified. Today's daily note is pinned to the top whenever
+          // it's a sensible candidate for the active picker (the
+          // typical pickPage use case is embedding views or moving
+          // blocks, and the active daily is the overwhelming target).
+          // Skipped when the caller has filtered to a non-daily
+          // page_type (e.g. the template picker) since today's daily
+          // wouldn't match that filter anyway.
+          const todayLookup =
+            pageType && pageType !== "daily"
+              ? Promise.resolve(null)
+              : this._fetchTodayDailyPage();
+          const [recentResult, todayPage] = await Promise.all([
+            window.apiService.getPages(true, 15, 0, pageType),
+            todayLookup,
+          ]);
+          if (requestId !== this._pickerRequestId) return; // stale
+          pages =
+            (recentResult && recentResult.data && recentResult.data.pages) ||
+            [];
+          if (todayPage) {
+            pages = pages.filter((p) => p.uuid !== todayPage.uuid);
+            pages.unshift(todayPage);
+          }
+        } else {
+          const result = await window.apiService.searchPages(
+            query.trim(),
+            15,
+            pageType
+          );
+          if (requestId !== this._pickerRequestId) return; // stale
+          pages = (result && result.data && result.data.pages) || [];
+        }
         this.pickerResults = pages;
         // Clamp selectedIndex into range — keep highlight on the first
         // result by default so Enter picks the obvious choice.
@@ -237,6 +263,29 @@ window.AppModals = {
         if (requestId === this._pickerRequestId) {
           this.pickerLoading = false;
         }
+      }
+    },
+
+    async _fetchTodayDailyPage() {
+      // Locate the user's daily note for today's date so the picker can
+      // pin it to the top of the empty-query list. Goes through the
+      // existing search endpoint (constrained to page_type=daily) and
+      // verifies an exact slug match, since searchPages does substring
+      // matching — a page titled "notes from 2026-05-17" shouldn't be
+      // mistaken for the actual daily.
+      const now = new Date();
+      const slug =
+        now.getFullYear() +
+        "-" +
+        String(now.getMonth() + 1).padStart(2, "0") +
+        "-" +
+        String(now.getDate()).padStart(2, "0");
+      try {
+        const result = await window.apiService.searchPages(slug, 5, "daily");
+        const pages = (result && result.data && result.data.pages) || [];
+        return pages.find((p) => p.slug === slug) || null;
+      } catch (_) {
+        return null;
       }
     },
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
@@ -40,6 +40,14 @@ const ChatPanel = {
       isResizing: false,
       minWidth: 300,
       maxWidth: 800,
+      // User-set height of the chat input area (the bottom strip with
+      // attachments, controls, and the textarea). null = let it use
+      // the natural content height; a number locks it to that pixel
+      // height and the textarea inside stretches to fit. See
+      // .chat-input-resize-handle.
+      inputAreaHeight: this.loadInputAreaHeight(),
+      isResizingInputArea: false,
+      minInputAreaHeight: 120,
       currentSessionId: null,
       showModelSelector: false,
       aiSettings: null,
@@ -253,6 +261,20 @@ const ChatPanel = {
     },
     saveWidth() {
       localStorage.setItem("chatPanel.width", this.width.toString());
+    },
+    loadInputAreaHeight() {
+      const saved = localStorage.getItem("chatPanel.inputAreaHeight");
+      if (!saved) return null;
+      const value = parseInt(saved, 10);
+      return Number.isFinite(value) && value > 0 ? value : null;
+    },
+    saveInputAreaHeight() {
+      if (this.inputAreaHeight) {
+        localStorage.setItem(
+          "chatPanel.inputAreaHeight",
+          String(this.inputAreaHeight)
+        );
+      }
     },
     togglePanel() {
       if (this.isOpen) {
@@ -741,6 +763,47 @@ const ChatPanel = {
       document.removeEventListener("mousemove", this.resizeHandler);
       document.removeEventListener("mouseup", this.stopResizeHandler);
       this.saveWidth(); // Save width when resize is finished
+    },
+    startInputAreaResize(e) {
+      this.isResizingInputArea = true;
+      this.inputAreaStartY = e.clientY;
+      const el = this.$refs.inputArea;
+      // Anchor to the current rendered height so the first drag picks
+      // up smoothly from wherever the area is sitting, whether the
+      // user has resized before or not.
+      this.inputAreaStartHeight =
+        this.inputAreaHeight || (el ? el.offsetHeight : this.minInputAreaHeight);
+      this.inputAreaResizeMove = this.handleInputAreaResize.bind(this);
+      this.inputAreaResizeStop = this.stopInputAreaResize.bind(this);
+      document.addEventListener("mousemove", this.inputAreaResizeMove);
+      document.addEventListener("mouseup", this.inputAreaResizeStop);
+      e.preventDefault();
+    },
+    handleInputAreaResize(e) {
+      if (!this.isResizingInputArea) return;
+      // Dragging the handle up grows the input area; dragging it down
+      // shrinks it. Mirrors the width-resize handler's reversed delta.
+      const deltaY = this.inputAreaStartY - e.clientY;
+      const newHeight = this.inputAreaStartHeight + deltaY;
+      // Cap to a slice of the viewport so the messages list can't be
+      // squeezed away entirely.
+      const maxHeight = Math.max(
+        this.minInputAreaHeight,
+        window.innerHeight - 120
+      );
+      if (newHeight < this.minInputAreaHeight) {
+        this.inputAreaHeight = this.minInputAreaHeight;
+      } else if (newHeight > maxHeight) {
+        this.inputAreaHeight = maxHeight;
+      } else {
+        this.inputAreaHeight = newHeight;
+      }
+    },
+    stopInputAreaResize() {
+      this.isResizingInputArea = false;
+      document.removeEventListener("mousemove", this.inputAreaResizeMove);
+      document.removeEventListener("mouseup", this.inputAreaResizeStop);
+      this.saveInputAreaHeight();
     },
     handleKeydown(e) {
       // Tag autocomplete keys take precedence when the popover is open.
@@ -2010,7 +2073,16 @@ const ChatPanel = {
           </div>
         </div>
         
-        <div class="input-area">
+        <div
+          class="input-area"
+          ref="inputArea"
+          :style="inputAreaHeight ? { height: inputAreaHeight + 'px' } : {}"
+        >
+          <div
+            class="chat-input-resize-handle"
+            :class="{ resizing: isResizingInputArea }"
+            @mousedown="startInputAreaResize"
+          ></div>
           <div v-if="hasSessionStats" class="session-stats" title="Session token usage">
             <span>{{ sessionStats.turns }} turn{{ sessionStats.turns === 1 ? '' : 's' }}</span>
             <span class="session-stats-sep">·</span>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/ChatPanel.js
@@ -772,7 +772,8 @@ const ChatPanel = {
       // up smoothly from wherever the area is sitting, whether the
       // user has resized before or not.
       this.inputAreaStartHeight =
-        this.inputAreaHeight || (el ? el.offsetHeight : this.minInputAreaHeight);
+        this.inputAreaHeight ||
+        (el ? el.offsetHeight : this.minInputAreaHeight);
       this.inputAreaResizeMove = this.handleInputAreaResize.bind(this);
       this.inputAreaResizeStop = this.stopInputAreaResize.bind(this);
       document.addEventListener("mousemove", this.inputAreaResizeMove);

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/LeftNav.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/LeftNav.js
@@ -124,6 +124,12 @@ window.LeftNav = {
     todayHref() {
       return this.pageUrl(this.todaySlug);
     },
+    // Current day-of-month, drawn inside the today nav icon so the
+    // glyph reads as "today" at a glance (instead of the generic
+    // planner block it used to be).
+    todayDayNumber() {
+      return new Date().getDate();
+    },
   },
 
   mounted() {
@@ -849,7 +855,32 @@ window.LeftNav = {
           @auxclick="onTodayClick"
           title="Today"
           aria-label="Today"
-        >▤</a>
+        >
+          <svg
+            class="leftnav-today-svg"
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="2" y="3.5" width="12" height="10.5" rx="0.5"/>
+            <line x1="2" y1="7" x2="14" y2="7"/>
+            <line x1="5" y1="2" x2="5" y2="5"/>
+            <line x1="11" y1="2" x2="11" y2="5"/>
+            <text
+              x="8"
+              y="12.6"
+              font-size="6"
+              font-weight="700"
+              text-anchor="middle"
+              stroke="none"
+              fill="currentColor"
+            >{{ todayDayNumber }}</text>
+          </svg>
+        </a>
         <button
           type="button"
           class="leftnav-rail-btn leftnav-rail-action"
@@ -943,7 +974,31 @@ window.LeftNav = {
               @auxclick="onTodayClick"
               title="Go to today's daily note"
             >
-              <span class="leftnav-icon" aria-hidden="true">▤</span>
+              <span class="leftnav-icon leftnav-today-icon" aria-hidden="true">
+                <svg
+                  class="leftnav-today-svg"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <rect x="2" y="3.5" width="12" height="10.5" rx="0.5"/>
+                  <line x1="2" y1="7" x2="14" y2="7"/>
+                  <line x1="5" y1="2" x2="5" y2="5"/>
+                  <line x1="11" y1="2" x2="11" y2="5"/>
+                  <text
+                    x="8"
+                    y="12.6"
+                    font-size="6"
+                    font-weight="700"
+                    text-anchor="middle"
+                    stroke="none"
+                    fill="currentColor"
+                  >{{ todayDayNumber }}</text>
+                </svg>
+              </span>
               <span class="leftnav-label">today</span>
             </a>
             <button

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/LeftNav.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/LeftNav.js
@@ -24,18 +24,24 @@ window.LeftNav = {
     const isMobile = typeof window !== "undefined" && window.innerWidth <= 768;
     // Persist the open/closed pref so a refresh doesn't blow away the
     // user's choice. First visit (no saved value) still defaults to
-    // open on desktop, closed on mobile.
+    // open on desktop, closed on mobile. The saved pref is desktop-only
+    // — on mobile the drawer is a transient overlay that we always
+    // start closed and auto-close after each navigation, so a "saved
+    // open" pref from a desktop session shouldn't blanket-open the
+    // drawer every time the user lands on a mobile page.
     let isOpen = !isMobile;
-    try {
-      const saved =
-        typeof window !== "undefined" && window.localStorage
-          ? window.localStorage.getItem("brainspread.leftNavOpen")
-          : null;
-      if (saved === "1") isOpen = true;
-      else if (saved === "0") isOpen = false;
-    } catch (_) {
-      // localStorage can throw in private mode / disabled-cookie setups.
-      // Fall back to the viewport default.
+    if (!isMobile) {
+      try {
+        const saved =
+          typeof window !== "undefined" && window.localStorage
+            ? window.localStorage.getItem("brainspread.leftNavOpen")
+            : null;
+        if (saved === "1") isOpen = true;
+        else if (saved === "0") isOpen = false;
+      } catch (_) {
+        // localStorage can throw in private mode / disabled-cookie setups.
+        // Fall back to the viewport default.
+      }
     }
     let favoritesExpanded = true;
     try {
@@ -237,6 +243,10 @@ window.LeftNav = {
 
     toggleSidebar() {
       this.isOpen = !this.isOpen;
+      // Mobile state is transient (see data()'s init comment) — don't
+      // persist a mobile-only toggle as the user's saved preference,
+      // or their next desktop session will inherit it.
+      if (this.isMobileViewport()) return;
       try {
         if (typeof window !== "undefined" && window.localStorage) {
           window.localStorage.setItem(
@@ -247,6 +257,16 @@ window.LeftNav = {
       } catch (_) {
         // localStorage can throw in private mode; the toggle still
         // works for the current session, just won't persist.
+      }
+    },
+
+    closeOnMobile() {
+      // Auto-dismiss the mobile drawer after a navigation or action
+      // click — once the user has picked something the drawer's job is
+      // done and leaving it open just obscures whatever they navigated
+      // to. No-op on desktop where the sidebar is pinned.
+      if (this.isMobileViewport()) {
+        this.isOpen = false;
       }
     },
 
@@ -375,6 +395,7 @@ window.LeftNav = {
       // path changes).
       if (this.shouldDeferToBrowser(event)) return;
       event.preventDefault();
+      this.closeOnMobile();
       window.location.href = `/knowledge/views/${encodeURIComponent(slug)}/`;
     },
 
@@ -418,6 +439,7 @@ window.LeftNav = {
         event.stopPropagation();
       }
       this.$emit("use-template", template);
+      this.closeOnMobile();
     },
 
     onFavoriteDragStart(event, index) {
@@ -602,48 +624,58 @@ window.LeftNav = {
       if (this.shouldDeferToBrowser(event)) return;
       event.preventDefault();
       this.$emit("navigate-to-slug", slug);
+      this.closeOnMobile();
     },
 
     onTodayClick(event) {
       if (this.shouldDeferToBrowser(event)) return;
       event.preventDefault();
       this.$emit("navigate-today");
+      this.closeOnMobile();
     },
 
     onGraphClick(event) {
       if (this.shouldDeferToBrowser(event)) return;
       event.preventDefault();
       this.$emit("navigate-graph");
+      this.closeOnMobile();
     },
 
     onViewsClick(event) {
       if (this.shouldDeferToBrowser(event)) return;
       event.preventDefault();
       this.$emit("navigate-views");
+      this.closeOnMobile();
     },
 
     onSearchClick() {
       this.$emit("open-search");
+      this.closeOnMobile();
     },
 
     onCreatePageClick() {
       this.$emit("create-page");
+      this.closeOnMobile();
     },
 
     onCreateWhiteboardClick() {
       this.$emit("create-whiteboard");
+      this.closeOnMobile();
     },
 
     onSettingsClick() {
       this.$emit("open-settings");
+      this.closeOnMobile();
     },
 
     onHelpClick() {
       this.$emit("open-help");
+      this.closeOnMobile();
     },
 
     onLogoutClick() {
       this.$emit("logout");
+      this.closeOnMobile();
     },
 
     handleFooterKeydown(event) {
@@ -814,6 +846,7 @@ window.LeftNav = {
       if (this.shouldDeferToBrowser(event)) return;
       event.preventDefault();
       this.$emit("navigate-to-slug", tagName);
+      this.closeOnMobile();
     },
   },
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -2624,6 +2624,22 @@ const Page = {
       }
     },
 
+    openDatePicker(event) {
+      // We hide ::-webkit-calendar-picker-indicator so we can paint a
+      // themed calendar glyph via .title-left::after. Chrome stopped
+      // opening the picker on input click once the indicator is
+      // display: none, so trigger it explicitly. showPicker requires a
+      // user-activation gesture, which @click satisfies.
+      const input = event?.currentTarget;
+      if (input && typeof input.showPicker === "function") {
+        try {
+          input.showPicker();
+        } catch (_) {
+          // showPicker throws on disabled/detached inputs; harmless.
+        }
+      }
+    },
+
     initializeDateSelector() {
       if (this.isDaily && this.page?.date) {
         this.selectedDate = this.page.date;
@@ -3739,6 +3755,7 @@ const Page = {
                   type="date"
                   v-model="selectedDate"
                   @change="onDateChange"
+                  @click="openDatePicker"
                   class="date-picker"
                   title="Navigate to date"
                 />

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -2625,12 +2625,14 @@ const Page = {
     },
 
     openDatePicker(event) {
-      // We hide ::-webkit-calendar-picker-indicator so we can paint a
-      // themed calendar glyph via .title-left::after. Chrome stopped
-      // opening the picker on input click once the indicator is
-      // display: none, so trigger it explicitly. showPicker requires a
-      // user-activation gesture, which @click satisfies.
-      const input = event?.currentTarget;
+      // Wired on .title-left so the click is captured whether the user
+      // hits the date text, the input padding, or the calendar glyph
+      // painted on top via .title-left::after (pointer-events: none
+      // doesn't always cooperate with all hit-test paths). The
+      // favorite-toggle button lives in the same wrapper, so skip
+      // those so the star keeps its own click semantics.
+      if (event?.target?.closest?.(".page-favorite-toggle")) return;
+      const input = this.$refs.dateInput;
       if (input && typeof input.showPicker === "function") {
         try {
           input.showPicker();
@@ -3742,7 +3744,7 @@ const Page = {
           <div class="page-title-container">
             <!-- Daily Note Header -->
             <div v-if="isDaily" class="daily-note-title current-note page-header-flex">
-              <div class="title-left">
+              <div class="title-left" @click="openDatePicker">
                 <button
                   type="button"
                   class="page-favorite-toggle"
@@ -3752,10 +3754,10 @@ const Page = {
                   :aria-pressed="isFavorited"
                 >{{ isFavorited ? '★' : '☆' }}</button>
                 <input
+                  ref="dateInput"
                   type="date"
                   v-model="selectedDate"
                   @change="onDateChange"
-                  @click="openDatePicker"
                   class="date-picker"
                   title="Navigate to date"
                 />

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/ScheduleBlockPopover.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/ScheduleBlockPopover.js
@@ -10,7 +10,13 @@
 //
 // Emits: save({ scheduledFor, reminderDate, reminderTime }) and cancel.
 
-const SCHEDULE_TIME_CHUNKS = ["09:00", "12:00", "15:00", "17:00", "20:00"];
+const SCHEDULE_TIME_CHUNKS = [
+  { time: "09:00", label: "9am" },
+  { time: "12:00", label: "noon" },
+  { time: "15:00", label: "3pm" },
+  { time: "17:00", label: "5pm" },
+  { time: "20:00", label: "8pm" },
+];
 
 const REMINDER_OFFSETS = [
   { value: "day_of", label: "day of", days: 0 },
@@ -25,13 +31,29 @@ function todayLocalISO(now = new Date()) {
   return new Date(now.getTime() - tzOffsetMs).toISOString().slice(0, 10);
 }
 
+function pad2(n) {
+  return String(n).padStart(2, "0");
+}
+
+// HH:MM in local time.
+function timeHHMM(date) {
+  return `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
+}
+
+// Both the local-date ISO and HH:MM for the given Date — used by the
+// "in 30m" / "in 1h" relative time chips so they can roll the schedule
+// date over to tomorrow if "now + offset" crosses midnight.
+function localDateTimeISO(date) {
+  return { date: todayLocalISO(date), time: timeHHMM(date) };
+}
+
 function defaultReminderTimeFor(scheduledFor, now = new Date()) {
   if (!scheduledFor) return "";
   if (scheduledFor !== todayLocalISO(now)) return "09:00";
   const nowMins = now.getHours() * 60 + now.getMinutes();
   for (const chunk of SCHEDULE_TIME_CHUNKS) {
-    const [h, m] = chunk.split(":").map(Number);
-    if (h * 60 + m > nowMins) return chunk;
+    const [h, m] = chunk.time.split(":").map(Number);
+    if (h * 60 + m > nowMins) return chunk.time;
   }
   return "";
 }
@@ -80,6 +102,11 @@ window.ScheduleBlockPopover = {
       reminderTime: "",
       timeManuallyEdited: false,
       offsets: REMINDER_OFFSETS,
+      // Refreshed when the popover opens so the relative-time chips
+      // ("in 30m", "in 1h") and the past-chunk filter are anchored to
+      // when the user actually started looking at the popover, not
+      // page-load time.
+      nowMs: Date.now(),
     };
   },
   computed: {
@@ -95,11 +122,52 @@ window.ScheduleBlockPopover = {
       );
       return subtractDaysISO(this.scheduledFor, offset?.days ?? 0);
     },
+    todayIso() {
+      return todayLocalISO(new Date(this.nowMs));
+    },
+    tomorrowIso() {
+      const t = new Date(this.nowMs);
+      t.setDate(t.getDate() + 1);
+      return todayLocalISO(t);
+    },
+    // Relative time chips ("in 30m" / "in 1h"). Each preset carries both
+    // the target date and target time so the chip can correctly roll
+    // the schedule to tomorrow if "now + offset" crosses midnight.
+    relativeTimePresets() {
+      return [30, 60].map((minutes) => {
+        const target = new Date(this.nowMs + minutes * 60_000);
+        const { date, time } = localDateTimeISO(target);
+        return {
+          key: `rel-${minutes}`,
+          label: minutes === 60 ? "in 1h" : `in ${minutes}m`,
+          date,
+          time,
+        };
+      });
+    },
+    // Fixed chunk-time chips. When the user is scheduling for today,
+    // hide chunks that have already passed so the chip row stays
+    // useful instead of offering reminder times that would fire in the
+    // past. Future dates show every chunk.
+    chunkTimePresets() {
+      const isToday = this.scheduledFor === this.todayIso;
+      const now = new Date(this.nowMs);
+      const nowMins = now.getHours() * 60 + now.getMinutes();
+      return SCHEDULE_TIME_CHUNKS.filter(({ time }) => {
+        if (!isToday) return true;
+        const [h, m] = time.split(":").map(Number);
+        return h * 60 + m > nowMins;
+      }).map((c) => ({ key: `chunk-${c.time}`, label: c.label, time: c.time }));
+    },
   },
   watch: {
     isOpen: {
       handler(open) {
         if (!open) return;
+        // Anchor relative-time chips and past-chunk filtering to the
+        // moment the popover was opened so they don't drift while
+        // the user deliberates.
+        this.nowMs = Date.now();
         this.scheduledFor = this.initialDate || todayLocalISO();
         this.reminderEnabled = !!this.initialTime;
         this.reminderTime =
@@ -137,6 +205,18 @@ window.ScheduleBlockPopover = {
         this.reminderTime =
           defaultReminderTimeFor(this.scheduledFor) || "09:00";
       }
+    },
+    setScheduledFor(iso) {
+      this.scheduledFor = iso;
+    },
+    // Quick-pick chip: jump straight to a specific reminder time. Also
+    // enables the reminder so the user doesn't have to tick the box
+    // first — tapping a time chip clearly signals they want one.
+    pickReminderTime(time, date) {
+      if (date) this.scheduledFor = date;
+      this.reminderTime = time;
+      this.timeManuallyEdited = true;
+      this.reminderEnabled = true;
     },
     onOffsetChange() {
       // When switching to custom, seed the input with the due date so the
@@ -188,6 +268,21 @@ window.ScheduleBlockPopover = {
           />
         </label>
 
+        <div class="schedule-popover-quick-row schedule-popover-quick-row-date">
+          <button
+            type="button"
+            class="schedule-popover-quick-btn"
+            :class="{ 'is-active': scheduledFor === todayIso }"
+            @click="setScheduledFor(todayIso)"
+          >today</button>
+          <button
+            type="button"
+            class="schedule-popover-quick-btn"
+            :class="{ 'is-active': scheduledFor === tomorrowIso }"
+            @click="setScheduledFor(tomorrowIso)"
+          >tomorrow</button>
+        </div>
+
         <label class="schedule-popover-row schedule-popover-row-reminder">
           <input
             type="checkbox"
@@ -213,6 +308,32 @@ window.ScheduleBlockPopover = {
             :disabled="!reminderEnabled || !scheduledFor"
           />
         </label>
+
+        <div
+          v-if="scheduledFor"
+          class="schedule-popover-quick-row schedule-popover-quick-row-time"
+        >
+          <button
+            v-for="preset in relativeTimePresets"
+            :key="preset.key"
+            type="button"
+            class="schedule-popover-quick-btn schedule-popover-quick-btn-relative"
+            @click="pickReminderTime(preset.time, preset.date)"
+          >{{ preset.label }}</button>
+          <span
+            v-if="relativeTimePresets.length && chunkTimePresets.length"
+            class="schedule-popover-quick-divider"
+            aria-hidden="true"
+          ></span>
+          <button
+            v-for="preset in chunkTimePresets"
+            :key="preset.key"
+            type="button"
+            class="schedule-popover-quick-btn"
+            :class="{ 'is-active': reminderEnabled && reminderTime === preset.time }"
+            @click="pickReminderTime(preset.time)"
+          >{{ preset.label }}</button>
+        </div>
 
         <label v-if="showCustomDate" class="schedule-popover-row">
           <span class="schedule-popover-label">on</span>

--- a/packages/django-app/app/knowledge/test/commands/test_update_block_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_update_block_command.py
@@ -519,3 +519,50 @@ class TestUpdateBlockCommand(TestCase):
 
         block.refresh_from_db()
         self.assertEqual(block.asset_id, asset.id)
+
+    def test_should_preserve_ui_managed_properties_on_content_edit(self):
+        """A content edit must not clobber UI-managed properties (image
+        resize width, "show as raw" render flag). Both live in the same
+        JSON blob as content-derived `key:: value` properties, but they
+        aren't represented in text, so the content-driven extractor that
+        runs on every UpdateBlock has to leave them alone."""
+        self.block.properties = {
+            "size": {"width": 240},
+            "render": "raw",
+        }
+        self.block.save()
+
+        form = UpdateBlockForm(
+            {
+                "user": self.user.id,
+                "block": str(self.block.uuid),
+                "content": "now with words but no key:: value syntax",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        UpdateBlockCommand(form).execute()
+
+        self.block.refresh_from_db()
+        self.assertEqual(self.block.properties.get("size"), {"width": 240})
+        self.assertEqual(self.block.properties.get("render"), "raw")
+
+    def test_should_merge_content_properties_with_ui_managed_ones(self):
+        """When the user adds a `priority:: high` line to content, the
+        extractor should add that key without dropping a previously
+        set image width."""
+        self.block.properties = {"size": {"width": 180}}
+        self.block.save()
+
+        form = UpdateBlockForm(
+            {
+                "user": self.user.id,
+                "block": str(self.block.uuid),
+                "content": "rework intro\npriority:: high",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        UpdateBlockCommand(form).execute()
+
+        self.block.refresh_from_db()
+        self.assertEqual(self.block.properties.get("priority"), "high")
+        self.assertEqual(self.block.properties.get("size"), {"width": 180})


### PR DESCRIPTION
Mobile + chat tidy-up.

- Search modal now sits above the mobile drawer (z-index)
- Mobile drawer auto-closes after any nav/action click
- Chat input area is drag-resizable from its top edge; textarea fills it
- Daily-page calendar icon reliably opens the date picker
- "Today" nav icon swapped for a calendar SVG with today's day-of-month inside
- pickPage modal sorts by most-recently-modified and pins today's daily on top