### PR TITLE
Add chat session favorites and inline rename UI

### DIFF
--- a/packages/django-app/app/ai_chat/commands/__init__.py
+++ b/packages/django-app/app/ai_chat/commands/__init__.py
@@ -1,4 +1,7 @@
 from .list_chat_sessions_command import ListChatSessionsCommand
+from .reorder_favorited_chat_sessions_command import (
+    ReorderFavoritedChatSessionsCommand,
+)
 from .resume_approval_command import ResumeApprovalCommand
 from .send_message_command import SendMessageCommand
 from .set_chat_session_favorited_command import SetChatSessionFavoritedCommand

--- a/packages/django-app/app/ai_chat/commands/__init__.py
+++ b/packages/django-app/app/ai_chat/commands/__init__.py
@@ -1,4 +1,6 @@
 from .list_chat_sessions_command import ListChatSessionsCommand
 from .resume_approval_command import ResumeApprovalCommand
 from .send_message_command import SendMessageCommand
+from .set_chat_session_favorited_command import SetChatSessionFavoritedCommand
 from .stream_send_message_command import StreamSendMessageCommand
+from .update_chat_session_title_command import UpdateChatSessionTitleCommand

--- a/packages/django-app/app/ai_chat/commands/list_chat_sessions_command.py
+++ b/packages/django-app/app/ai_chat/commands/list_chat_sessions_command.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any, Dict, List, Optional
 
 from common.commands.abstract_base_command import AbstractBaseCommand
@@ -9,6 +10,15 @@ from ..repositories import ChatMessageRepository, ChatSessionRepository
 PREVIEW_LEN = 100
 SNIPPET_RADIUS = 60
 SNIPPET_MAX = 200
+
+# Strip the `**Context from my notes:** ... **My question:**\n` wrapper
+# the SendMessage command adds when context blocks are attached, so a
+# legacy session without a curated title still produces a readable
+# preview instead of a wall of context bullets.
+_CONTEXT_WRAPPER_RE = re.compile(
+    r"^\*\*Context from my notes:\*\*.*?\*\*My question:\*\*\s*",
+    re.DOTALL,
+)
 
 
 class ListChatSessionsCommand(AbstractBaseCommand):
@@ -30,15 +40,18 @@ class ListChatSessionsCommand(AbstractBaseCommand):
 
         user = self.form.cleaned_data["user"]
         search: str = self.form.cleaned_data.get("search") or ""
+        favorites_only: bool = bool(self.form.cleaned_data.get("favorites_only"))
 
-        sessions = ChatSessionRepository.list_for_user(user, search=search)
+        sessions = ChatSessionRepository.list_for_user(
+            user, search=search, favorites_only=favorites_only
+        )
 
         sessions_data: List[Dict[str, Any]] = []
         for session in sessions:
             first_message = ChatMessageRepository.first_user_message(session)
             preview = ""
             if first_message and first_message.content:
-                content = first_message.content
+                content = self._strip_context_wrapper(first_message.content)
                 preview = (
                     content[:PREVIEW_LEN] + "..."
                     if len(content) > PREVIEW_LEN
@@ -47,7 +60,13 @@ class ListChatSessionsCommand(AbstractBaseCommand):
 
             entry: Dict[str, Any] = {
                 "uuid": str(session.uuid),
+                # Surface the curated title separately from the
+                # context-derived fallback so the UI can render a
+                # different style for each (and we keep "New Chat"
+                # as the last-ditch label).
                 "title": session.title or preview or "New Chat",
+                "has_title": bool(session.title),
+                "is_favorited": bool(session.is_favorited),
                 "preview": preview,
                 "created_at": session.created_at.isoformat(),
                 "modified_at": session.modified_at.isoformat(),
@@ -60,6 +79,15 @@ class ListChatSessionsCommand(AbstractBaseCommand):
             sessions_data.append(entry)
 
         return sessions_data
+
+    @staticmethod
+    def _strip_context_wrapper(content: str) -> str:
+        """Remove the `**Context from my notes:** ... **My question:**`
+        prefix the SendMessage command prepends when context blocks are
+        attached, so the preview shows the user's actual question
+        instead of the context dump."""
+        stripped = _CONTEXT_WRAPPER_RE.sub("", content, count=1)
+        return stripped.strip() or content.strip()
 
     @staticmethod
     def _build_snippet(session: ChatSession, search: str) -> Optional[str]:

--- a/packages/django-app/app/ai_chat/commands/reorder_favorited_chat_sessions_command.py
+++ b/packages/django-app/app/ai_chat/commands/reorder_favorited_chat_sessions_command.py
@@ -1,0 +1,65 @@
+from typing import Any, Dict, List
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+
+from common.commands.abstract_base_command import AbstractBaseCommand
+
+from ..forms import ReorderFavoritedChatSessionsForm
+from ..repositories import ChatSessionRepository
+
+
+class ReorderFavoritedChatSessionsCommand(AbstractBaseCommand):
+    """Persist a new drag-sorted order for the user's favorited chats.
+
+    The payload is the desired full ordering. Any favorited chat the
+    caller omits keeps its old relative position behind the ones they
+    did list — a partial payload won't silently demote a chat off the
+    Pinned section. Cross-user / unknown uuids are rejected loudly so
+    a stale tab racing a delete surfaces the error instead of
+    silently dropping rows.
+    """
+
+    def __init__(self, form: ReorderFavoritedChatSessionsForm) -> None:
+        self.form = form
+
+    def execute(self) -> List[Dict[str, Any]]:
+        super().execute()
+
+        user = self.form.cleaned_data["user"]
+        ordered_uuids: List[str] = self.form.cleaned_data["session_uuids"]
+
+        favorited = ChatSessionRepository.list_favorited(user)
+        session_by_uuid = {str(s.uuid): s for s in favorited}
+
+        unknown = [u for u in ordered_uuids if u not in session_by_uuid]
+        if unknown:
+            raise ValidationError(
+                "One or more chats are not in your favorites: " + ", ".join(unknown)
+            )
+
+        # Apply the requested order, then append any favorites the caller
+        # omitted so we never lose them. The omitted ones keep their
+        # existing relative order.
+        seen = set(ordered_uuids)
+        omitted = [str(s.uuid) for s in favorited if str(s.uuid) not in seen]
+        new_order = ordered_uuids + omitted
+
+        with transaction.atomic():
+            for index, session_uuid in enumerate(new_order):
+                session = session_by_uuid[session_uuid]
+                if session.favorite_position == index:
+                    continue
+                session.favorite_position = index
+                # Skip modified_at so a reorder doesn't bubble the
+                # whole Pinned section to the top of the chronological
+                # half of the list.
+                session.save(update_fields=["favorite_position"])
+
+        return [
+            {
+                "uuid": str(s.uuid),
+                "favorite_position": s.favorite_position,
+            }
+            for s in ChatSessionRepository.list_favorited(user)
+        ]

--- a/packages/django-app/app/ai_chat/commands/send_message_command.py
+++ b/packages/django-app/app/ai_chat/commands/send_message_command.py
@@ -22,6 +22,12 @@ logger = logging.getLogger(__name__)
 
 # A stable system prompt gives providers that support prompt caching something
 # worth caching. Keep it short but concrete.
+# Cap auto-generated titles at a length that comfortably fits on a
+# history-row line. The DB allows up to 200, but anything over ~80 looks
+# truncated in the dropdown anyway.
+AUTO_TITLE_MAX_LEN = 80
+
+
 BRAINSPREAD_SYSTEM_PROMPT = (
     "You are the assistant embedded in brainspread, a personal note-taking app"
     " where users capture thoughts as hierarchical blocks on daily pages."
@@ -79,6 +85,15 @@ class SendMessageCommand(AbstractBaseCommand):
                 "user",
                 formatted_message,
                 attachments=SendMessageCommand._serialize_attachments(attached_assets),
+            )
+
+            # Auto-label brand-new sessions from the user's raw message
+            # (not formatted_message — we don't want the context bullets
+            # in the title). set_title_if_blank is idempotent, so this
+            # is a no-op on follow-up turns and on sessions the user
+            # already renamed.
+            ChatSessionRepository.set_title_if_blank(
+                session, SendMessageCommand._derive_auto_title(message)
             )
 
             messages = SendMessageCommand._build_messages_with_images(session)
@@ -267,6 +282,25 @@ class SendMessageCommand(AbstractBaseCommand):
                 entry["images"] = images
             out.append(entry)
         return out
+
+    @staticmethod
+    def _derive_auto_title(message: str) -> str:
+        """Squash newlines and clip to a one-line display length so the
+        title sits cleanly on a chat-history row. Returns empty string
+        for empty messages (image-only turns) — the repo helper
+        no-ops on those."""
+        if not message:
+            return ""
+        collapsed = " ".join(message.split())
+        if len(collapsed) <= AUTO_TITLE_MAX_LEN:
+            return collapsed
+        # Trim to a word boundary so the title doesn't cut a word in
+        # half, with an ellipsis to signal truncation.
+        clip = collapsed[: AUTO_TITLE_MAX_LEN - 1]
+        space = clip.rfind(" ")
+        if space > AUTO_TITLE_MAX_LEN // 2:
+            clip = clip[:space]
+        return clip.rstrip() + "…"
 
     @staticmethod
     def _format_message_with_context(message: str, context_blocks: List[Dict]) -> str:

--- a/packages/django-app/app/ai_chat/commands/set_chat_session_favorited_command.py
+++ b/packages/django-app/app/ai_chat/commands/set_chat_session_favorited_command.py
@@ -1,0 +1,31 @@
+from typing import Any, Dict
+
+from common.commands.abstract_base_command import AbstractBaseCommand
+
+from ..forms import SetChatSessionFavoritedForm
+from ..repositories import ChatSessionRepository
+
+
+class SetChatSessionFavoritedCommand(AbstractBaseCommand):
+    """Toggle a chat session's favorited flag.
+
+    The form validates user ownership of the session before this runs,
+    so the command can persist directly without re-authorizing.
+    """
+
+    def __init__(self, form: SetChatSessionFavoritedForm) -> None:
+        self.form = form
+
+    def execute(self) -> Dict[str, Any]:
+        super().execute()
+        user = self.form.cleaned_data["user"]
+        session = self.form.cleaned_data["session"]
+        is_favorited = self.form.cleaned_data["is_favorited"]
+
+        updated = ChatSessionRepository.set_favorited(
+            uuid=str(session.uuid), user=user, is_favorited=is_favorited
+        )
+        return {
+            "uuid": str(updated.uuid),
+            "is_favorited": updated.is_favorited,
+        }

--- a/packages/django-app/app/ai_chat/commands/stream_send_message_command.py
+++ b/packages/django-app/app/ai_chat/commands/stream_send_message_command.py
@@ -111,6 +111,12 @@ class StreamSendMessageCommand(AbstractBaseCommand):
                 attachments=SendMessageCommand._serialize_attachments(attached_assets),
             )
 
+            # Auto-label brand-new sessions from the user's raw message.
+            # Idempotent: follow-up turns and renamed sessions no-op.
+            ChatSessionRepository.set_title_if_blank(
+                session, SendMessageCommand._derive_auto_title(message)
+            )
+
             messages = SendMessageCommand._build_messages_with_images(session)
 
             service = AIServiceFactory.create_service(

--- a/packages/django-app/app/ai_chat/commands/update_chat_session_title_command.py
+++ b/packages/django-app/app/ai_chat/commands/update_chat_session_title_command.py
@@ -1,0 +1,31 @@
+from typing import Any, Dict
+
+from common.commands.abstract_base_command import AbstractBaseCommand
+
+from ..forms import UpdateChatSessionTitleForm
+from ..repositories import ChatSessionRepository
+
+
+class UpdateChatSessionTitleCommand(AbstractBaseCommand):
+    """Rename a chat session.
+
+    The form validates user ownership of the session and rejects blank
+    titles, so this command can persist directly.
+    """
+
+    def __init__(self, form: UpdateChatSessionTitleForm) -> None:
+        self.form = form
+
+    def execute(self) -> Dict[str, Any]:
+        super().execute()
+        user = self.form.cleaned_data["user"]
+        session = self.form.cleaned_data["session"]
+        title = self.form.cleaned_data["title"]
+
+        updated = ChatSessionRepository.update_title(
+            uuid=str(session.uuid), user=user, title=title
+        )
+        return {
+            "uuid": str(updated.uuid),
+            "title": updated.title,
+        }

--- a/packages/django-app/app/ai_chat/forms.py
+++ b/packages/django-app/app/ai_chat/forms.py
@@ -1,3 +1,4 @@
+import uuid as uuid_lib
 from typing import Dict, List, Optional
 
 from django import forms
@@ -344,6 +345,46 @@ class SetChatSessionFavoritedForm(_ChatSessionLookupMixin, BaseForm):
 
     def clean_is_favorited(self) -> bool:
         return bool(self.cleaned_data.get("is_favorited"))
+
+
+class ReorderFavoritedChatSessionsForm(BaseForm):
+    """Inputs for persisting a new drag-sorted order on the Pinned section.
+
+    `session_uuids` is the desired full ordering of the user's
+    favorited chats. Cross-user uuids are rejected by the command's
+    membership check (not here) so the error message can name the
+    offending rows.
+    """
+
+    user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
+    session_uuids = forms.JSONField()
+
+    def clean_user(self) -> User:
+        user = self.cleaned_data.get("user")
+        if not user:
+            raise ValidationError("User is required")
+        return user
+
+    def clean_session_uuids(self) -> List[str]:
+        raw = self.cleaned_data.get("session_uuids")
+        if not isinstance(raw, list):
+            raise ValidationError("session_uuids must be a list")
+
+        normalized: List[str] = []
+        seen = set()
+        for i, item in enumerate(raw):
+            try:
+                parsed = uuid_lib.UUID(str(item))
+            except (ValueError, AttributeError, TypeError):
+                raise ValidationError(
+                    f"Item at index {i} has an invalid UUID: {item!r}"
+                )
+            s = str(parsed)
+            if s in seen:
+                raise ValidationError(f"Duplicate chat session UUID: {s}")
+            seen.add(s)
+            normalized.append(s)
+        return normalized
 
 
 class UpdateChatSessionTitleForm(_ChatSessionLookupMixin, BaseForm):

--- a/packages/django-app/app/ai_chat/forms.py
+++ b/packages/django-app/app/ai_chat/forms.py
@@ -290,11 +290,14 @@ class ListChatSessionsForm(BaseForm):
 
     The search field is matched (case-insensitive) against session
     titles and the content of any message in the session. Empty /
-    blank search returns the user's full session list.
+    blank search returns the user's full session list. When
+    favorites_only is true, the response is restricted to favorited
+    sessions.
     """
 
     user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
     search = forms.CharField(required=False, max_length=200)
+    favorites_only = forms.NullBooleanField(required=False)
 
     def clean_user(self) -> User:
         user = self.cleaned_data.get("user")
@@ -304,6 +307,69 @@ class ListChatSessionsForm(BaseForm):
 
     def clean_search(self) -> str:
         return (self.cleaned_data.get("search") or "").strip()
+
+    def clean_favorites_only(self) -> bool:
+        return bool(self.cleaned_data.get("favorites_only"))
+
+
+class _ChatSessionLookupMixin:
+    """Resolve session_id → ChatSession, scoped to the user."""
+
+    def clean(self):
+        cleaned_data = super().clean()
+        user = cleaned_data.get("user")
+        session_id = cleaned_data.get("session_id")
+        if user is None or not session_id:
+            return cleaned_data
+        try:
+            session = ChatSession.objects.get(uuid=session_id, user=user)
+        except ChatSession.DoesNotExist:
+            raise ValidationError("Chat session not found")
+        cleaned_data["session"] = session
+        return cleaned_data
+
+
+class SetChatSessionFavoritedForm(_ChatSessionLookupMixin, BaseForm):
+    """Inputs for toggling a chat session's favorited flag."""
+
+    user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
+    session_id = forms.CharField(required=True, max_length=64)
+    is_favorited = forms.BooleanField(required=False)
+
+    def clean_user(self) -> User:
+        user = self.cleaned_data.get("user")
+        if not user:
+            raise ValidationError("User is required")
+        return user
+
+    def clean_is_favorited(self) -> bool:
+        return bool(self.cleaned_data.get("is_favorited"))
+
+
+class UpdateChatSessionTitleForm(_ChatSessionLookupMixin, BaseForm):
+    """Inputs for renaming a chat session.
+
+    Empty / whitespace-only titles are rejected: a renamed chat is the
+    user opting into a label, so silently falling back to the
+    auto-generated preview would be surprising. To "clear" a title
+    they can rename to something meaningful instead.
+    """
+
+    user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
+    session_id = forms.CharField(required=True, max_length=64)
+    title = forms.CharField(required=True, max_length=200)
+
+    def clean_user(self) -> User:
+        user = self.cleaned_data.get("user")
+        if not user:
+            raise ValidationError("User is required")
+        return user
+
+    def clean_title(self) -> str:
+        title = (self.cleaned_data.get("title") or "").strip()
+        if not title:
+            raise ValidationError("Title cannot be blank")
+        return title
 
 
 class GetChatHistorySummaryForm(BaseForm):

--- a/packages/django-app/app/ai_chat/migrations/0020_chatsession_is_favorited.py
+++ b/packages/django-app/app/ai_chat/migrations/0020_chatsession_is_favorited.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ai_chat", "0019_chatmessage_status"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="chatsession",
+            name="is_favorited",
+            field=models.BooleanField(db_index=True, default=False),
+        ),
+    ]

--- a/packages/django-app/app/ai_chat/migrations/0021_chatsession_favorite_position.py
+++ b/packages/django-app/app/ai_chat/migrations/0021_chatsession_favorite_position.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ai_chat", "0020_chatsession_is_favorited"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="chatsession",
+            name="favorite_position",
+            field=models.IntegerField(default=0),
+        ),
+    ]

--- a/packages/django-app/app/ai_chat/models/chat_session.py
+++ b/packages/django-app/app/ai_chat/models/chat_session.py
@@ -8,6 +8,10 @@ from common.models.uuid_mixin import UUIDModelMixin
 class ChatSession(UUIDModelMixin, CRUDTimestampsMixin):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     title = models.CharField(max_length=200, blank=True)
+    # Pinned chats sort to the top of the history list and can be filtered
+    # to via the "favorites only" toggle. db_index so the favorites-only
+    # query stays cheap as the session table grows.
+    is_favorited = models.BooleanField(default=False, db_index=True)
 
     class Meta:
         db_table = "ai_chat_sessions"

--- a/packages/django-app/app/ai_chat/models/chat_session.py
+++ b/packages/django-app/app/ai_chat/models/chat_session.py
@@ -12,6 +12,10 @@ class ChatSession(UUIDModelMixin, CRUDTimestampsMixin):
     # to via the "favorites only" toggle. db_index so the favorites-only
     # query stays cheap as the session table grows.
     is_favorited = models.BooleanField(default=False, db_index=True)
+    # Order within the user's Pinned section. Lower values appear first;
+    # ties fall back to -modified_at so freshly-touched chats lead. The
+    # field is only meaningful for is_favorited=True rows.
+    favorite_position = models.IntegerField(default=0)
 
     class Meta:
         db_table = "ai_chat_sessions"

--- a/packages/django-app/app/ai_chat/repositories/chat_session_repository.py
+++ b/packages/django-app/app/ai_chat/repositories/chat_session_repository.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from django.db.models import Count, Q, QuerySet
+from django.db.models import Count, Max, Q, QuerySet
 
 from common.repositories.base_repository import BaseRepository
 from core.models import User
@@ -60,7 +60,11 @@ class ChatSessionRepository(BaseRepository):
             ).distinct()
         # Favorites pin to the top so the "Pinned" section in the UI
         # can be built off the same query without a second round-trip.
-        return qs.order_by("-is_favorited", "-modified_at")
+        # Within favorites: user-curated favorite_position wins, then
+        # -modified_at as a tiebreaker. Non-favorites fall through to
+        # -modified_at (favorite_position is 0 for all non-favorites,
+        # so it's a no-op on that side).
+        return qs.order_by("-is_favorited", "favorite_position", "-modified_at")
 
     @classmethod
     def set_favorited(
@@ -69,9 +73,39 @@ class ChatSessionRepository(BaseRepository):
         session = cls.get_for_user(uuid=uuid, user=user)
         if session is None:
             return None
+        update_fields = ["is_favorited", "modified_at"]
         session.is_favorited = is_favorited
-        session.save(update_fields=["is_favorited", "modified_at"])
+        if is_favorited:
+            # Append to the end of the Pinned section. Without this,
+            # newly-favorited chats would all share favorite_position=0
+            # and tiebreak only on -modified_at, which would shuffle
+            # the older pinned items every time a new one was added.
+            session.favorite_position = cls.next_favorite_position(user)
+            update_fields.append("favorite_position")
+        session.save(update_fields=update_fields)
         return session
+
+    @classmethod
+    def list_favorited(cls, user: User) -> List[ChatSession]:
+        """Favorited sessions in their curated order, for the reorder
+        command and the post-reorder response."""
+        return list(
+            cls.get_queryset()
+            .filter(user=user, is_favorited=True)
+            .order_by("favorite_position", "-modified_at")
+        )
+
+    @classmethod
+    def next_favorite_position(cls, user: User) -> int:
+        """Next-highest favorite_position so a newly-pinned chat lands
+        at the end of the Pinned section rather than racing with the
+        existing 0-positioned rows."""
+        current_max = (
+            cls.get_queryset()
+            .filter(user=user, is_favorited=True)
+            .aggregate(max_pos=Max("favorite_position"))["max_pos"]
+        )
+        return 0 if current_max is None else current_max + 1
 
     @classmethod
     def update_title(cls, uuid: str, user: User, title: str) -> Optional[ChatSession]:

--- a/packages/django-app/app/ai_chat/repositories/chat_session_repository.py
+++ b/packages/django-app/app/ai_chat/repositories/chat_session_repository.py
@@ -41,16 +41,56 @@ class ChatSessionRepository(BaseRepository):
             return None
 
     @classmethod
-    def list_for_user(cls, user: User, search: str = "") -> QuerySet:
-        """Sessions for the user, newest-modified first. When `search`
-        is non-empty, narrow to titles or message contents that match
-        it case-insensitively. distinct() because the join through
-        messages can multiply rows when many messages match in one
-        session.
+    def list_for_user(
+        cls, user: User, search: str = "", favorites_only: bool = False
+    ) -> QuerySet:
+        """Sessions for the user, favorited first then newest-modified.
+        When `search` is non-empty, narrow to titles or message contents
+        that match it case-insensitively. When `favorites_only` is True,
+        only return favorited sessions. distinct() because the join
+        through messages can multiply rows when many messages match in
+        one session.
         """
         qs = cls.get_queryset().filter(user=user)
+        if favorites_only:
+            qs = qs.filter(is_favorited=True)
         if search:
             qs = qs.filter(
                 Q(title__icontains=search) | Q(messages__content__icontains=search)
             ).distinct()
-        return qs.order_by("-modified_at")
+        # Favorites pin to the top so the "Pinned" section in the UI
+        # can be built off the same query without a second round-trip.
+        return qs.order_by("-is_favorited", "-modified_at")
+
+    @classmethod
+    def set_favorited(
+        cls, uuid: str, user: User, is_favorited: bool
+    ) -> Optional[ChatSession]:
+        session = cls.get_for_user(uuid=uuid, user=user)
+        if session is None:
+            return None
+        session.is_favorited = is_favorited
+        session.save(update_fields=["is_favorited", "modified_at"])
+        return session
+
+    @classmethod
+    def update_title(cls, uuid: str, user: User, title: str) -> Optional[ChatSession]:
+        session = cls.get_for_user(uuid=uuid, user=user)
+        if session is None:
+            return None
+        session.title = title
+        session.save(update_fields=["title", "modified_at"])
+        return session
+
+    @classmethod
+    def set_title_if_blank(cls, session: ChatSession, title: str) -> ChatSession:
+        """Set a derived title on a brand-new session, idempotently.
+        Subsequent turns on the same session won't overwrite a title
+        the user has already curated (or that the first turn produced).
+        """
+        if session.title or not title:
+            return session
+        max_len = cls.model._meta.get_field("title").max_length
+        session.title = title[:max_len]
+        session.save(update_fields=["title", "modified_at"])
+        return session

--- a/packages/django-app/app/ai_chat/test/test_auto_title.py
+++ b/packages/django-app/app/ai_chat/test/test_auto_title.py
@@ -1,0 +1,89 @@
+from django.test import TestCase
+
+from ai_chat.commands.send_message_command import (
+    AUTO_TITLE_MAX_LEN,
+    SendMessageCommand,
+)
+from ai_chat.repositories import ChatSessionRepository
+from ai_chat.test.helpers import ChatSessionFactory
+from core.test.helpers import UserFactory
+
+
+class TestDeriveAutoTitle(TestCase):
+    """Pure-function tests for the auto-title formatter."""
+
+    def test_short_message_returned_as_is(self):
+        self.assertEqual(
+            SendMessageCommand._derive_auto_title("What is a pinecone?"),
+            "What is a pinecone?",
+        )
+
+    def test_collapses_newlines_and_whitespace(self):
+        self.assertEqual(
+            SendMessageCommand._derive_auto_title("hello\n\n  world\t!"),
+            "hello world !",
+        )
+
+    def test_empty_message_returns_empty(self):
+        # Image-only turns send an empty caption; auto-titling shouldn't
+        # overwrite the existing (blank) title with another blank.
+        self.assertEqual(SendMessageCommand._derive_auto_title(""), "")
+        self.assertEqual(SendMessageCommand._derive_auto_title("   "), "")
+
+    def test_truncates_long_message_with_ellipsis(self):
+        # Anything past AUTO_TITLE_MAX_LEN gets clipped to a word
+        # boundary and ends with the ellipsis character.
+        long_msg = " ".join(["word"] * 50)
+        title = SendMessageCommand._derive_auto_title(long_msg)
+        self.assertLessEqual(len(title), AUTO_TITLE_MAX_LEN)
+        self.assertTrue(title.endswith("…"))
+        # Word boundary respected — no half-word before the ellipsis.
+        body = title.rstrip("…").rstrip()
+        self.assertFalse(body.endswith("wor"))
+
+    def test_truncation_falls_back_when_no_word_boundary(self):
+        # A single super-long token has nowhere to split — we still
+        # truncate to the max length rather than blow past it.
+        title = SendMessageCommand._derive_auto_title("x" * 200)
+        self.assertLessEqual(len(title), AUTO_TITLE_MAX_LEN)
+        self.assertTrue(title.endswith("…"))
+
+
+class TestSetTitleIfBlank(TestCase):
+    """ChatSessionRepository.set_title_if_blank should be idempotent."""
+
+    def setUp(self):
+        self.user = UserFactory()
+
+    def test_sets_title_on_blank_session(self):
+        session = ChatSessionFactory(user=self.user, title="")
+        ChatSessionRepository.set_title_if_blank(session, "Recipe brainstorm")
+        session.refresh_from_db()
+        self.assertEqual(session.title, "Recipe brainstorm")
+
+    def test_no_op_on_already_titled_session(self):
+        # Manual renames must survive subsequent turns — set_title_if_blank
+        # is what each SendMessage call invokes, so a user-curated title
+        # has to win against the auto-derived one.
+        session = ChatSessionFactory(user=self.user, title="My pinned chat")
+        ChatSessionRepository.set_title_if_blank(session, "Different label")
+        session.refresh_from_db()
+        self.assertEqual(session.title, "My pinned chat")
+
+    def test_no_op_on_empty_derived_title(self):
+        # An image-only first turn produces an empty derived title.
+        # The session keeps its (still blank) title rather than getting
+        # an "" written into the column.
+        session = ChatSessionFactory(user=self.user, title="")
+        ChatSessionRepository.set_title_if_blank(session, "")
+        session.refresh_from_db()
+        self.assertEqual(session.title, "")
+
+    def test_truncates_to_field_max_length(self):
+        # The repo is the last line of defense — even if someone hands
+        # it a string longer than the column, it must fit.
+        session = ChatSessionFactory(user=self.user, title="")
+        max_len = session._meta.get_field("title").max_length
+        ChatSessionRepository.set_title_if_blank(session, "x" * (max_len + 50))
+        session.refresh_from_db()
+        self.assertEqual(len(session.title), max_len)

--- a/packages/django-app/app/ai_chat/test/test_list_chat_sessions_command.py
+++ b/packages/django-app/app/ai_chat/test/test_list_chat_sessions_command.py
@@ -129,6 +129,23 @@ class TestListChatSessionsCommand(TestCase):
         # Favorite is now first regardless of -modified_at.
         self.assertEqual(ordered_uuids[0], str(self.session_titled.uuid))
 
+    def test_favorites_respect_favorite_position_within_pinned(self):
+        # Two pinned chats: the one with the lower favorite_position
+        # sorts above the other, even though -modified_at would have
+        # ordered them differently.
+        self.session_titled.is_favorited = True
+        self.session_titled.favorite_position = 1
+        self.session_titled.save(update_fields=["is_favorited", "favorite_position"])
+        self.session_unrelated.is_favorited = True
+        self.session_unrelated.favorite_position = 0
+        self.session_unrelated.save(update_fields=["is_favorited", "favorite_position"])
+        result = self._run(self.user)
+        favorited = [entry["uuid"] for entry in result if entry["is_favorited"]]
+        self.assertEqual(
+            favorited,
+            [str(self.session_unrelated.uuid), str(self.session_titled.uuid)],
+        )
+
     def test_favorites_only_filter(self):
         self.session_titled.is_favorited = True
         self.session_titled.save(update_fields=["is_favorited"])

--- a/packages/django-app/app/ai_chat/test/test_list_chat_sessions_command.py
+++ b/packages/django-app/app/ai_chat/test/test_list_chat_sessions_command.py
@@ -97,3 +97,67 @@ class TestListChatSessionsCommand(TestCase):
         result = self._run(self.user, "pinecone")
         uuids = [entry["uuid"] for entry in result]
         self.assertEqual(len(uuids), len(set(uuids)))
+
+    def test_includes_is_favorited_flag(self):
+        result = self._run(self.user)
+        for entry in result:
+            self.assertIn("is_favorited", entry)
+            self.assertFalse(entry["is_favorited"])
+
+    def test_has_title_flag_reflects_curated_titles(self):
+        # Untitled sessions surface has_title=False so the UI can fall
+        # back to the context preview as the visible label.
+        untitled = ChatSessionFactory(user=self.user, title="")
+        ChatMessageFactory(
+            session=untitled,
+            role="user",
+            content="A bare question without a title",
+        )
+        result = self._run(self.user)
+        by_uuid = {e["uuid"]: e for e in result}
+        self.assertTrue(by_uuid[str(self.session_titled.uuid)]["has_title"])
+        self.assertFalse(by_uuid[str(untitled.uuid)]["has_title"])
+
+    def test_favorites_sort_to_top(self):
+        # The chronological ordering puts session_unrelated first
+        # (most-recently created in setUp); favoriting an earlier
+        # session should bump it above the unrelated one.
+        self.session_titled.is_favorited = True
+        self.session_titled.save(update_fields=["is_favorited"])
+        result = self._run(self.user)
+        ordered_uuids = [entry["uuid"] for entry in result]
+        # Favorite is now first regardless of -modified_at.
+        self.assertEqual(ordered_uuids[0], str(self.session_titled.uuid))
+
+    def test_favorites_only_filter(self):
+        self.session_titled.is_favorited = True
+        self.session_titled.save(update_fields=["is_favorited"])
+        form = ListChatSessionsForm(
+            {"user": self.user.id, "search": "", "favorites_only": True}
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        result = ListChatSessionsCommand(form).execute()
+        uuids = [entry["uuid"] for entry in result]
+        self.assertEqual(uuids, [str(self.session_titled.uuid)])
+
+    def test_preview_strips_context_wrapper(self):
+        # First user messages that include the context wrapper added
+        # by SendMessageCommand shouldn't blast that wrapper into the
+        # preview. The UI uses the preview as the label fallback for
+        # untitled chats, so a clean question is what we want.
+        wrapped = ChatSessionFactory(user=self.user, title="")
+        ChatMessageFactory(
+            session=wrapped,
+            role="user",
+            content=(
+                "**Context from my notes:**\n"
+                "• [block abc on page def] some context\n\n"
+                "**My question:**\n"
+                "Help me plan dinner"
+            ),
+        )
+        result = self._run(self.user)
+        by_uuid = {e["uuid"]: e for e in result}
+        preview = by_uuid[str(wrapped.uuid)]["preview"]
+        self.assertEqual(preview, "Help me plan dinner")
+        self.assertNotIn("Context from my notes", preview)

--- a/packages/django-app/app/ai_chat/test/test_reorder_favorited_chat_sessions_command.py
+++ b/packages/django-app/app/ai_chat/test/test_reorder_favorited_chat_sessions_command.py
@@ -1,0 +1,128 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from ai_chat.commands import ReorderFavoritedChatSessionsCommand
+from ai_chat.forms import ReorderFavoritedChatSessionsForm
+from ai_chat.repositories import ChatSessionRepository
+from ai_chat.test.helpers import ChatSessionFactory
+from core.test.helpers import UserFactory
+
+
+class TestReorderFavoritedChatSessionsCommand(TestCase):
+    def setUp(self):
+        self.user = UserFactory()
+        self.a = ChatSessionFactory(
+            user=self.user, title="alpha", is_favorited=True, favorite_position=0
+        )
+        self.b = ChatSessionFactory(
+            user=self.user, title="bravo", is_favorited=True, favorite_position=1
+        )
+        self.c = ChatSessionFactory(
+            user=self.user, title="charlie", is_favorited=True, favorite_position=2
+        )
+
+    def _run(self, *, session_uuids):
+        form = ReorderFavoritedChatSessionsForm(
+            {"user": self.user.id, "session_uuids": session_uuids}
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        return ReorderFavoritedChatSessionsCommand(form).execute()
+
+    def test_persists_full_explicit_ordering(self):
+        self._run(session_uuids=[str(self.c.uuid), str(self.a.uuid), str(self.b.uuid)])
+        self.a.refresh_from_db()
+        self.b.refresh_from_db()
+        self.c.refresh_from_db()
+        # New positions reflect the requested order, 0-indexed.
+        self.assertEqual(self.c.favorite_position, 0)
+        self.assertEqual(self.a.favorite_position, 1)
+        self.assertEqual(self.b.favorite_position, 2)
+
+    def test_partial_payload_keeps_omitted_favorites_at_end(self):
+        # Caller lists only b → b ends up first, the omitted a and c
+        # follow in their existing relative order so nothing silently
+        # drops off the Pinned section.
+        self._run(session_uuids=[str(self.b.uuid)])
+        self.a.refresh_from_db()
+        self.b.refresh_from_db()
+        self.c.refresh_from_db()
+        self.assertEqual(self.b.favorite_position, 0)
+        self.assertEqual(self.a.favorite_position, 1)
+        self.assertEqual(self.c.favorite_position, 2)
+
+    def test_rejects_uuid_not_in_user_favorites(self):
+        # An unfavorited chat (even owned by the same user) isn't part
+        # of the Pinned section; including its uuid in the payload is
+        # a client-state bug we want to surface, not a silent no-op.
+        unfavorited = ChatSessionFactory(user=self.user, is_favorited=False)
+        form = ReorderFavoritedChatSessionsForm(
+            {"user": self.user.id, "session_uuids": [str(unfavorited.uuid)]}
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        with self.assertRaises(ValidationError):
+            ReorderFavoritedChatSessionsCommand(form).execute()
+
+    def test_rejects_uuid_belonging_to_another_user(self):
+        other = UserFactory()
+        their_fav = ChatSessionFactory(user=other, is_favorited=True)
+        form = ReorderFavoritedChatSessionsForm(
+            {"user": self.user.id, "session_uuids": [str(their_fav.uuid)]}
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        with self.assertRaises(ValidationError):
+            ReorderFavoritedChatSessionsCommand(form).execute()
+
+    def test_form_rejects_duplicate_uuids(self):
+        form = ReorderFavoritedChatSessionsForm(
+            {
+                "user": self.user.id,
+                "session_uuids": [str(self.a.uuid), str(self.a.uuid)],
+            }
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("session_uuids", form.errors)
+
+
+class TestFavoritePositionAssignedOnPin(TestCase):
+    """set_favorited should append newly-favorited chats to the end
+    of the Pinned section so we don't shuffle already-pinned rows."""
+
+    def setUp(self):
+        self.user = UserFactory()
+
+    def test_first_favorite_gets_position_zero(self):
+        s = ChatSessionFactory(user=self.user, is_favorited=False)
+        ChatSessionRepository.set_favorited(
+            uuid=str(s.uuid), user=self.user, is_favorited=True
+        )
+        s.refresh_from_db()
+        self.assertEqual(s.favorite_position, 0)
+
+    def test_subsequent_favorites_append_to_end(self):
+        first = ChatSessionFactory(user=self.user, is_favorited=False)
+        second = ChatSessionFactory(user=self.user, is_favorited=False)
+
+        ChatSessionRepository.set_favorited(
+            uuid=str(first.uuid), user=self.user, is_favorited=True
+        )
+        ChatSessionRepository.set_favorited(
+            uuid=str(second.uuid), user=self.user, is_favorited=True
+        )
+
+        first.refresh_from_db()
+        second.refresh_from_db()
+        self.assertEqual(first.favorite_position, 0)
+        self.assertEqual(second.favorite_position, 1)
+
+    def test_unfavorite_leaves_remaining_positions_intact(self):
+        # Pulling a chat out of the Pinned section shouldn't renumber
+        # the others — favorite_position is only meaningful for
+        # is_favorited rows, and stale numbers stay harmless until the
+        # next reorder.
+        a = ChatSessionFactory(user=self.user, is_favorited=True, favorite_position=0)
+        b = ChatSessionFactory(user=self.user, is_favorited=True, favorite_position=1)
+        ChatSessionRepository.set_favorited(
+            uuid=str(a.uuid), user=self.user, is_favorited=False
+        )
+        b.refresh_from_db()
+        self.assertEqual(b.favorite_position, 1)

--- a/packages/django-app/app/ai_chat/test/test_set_chat_session_favorited_command.py
+++ b/packages/django-app/app/ai_chat/test/test_set_chat_session_favorited_command.py
@@ -1,0 +1,67 @@
+from django.test import TestCase
+
+from ai_chat.commands import SetChatSessionFavoritedCommand
+from ai_chat.forms import SetChatSessionFavoritedForm
+from ai_chat.test.helpers import ChatSessionFactory
+from core.test.helpers import UserFactory
+
+
+class TestSetChatSessionFavoritedCommand(TestCase):
+    def setUp(self):
+        self.user = UserFactory()
+        self.session = ChatSessionFactory(user=self.user, is_favorited=False)
+
+    def _run(self, *, user, session_uuid, is_favorited):
+        form = SetChatSessionFavoritedForm(
+            {
+                "user": user.id,
+                "session_id": str(session_uuid),
+                "is_favorited": is_favorited,
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        return SetChatSessionFavoritedCommand(form).execute()
+
+    def test_marks_session_as_favorited(self):
+        result = self._run(
+            user=self.user, session_uuid=self.session.uuid, is_favorited=True
+        )
+        self.assertEqual(result["uuid"], str(self.session.uuid))
+        self.assertTrue(result["is_favorited"])
+        self.session.refresh_from_db()
+        self.assertTrue(self.session.is_favorited)
+
+    def test_unfavorite_round_trip(self):
+        # favorite first, then unfavorite — both should persist
+        self._run(user=self.user, session_uuid=self.session.uuid, is_favorited=True)
+        result = self._run(
+            user=self.user, session_uuid=self.session.uuid, is_favorited=False
+        )
+        self.assertFalse(result["is_favorited"])
+        self.session.refresh_from_db()
+        self.assertFalse(self.session.is_favorited)
+
+    def test_rejects_session_owned_by_other_user(self):
+        other = UserFactory()
+        form = SetChatSessionFavoritedForm(
+            {
+                "user": other.id,
+                "session_id": str(self.session.uuid),
+                "is_favorited": True,
+            }
+        )
+        # The form's _ChatSessionLookupMixin scopes the lookup by user
+        # so cross-user requests fail validation rather than reaching
+        # the repository.
+        self.assertFalse(form.is_valid())
+        self.assertIn("__all__", form.errors)
+
+    def test_rejects_unknown_session(self):
+        form = SetChatSessionFavoritedForm(
+            {
+                "user": self.user.id,
+                "session_id": "00000000-0000-0000-0000-000000000000",
+                "is_favorited": True,
+            }
+        )
+        self.assertFalse(form.is_valid())

--- a/packages/django-app/app/ai_chat/test/test_update_chat_session_title_command.py
+++ b/packages/django-app/app/ai_chat/test/test_update_chat_session_title_command.py
@@ -1,0 +1,65 @@
+from django.test import TestCase
+
+from ai_chat.commands import UpdateChatSessionTitleCommand
+from ai_chat.forms import UpdateChatSessionTitleForm
+from ai_chat.test.helpers import ChatSessionFactory
+from core.test.helpers import UserFactory
+
+
+class TestUpdateChatSessionTitleCommand(TestCase):
+    def setUp(self):
+        self.user = UserFactory()
+        self.session = ChatSessionFactory(user=self.user, title="old title")
+
+    def _run(self, *, user, session_uuid, title):
+        form = UpdateChatSessionTitleForm(
+            {
+                "user": user.id,
+                "session_id": str(session_uuid),
+                "title": title,
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        return UpdateChatSessionTitleCommand(form).execute()
+
+    def test_updates_title_for_owner(self):
+        result = self._run(
+            user=self.user,
+            session_uuid=self.session.uuid,
+            title="Recipe brainstorm",
+        )
+        self.assertEqual(result["title"], "Recipe brainstorm")
+        self.session.refresh_from_db()
+        self.assertEqual(self.session.title, "Recipe brainstorm")
+
+    def test_trims_whitespace(self):
+        self._run(
+            user=self.user,
+            session_uuid=self.session.uuid,
+            title="   padded   ",
+        )
+        self.session.refresh_from_db()
+        self.assertEqual(self.session.title, "padded")
+
+    def test_rejects_blank_title(self):
+        form = UpdateChatSessionTitleForm(
+            {
+                "user": self.user.id,
+                "session_id": str(self.session.uuid),
+                "title": "   ",
+            }
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("title", form.errors)
+
+    def test_rejects_session_owned_by_other_user(self):
+        other = UserFactory()
+        form = UpdateChatSessionTitleForm(
+            {
+                "user": other.id,
+                "session_id": str(self.session.uuid),
+                "title": "Hostile rename",
+            }
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("__all__", form.errors)

--- a/packages/django-app/app/ai_chat/urls.py
+++ b/packages/django-app/app/ai_chat/urls.py
@@ -23,6 +23,16 @@ urlpatterns = [
         name="chat_session_detail",
     ),
     path(
+        "sessions/<str:session_id>/favorite/",
+        views.set_chat_session_favorited,
+        name="set_chat_session_favorited",
+    ),
+    path(
+        "sessions/<str:session_id>/title/",
+        views.update_chat_session_title,
+        name="update_chat_session_title",
+    ),
+    path(
         "messages/<str:message_uuid>/follow/",
         views.FollowMessageView.as_view(),
         name="follow_message",

--- a/packages/django-app/app/ai_chat/urls.py
+++ b/packages/django-app/app/ai_chat/urls.py
@@ -18,6 +18,11 @@ urlpatterns = [
     ),
     path("sessions/", views.chat_sessions, name="chat_sessions"),
     path(
+        "sessions/reorder-favorites/",
+        views.reorder_favorited_chat_sessions,
+        name="reorder_favorited_chat_sessions",
+    ),
+    path(
         "sessions/<str:session_id>/",
         views.chat_session_detail,
         name="chat_session_detail",

--- a/packages/django-app/app/ai_chat/views.py
+++ b/packages/django-app/app/ai_chat/views.py
@@ -14,10 +14,18 @@ from .commands import (
     ListChatSessionsCommand,
     ResumeApprovalCommand,
     SendMessageCommand,
+    SetChatSessionFavoritedCommand,
     StreamSendMessageCommand,
+    UpdateChatSessionTitleCommand,
 )
 from .commands.send_message_command import SendMessageCommandError
-from .forms import ListChatSessionsForm, ResumeApprovalForm, SendMessageForm
+from .forms import (
+    ListChatSessionsForm,
+    ResumeApprovalForm,
+    SendMessageForm,
+    SetChatSessionFavoritedForm,
+    UpdateChatSessionTitleForm,
+)
 from .models import (
     AIModel,
     AIProvider,
@@ -283,8 +291,14 @@ def chat_sessions(request):
     matching session.
     """
     try:
+        favorites_param = request.GET.get("favorites_only", "")
+        favorites_only = favorites_param.lower() in ("1", "true", "yes")
         form = ListChatSessionsForm(
-            {"user": request.user.id, "search": request.GET.get("search", "")}
+            {
+                "user": request.user.id,
+                "search": request.GET.get("search", ""),
+                "favorites_only": favorites_only,
+            }
         )
         if not form.is_valid():
             return Response(
@@ -351,6 +365,8 @@ def chat_session_detail(request, session_id):
         session_data = {
             "uuid": str(session.uuid),
             "title": session.title,
+            "has_title": bool(session.title),
+            "is_favorited": bool(session.is_favorited),
             "created_at": session.created_at.isoformat(),
             "modified_at": session.modified_at.isoformat(),
             "messages": messages_data,
@@ -369,6 +385,73 @@ def chat_session_detail(request, session_id):
         )
         return Response(
             {"success": False, "error": "Failed to fetch chat session"},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def set_chat_session_favorited(request, session_id):
+    """Pin or unpin a chat session in the history list.
+
+    Body: {"is_favorited": bool}. The form rejects requests that don't
+    own the session, so a 404 here means either the session is gone or
+    the requester is not its owner.
+    """
+    try:
+        form = SetChatSessionFavoritedForm(
+            {
+                "user": request.user.id,
+                "session_id": session_id,
+                "is_favorited": bool(request.data.get("is_favorited")),
+            }
+        )
+        if not form.is_valid():
+            return Response(
+                {"success": False, "errors": form.errors},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        data = SetChatSessionFavoritedCommand(form).execute()
+        return Response({"success": True, "data": data})
+    except Exception as e:
+        logger.error(
+            f"Error favoriting session {session_id} for user {request.user.id}: {e}"
+        )
+        return Response(
+            {"success": False, "error": "Failed to update favorite state"},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def update_chat_session_title(request, session_id):
+    """Rename a chat session.
+
+    Body: {"title": str}. Blank / whitespace-only titles are rejected
+    by the form.
+    """
+    try:
+        form = UpdateChatSessionTitleForm(
+            {
+                "user": request.user.id,
+                "session_id": session_id,
+                "title": request.data.get("title", ""),
+            }
+        )
+        if not form.is_valid():
+            return Response(
+                {"success": False, "errors": form.errors},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        data = UpdateChatSessionTitleCommand(form).execute()
+        return Response({"success": True, "data": data})
+    except Exception as e:
+        logger.error(
+            f"Error renaming session {session_id} for user {request.user.id}: {e}"
+        )
+        return Response(
+            {"success": False, "error": "Failed to rename chat session"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 

--- a/packages/django-app/app/ai_chat/views.py
+++ b/packages/django-app/app/ai_chat/views.py
@@ -2,6 +2,7 @@ import json
 import logging
 from typing import TypedDict
 
+from django.core.exceptions import ValidationError
 from django.http import StreamingHttpResponse
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
@@ -12,6 +13,7 @@ from rest_framework.views import APIView
 
 from .commands import (
     ListChatSessionsCommand,
+    ReorderFavoritedChatSessionsCommand,
     ResumeApprovalCommand,
     SendMessageCommand,
     SetChatSessionFavoritedCommand,
@@ -21,6 +23,7 @@ from .commands import (
 from .commands.send_message_command import SendMessageCommandError
 from .forms import (
     ListChatSessionsForm,
+    ReorderFavoritedChatSessionsForm,
     ResumeApprovalForm,
     SendMessageForm,
     SetChatSessionFavoritedForm,
@@ -419,6 +422,45 @@ def set_chat_session_favorited(request, session_id):
         )
         return Response(
             {"success": False, "error": "Failed to update favorite state"},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def reorder_favorited_chat_sessions(request):
+    """Persist a new drag-sorted order on the Pinned section.
+
+    Body: {"session_uuids": [uuid, uuid, ...]} — the desired full
+    ordering of the user's favorited chats.
+    """
+    try:
+        form = ReorderFavoritedChatSessionsForm(
+            {
+                "user": request.user.id,
+                "session_uuids": request.data.get("session_uuids", []),
+            }
+        )
+        if not form.is_valid():
+            return Response(
+                {"success": False, "errors": form.errors},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        data = ReorderFavoritedChatSessionsCommand(form).execute()
+        return Response({"success": True, "data": data})
+    except ValidationError as e:
+        # Raised by the command when the payload mentions chats the
+        # user doesn't own / isn't currently favoriting.
+        return Response(
+            {"success": False, "error": str(e)},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    except Exception as e:
+        logger.error(
+            f"Error reordering favorited chats for user {request.user.id}: {e}"
+        )
+        return Response(
+            {"success": False, "error": "Failed to reorder favorited chats"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 

--- a/packages/django-app/app/knowledge/commands/__init__.py
+++ b/packages/django-app/app/knowledge/commands/__init__.py
@@ -3,6 +3,7 @@ from .bulk_cancel_reminders_command import BulkCancelRemindersCommand
 from .bulk_clear_schedule_command import BulkClearScheduleCommand
 from .bulk_delete_blocks_command import BulkDeleteBlocksCommand
 from .bulk_move_blocks_command import BulkMoveBlocksCommand
+from .bulk_move_blocks_to_page_command import BulkMoveBlocksToPageCommand
 from .bulk_schedule_command import BulkScheduleCommand
 from .bulk_set_block_type_command import BulkSetBlockTypeCommand
 from .bulk_snooze_command import BulkSnoozeCommand

--- a/packages/django-app/app/knowledge/commands/bulk_move_blocks_to_page_command.py
+++ b/packages/django-app/app/knowledge/commands/bulk_move_blocks_to_page_command.py
@@ -1,0 +1,88 @@
+from typing import List, TypedDict
+
+from django.db import transaction
+
+from common.commands.abstract_base_command import AbstractBaseCommand
+
+from ..forms.bulk_move_blocks_to_page_form import BulkMoveBlocksToPageForm
+from ..forms.move_block_to_page_form import MoveBlockToPageForm
+from ..models import PageData
+from ..repositories import BlockRepository
+from .move_block_to_page_command import MoveBlockToPageCommand
+
+
+class BulkMoveBlocksToPageCommand(AbstractBaseCommand):
+    """Move a list of blocks to an arbitrary target page as siblings.
+
+    Mirrors BulkMoveBlocksCommand but the target is an explicit page
+    rather than a daily by date. Per-block hierarchy within the
+    selection is preserved: blocks whose parent is also in the
+    selection are not promoted — they ride along with the ancestor
+    that MoveBlockToPageCommand drags through via
+    BlockRepository.get_block_descendants. Top-level blocks (whose
+    parent is not in the selection) are moved individually in
+    document order so their relative order on the target page
+    matches the source.
+    """
+
+    def __init__(self, form: BulkMoveBlocksToPageForm) -> None:
+        self.form = form
+
+    def execute(self) -> "BulkMoveBlocksToPageData":
+        super().execute()
+
+        user = self.form.cleaned_data["user"]
+        uuids: List[str] = self.form.cleaned_data["blocks"]
+        target_page = self.form.cleaned_data["target_page"]
+
+        blocks_qs = BlockRepository.get_queryset().filter(user=user, uuid__in=uuids)
+        blocks_by_uuid = {str(b.uuid): b for b in blocks_qs}
+        selected_uuids = set(blocks_by_uuid.keys())
+
+        # Find blocks whose parent isn't in the selection — those are the
+        # "top" of the selected forest and the only ones we need to move
+        # explicitly (their descendants follow). Order them in document
+        # order: first by page, then by tree position, so siblings on
+        # the same page stay adjacent and in their original sequence on
+        # the target.
+        top_blocks = [
+            block
+            for uuid_str, block in blocks_by_uuid.items()
+            if not (block.parent and str(block.parent.uuid) in selected_uuids)
+        ]
+        top_blocks.sort(key=lambda b: (b.page_id, b.order, str(b.uuid)))
+
+        moved = 0
+        skipped = len(uuids) - len(selected_uuids)
+        with transaction.atomic():
+            for block in top_blocks:
+                inner = MoveBlockToPageForm(
+                    {
+                        "user": user.id,
+                        "block": str(block.uuid),
+                        "target_page": str(target_page.uuid),
+                    }
+                )
+                if not inner.is_valid():
+                    skipped += 1
+                    continue
+                result = MoveBlockToPageCommand(inner).execute()
+                if result.get("moved"):
+                    moved += 1
+
+        return {
+            "moved_count": moved,
+            "skipped_count": skipped,
+            "target_page": target_page.to_dict(),
+            "message": (
+                f"Moved {moved} block{'s' if moved != 1 else ''} to "
+                f"{target_page.title}"
+            ),
+        }
+
+
+class BulkMoveBlocksToPageData(TypedDict):
+    moved_count: int
+    skipped_count: int
+    target_page: PageData
+    message: str

--- a/packages/django-app/app/knowledge/commands/consume_reminder_action_command.py
+++ b/packages/django-app/app/knowledge/commands/consume_reminder_action_command.py
@@ -108,7 +108,16 @@ class ConsumeReminderActionCommand(AbstractBaseCommand):
         now,
     ) -> None:
         if action == ReminderAction.ACTION_COMPLETE:
-            self._mark_block_done(block)
+            self._set_block_type(block, "done")
+            return
+
+        if action == ReminderAction.ACTION_MARK_DOING:
+            # The block-completed guard upstream already short-circuited
+            # done/wontdo, so a "mark doing" click here can safely flip
+            # the block to the doing state regardless of its prior type
+            # (todo, bullet, later, etc.). SetBlockTypeCommand no-ops if
+            # it's already doing.
+            self._set_block_type(block, "doing")
             return
 
         delta = _SNOOZE_DELTAS.get(action)
@@ -120,12 +129,17 @@ class ConsumeReminderActionCommand(AbstractBaseCommand):
         self._snooze_reminder(reminder, delta, now)
 
     @staticmethod
-    def _mark_block_done(block: Block) -> None:
-        # Routing through SetBlockTypeCommand keeps the completion
+    def _set_block_type(block: Block, block_type: str) -> None:
+        # Routing through SetBlockTypeCommand keeps the transition
         # behavior consistent with toggle-todo / chat tools — including
-        # the side-effect that flips any pending reminders to skipped.
+        # the content-prefix swap and the side-effect that flips any
+        # pending reminders to skipped on entering a terminal state.
         set_form = SetBlockTypeForm(
-            {"user": block.user_id, "block": str(block.uuid), "block_type": "done"}
+            {
+                "user": block.user_id,
+                "block": str(block.uuid),
+                "block_type": block_type,
+            }
         )
         if not set_form.is_valid():
             raise AssertionError(f"SetBlockTypeForm invalid: {set_form.errors}")
@@ -161,6 +175,8 @@ _SNOOZE_DELTAS = {
 def _executed_detail(action: str) -> str:
     if action == ReminderAction.ACTION_COMPLETE:
         return "Marked the block as done."
+    if action == ReminderAction.ACTION_MARK_DOING:
+        return "Marked the block as doing."
     if action == ReminderAction.ACTION_SNOOZE_1H:
         return "Snoozed for 1 hour."
     if action == ReminderAction.ACTION_SNOOZE_1D:

--- a/packages/django-app/app/knowledge/commands/send_due_reminders_command.py
+++ b/packages/django-app/app/knowledge/commands/send_due_reminders_command.py
@@ -281,8 +281,13 @@ def _author_block(environment: str, pr_number: str, pr_url: str) -> dict:
     return author
 
 
+# Order matters: this is the order the links appear in the embed.
+# "Mark doing" sits between "Mark done" and the snoozes so the two
+# status-change actions cluster together on the left and the deferrals
+# cluster on the right.
 _ACTION_LABELS = [
     (ReminderAction.ACTION_COMPLETE, "Mark done"),
+    (ReminderAction.ACTION_MARK_DOING, "Mark doing"),
     (ReminderAction.ACTION_SNOOZE_1H, "Snooze 1h"),
     (ReminderAction.ACTION_SNOOZE_1D, "Snooze 1d"),
 ]

--- a/packages/django-app/app/knowledge/forms/__init__.py
+++ b/packages/django-app/app/knowledge/forms/__init__.py
@@ -3,6 +3,7 @@ from .bulk_cancel_reminders_form import BulkCancelRemindersForm
 from .bulk_clear_schedule_form import BulkClearScheduleForm
 from .bulk_delete_blocks_form import BulkDeleteBlocksForm
 from .bulk_move_blocks_form import BulkMoveBlocksForm
+from .bulk_move_blocks_to_page_form import BulkMoveBlocksToPageForm
 from .bulk_schedule_form import BulkScheduleForm
 from .bulk_set_block_type_form import BulkSetBlockTypeForm
 from .bulk_snooze_form import BulkSnoozeForm

--- a/packages/django-app/app/knowledge/forms/bulk_move_blocks_to_page_form.py
+++ b/packages/django-app/app/knowledge/forms/bulk_move_blocks_to_page_form.py
@@ -1,0 +1,66 @@
+import uuid as uuid_lib
+from typing import List
+
+from django import forms
+from django.core.exceptions import ValidationError
+
+from common.forms import BaseForm, UUIDModelChoiceField
+from core.models import User
+from core.repositories import UserRepository
+
+from ..models import Page
+from ..repositories.page_repository import PageRepository
+
+
+class BulkMoveBlocksToPageForm(BaseForm):
+    """Inputs for moving a list of blocks to an arbitrary target page.
+
+    Sibling of BulkMoveBlocksForm — same `blocks` validation rules,
+    but the target is an explicit Page UUID instead of a date. We
+    never auto-create pages on this path; the caller picks an
+    existing one via the page-picker modal.
+    """
+
+    user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
+    blocks = forms.JSONField()
+    target_page = UUIDModelChoiceField(
+        queryset=PageRepository.get_queryset(), required=True
+    )
+
+    def clean_user(self) -> User:
+        user = self.cleaned_data.get("user")
+        if not user:
+            raise ValidationError("User is required")
+        return user
+
+    def clean_blocks(self) -> List[str]:
+        raw = self.cleaned_data.get("blocks")
+
+        if not isinstance(raw, list):
+            raise ValidationError("blocks must be a list")
+        if not raw:
+            raise ValidationError("blocks list must not be empty")
+
+        normalized: List[str] = []
+        seen = set()
+        for i, item in enumerate(raw):
+            try:
+                parsed = uuid_lib.UUID(str(item))
+            except (ValueError, AttributeError, TypeError):
+                raise ValidationError(
+                    f"Item at index {i} has an invalid UUID: {item!r}"
+                )
+            s = str(parsed)
+            if s in seen:
+                continue
+            seen.add(s)
+            normalized.append(s)
+
+        return normalized
+
+    def clean_target_page(self) -> Page:
+        page = self.cleaned_data.get("target_page")
+        user = self.cleaned_data.get("user")
+        if page and user and page.user != user:
+            raise ValidationError("Target page not found")
+        return page

--- a/packages/django-app/app/knowledge/migrations/0035_reminderaction_mark_doing.py
+++ b/packages/django-app/app/knowledge/migrations/0035_reminderaction_mark_doing.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("knowledge", "0034_page_embedded_view_daily_scope"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="reminderaction",
+            name="action",
+            field=models.CharField(
+                choices=[
+                    ("complete", "Mark complete"),
+                    ("mark_doing", "Mark doing"),
+                    ("snooze_1h", "Snooze 1 hour"),
+                    ("snooze_1d", "Snooze 1 day"),
+                ],
+                max_length=32,
+            ),
+        ),
+    ]

--- a/packages/django-app/app/knowledge/models/reminder_action.py
+++ b/packages/django-app/app/knowledge/models/reminder_action.py
@@ -33,10 +33,12 @@ class ReminderAction(UUIDModelMixin, CRUDTimestampsMixin):
     """
 
     ACTION_COMPLETE = "complete"
+    ACTION_MARK_DOING = "mark_doing"
     ACTION_SNOOZE_1H = "snooze_1h"
     ACTION_SNOOZE_1D = "snooze_1d"
     ACTION_CHOICES = [
         (ACTION_COMPLETE, "Mark complete"),
+        (ACTION_MARK_DOING, "Mark doing"),
         (ACTION_SNOOZE_1H, "Snooze 1 hour"),
         (ACTION_SNOOZE_1D, "Snooze 1 day"),
     ]

--- a/packages/django-app/app/knowledge/services/reminder_actions.py
+++ b/packages/django-app/app/knowledge/services/reminder_actions.py
@@ -17,13 +17,15 @@ def create_action_tokens(
 
     Returns a `{action: ReminderAction}` dict so callers can look up
     the per-action token without re-querying. `actions` defaults to
-    the full set we surface in Discord (`complete`, `snooze_1h`,
-    `snooze_1d`) — pass a subset if you ever want to hide an action.
+    the full set we surface in Discord (`complete`, `mark_doing`,
+    `snooze_1h`, `snooze_1d`) — pass a subset if you ever want to
+    hide an action.
     """
     moment = now or timezone.now()
     expires_at = moment + (ttl or ReminderAction.DEFAULT_TTL)
     chosen = actions or [
         ReminderAction.ACTION_COMPLETE,
+        ReminderAction.ACTION_MARK_DOING,
         ReminderAction.ACTION_SNOOZE_1H,
         ReminderAction.ACTION_SNOOZE_1D,
     ]

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -3893,6 +3893,126 @@ a.sidebar-item:visited {
   font-style: italic;
 }
 
+/* Favorites + rename additions to the chat-history dropdown.
+   The "Pinned" group is rendered above the chronological list when
+   favorites exist and the favorites-only filter is off. */
+
+.history-filters {
+  padding: 0.4rem 0.75rem;
+  border-bottom: 1px solid var(--border-secondary);
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.history-favorites-toggle {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-secondary);
+  border-radius: 3px;
+  padding: 0.25rem 0.6rem;
+  font-family: inherit;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.history-favorites-toggle:hover {
+  color: var(--text-primary);
+  background: var(--hover-bg);
+  border-color: var(--text-primary);
+}
+
+.history-favorites-toggle.active {
+  color: var(--text-primary);
+  border-color: var(--text-primary);
+  background: var(--tag-bg);
+}
+
+.session-group-header {
+  padding: 0.4rem 1rem 0.2rem;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border-secondary);
+  background: var(--bg-secondary, transparent);
+}
+
+.session-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.session-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.session-favorite-btn,
+.session-rename-btn {
+  flex: 0 0 auto;
+  background: transparent;
+  color: var(--text-muted);
+  border: none;
+  border-radius: 3px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.session-favorite-btn:hover,
+.session-rename-btn:hover {
+  color: var(--text-primary);
+  background: var(--hover-bg);
+}
+
+.session-favorite-btn.favorited {
+  color: var(--text-primary);
+}
+
+.session-title.untitled {
+  color: var(--text-secondary);
+  font-style: italic;
+  font-weight: 400;
+}
+
+.session-rename {
+  margin-bottom: 0.25rem;
+}
+
+.session-rename-input {
+  width: 100%;
+  padding: 0.3rem 0.5rem;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--text-primary);
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: 0.85rem;
+}
+
+.session-rename-input:focus {
+  outline: none;
+}
+
+.session-item.renaming {
+  background: var(--hover-bg);
+}
+
 /* Settings Modal Tabs */
 .settings-tabs {
   display: flex;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4013,6 +4013,48 @@ a.sidebar-item:visited {
   background: var(--hover-bg);
 }
 
+/* Drag-to-reorder affordances for the Pinned section in the chat
+   history dropdown. The grip glyph sits to the left of the favorite
+   star so the row reads "drag · pin · title". */
+
+.session-pinned-list {
+  position: relative;
+}
+
+.session-item[draggable="true"] {
+  cursor: grab;
+}
+
+.session-item[draggable="true"].is-dragging {
+  opacity: 0.5;
+  cursor: grabbing;
+}
+
+.session-pinned-grip {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1;
+  cursor: grab;
+  user-select: none;
+}
+
+.session-item:hover .session-pinned-grip {
+  color: var(--text-secondary);
+}
+
+.session-pinned-drop-indicator {
+  height: 2px;
+  margin: 0 0.5rem;
+  background: var(--text-primary);
+  pointer-events: none;
+}
+
 /* Settings Modal Tabs */
 .settings-tabs {
   display: flex;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/ChatHistory.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/ChatHistory.js
@@ -22,6 +22,13 @@ const ChatHistory = {
       editingUuid: null,
       editingTitle: "",
       savingTitle: false,
+      // Drag-to-reorder state for the Pinned section. Mirrors the
+      // LeftNav favorites pattern: dragIndex is the row being dragged,
+      // dropIndex is the gap the cursor is hovering between. Both are
+      // null when no drag is active. We always operate against the
+      // favoritedSessions slice — chronological rows are not draggable.
+      favoriteDragIndex: null,
+      favoriteDropIndex: null,
     };
   },
   computed: {
@@ -200,6 +207,82 @@ const ChatHistory = {
     formatDate(dateString) {
       return new Date(dateString).toLocaleDateString();
     },
+    onFavoriteDragStart(event, index) {
+      this.favoriteDragIndex = index;
+      this.favoriteDropIndex = index;
+      // Firefox needs setData to actually fire the drag. Payload is
+      // irrelevant — the reorder is local component state.
+      if (event.dataTransfer) {
+        event.dataTransfer.effectAllowed = "move";
+        try {
+          event.dataTransfer.setData("text/plain", String(index));
+        } catch (_) {
+          // Some sandboxed contexts throw on setData; the drag still
+          // works without the payload.
+        }
+      }
+    },
+    onFavoriteDragOver(event, index) {
+      if (this.favoriteDragIndex === null) return;
+      event.preventDefault();
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = "move";
+      }
+      // Halve the row to decide before/after — same feel as the
+      // LeftNav favorites list.
+      const rect = event.currentTarget.getBoundingClientRect();
+      const before = event.clientY < rect.top + rect.height / 2;
+      this.favoriteDropIndex = before ? index : index + 1;
+    },
+    onFavoriteDragLeaveList() {
+      this.favoriteDropIndex = null;
+    },
+    async onFavoriteDrop(event) {
+      event.preventDefault();
+      const fromIndex = this.favoriteDragIndex;
+      let toIndex = this.favoriteDropIndex;
+      this.favoriteDragIndex = null;
+      this.favoriteDropIndex = null;
+      if (fromIndex === null || toIndex === null) return;
+      if (toIndex > fromIndex) toIndex -= 1;
+      if (toIndex === fromIndex) return;
+
+      // Work off the favorited slice — chronological rows aren't
+      // drag sources, so a successful drop only ever reorders within
+      // the Pinned section.
+      const current = this.favoritedSessions;
+      const next = current.slice();
+      const [moved] = next.splice(fromIndex, 1);
+      next.splice(toIndex, 0, moved);
+
+      // Optimistic: rebuild this.sessions so the UI snaps before the
+      // round-trip. Favorites first (in the new order), then the
+      // unchanged chronological tail.
+      const previous = this.sessions.slice();
+      this.sessions = [...next, ...this.chronologicalSessions];
+
+      try {
+        const result = await window.apiService.reorderFavoritedChatSessions(
+          next.map((s) => s.uuid)
+        );
+        if (!result || !result.success) {
+          this.sessions = previous;
+          this.error = "failed to reorder favorites";
+          return;
+        }
+        // Trust the server's canonical ordering — refetch with current
+        // filters so chronological rows / search snippets stay accurate.
+        this.loadSessions(this.searchQuery);
+      } catch (err) {
+        console.error("failed to reorder favorited chats:", err);
+        this.sessions = previous;
+        this.error = "failed to reorder favorites";
+      }
+    },
+    onFavoriteDragEnd() {
+      this.favoriteDragIndex = null;
+      this.favoriteDropIndex = null;
+    },
     favoriteLabel(session) {
       return session.is_favorited ? "Unpin chat" : "Pin chat";
     },
@@ -263,20 +346,39 @@ const ChatHistory = {
               <div v-if="showPinnedSection" class="session-group-header">Pinned</div>
               <template v-if="showPinnedSection">
                 <div
-                  v-for="session in favoritedSessions"
-                  :key="'fav-' + session.uuid"
-                  class="session-item"
-                  :class="{ favorited: session.is_favorited, renaming: editingUuid === session.uuid }"
-                  @click="selectSession(session)"
+                  class="session-pinned-list"
+                  @dragleave.self="onFavoriteDragLeaveList"
+                  @drop="onFavoriteDrop"
+                  @dragover.prevent
                 >
-                  <div class="session-row">
-                    <button
-                      type="button"
-                      class="session-favorite-btn favorited"
-                      @click.stop="toggleFavorite(session)"
-                      :title="favoriteLabel(session)"
-                      :aria-label="favoriteLabel(session)"
-                    >{{ favoriteGlyph(session) }}</button>
+                  <template v-for="(session, index) in favoritedSessions" :key="'fav-' + session.uuid">
+                    <div
+                      v-if="favoriteDropIndex === index && favoriteDragIndex !== null"
+                      class="session-pinned-drop-indicator"
+                      aria-hidden="true"
+                    ></div>
+                    <div
+                      class="session-item"
+                      :class="{
+                        favorited: session.is_favorited,
+                        renaming: editingUuid === session.uuid,
+                        'is-dragging': favoriteDragIndex === index,
+                      }"
+                      draggable="true"
+                      @dragstart="onFavoriteDragStart($event, index)"
+                      @dragover="onFavoriteDragOver($event, index)"
+                      @dragend="onFavoriteDragEnd"
+                      @click="selectSession(session)"
+                    >
+                      <div class="session-row">
+                        <span class="session-pinned-grip" aria-hidden="true" title="Drag to reorder">⋮⋮</span>
+                        <button
+                          type="button"
+                          class="session-favorite-btn favorited"
+                          @click.stop="toggleFavorite(session)"
+                          :title="favoriteLabel(session)"
+                          :aria-label="favoriteLabel(session)"
+                        >{{ favoriteGlyph(session) }}</button>
                     <div class="session-main">
                       <div
                         v-if="editingUuid === session.uuid"
@@ -315,15 +417,22 @@ const ChatHistory = {
                         <span class="session-count">{{ session.message_count }} messages</span>
                       </div>
                     </div>
-                    <button
-                      v-if="editingUuid !== session.uuid"
-                      type="button"
-                      class="session-rename-btn"
-                      @click.stop="startRename(session)"
-                      title="Rename chat"
-                      aria-label="Rename chat"
-                    >✎</button>
-                  </div>
+                        <button
+                          v-if="editingUuid !== session.uuid"
+                          type="button"
+                          class="session-rename-btn"
+                          @click.stop="startRename(session)"
+                          title="Rename chat"
+                          aria-label="Rename chat"
+                        >✎</button>
+                      </div>
+                    </div>
+                  </template>
+                  <div
+                    v-if="favoriteDropIndex === favoritedSessions.length && favoriteDragIndex !== null"
+                    class="session-pinned-drop-indicator"
+                    aria-hidden="true"
+                  ></div>
                 </div>
                 <div v-if="chronologicalSessions.length > 0" class="session-group-header">
                   All chats

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/ChatHistory.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/ChatHistory.js
@@ -13,7 +13,30 @@ const ChatHistory = {
       // don't want to be unkind to the DB).
       searchQuery: "",
       _searchToken: 0,
+      // When on, the server filters to favorited sessions only. The
+      // pinned section above the chronological list still shows
+      // favorites first; this toggle hides the chronological half.
+      favoritesOnly: false,
+      // uuid of the row currently being renamed inline. Null when no
+      // row is in edit mode.
+      editingUuid: null,
+      editingTitle: "",
+      savingTitle: false,
     };
+  },
+  computed: {
+    favoritedSessions() {
+      return this.sessions.filter((s) => s.is_favorited);
+    },
+    chronologicalSessions() {
+      return this.sessions.filter((s) => !s.is_favorited);
+    },
+    showPinnedSection() {
+      // Hide the "Pinned" header when the favorites filter is on —
+      // every row in the list is already a favorite, so a separate
+      // section would just be visual noise.
+      return !this.favoritesOnly && this.favoritedSessions.length > 0;
+    },
   },
   async mounted() {
     await this.loadSessions();
@@ -35,7 +58,10 @@ const ChatHistory = {
       this.error = null;
       const myToken = ++this._searchToken;
       try {
-        const result = await window.apiService.getChatSessions(search);
+        const result = await window.apiService.getChatSessions(
+          search,
+          this.favoritesOnly
+        );
         // Drop late responses so a slow query for "foo" doesn't
         // overwrite the fresh result for "foobar".
         if (myToken !== this._searchToken) return;
@@ -60,6 +86,8 @@ const ChatHistory = {
           const input = this.$refs.searchInput;
           if (input) input.focus();
         });
+      } else {
+        this.cancelRename();
       }
     },
     onSearchInput() {
@@ -73,6 +101,10 @@ const ChatHistory = {
       if (this._searchTimer) clearTimeout(this._searchTimer);
       this.loadSessions("");
     },
+    toggleFavoritesFilter() {
+      this.favoritesOnly = !this.favoritesOnly;
+      this.loadSessions(this.searchQuery);
+    },
     onSessionsChanged() {
       // Re-fetch with the current search query so an externally-
       // triggered create / delete (e.g. starting a new chat from a
@@ -80,11 +112,101 @@ const ChatHistory = {
       this.loadSessions(this.searchQuery);
     },
     async selectSession(session) {
+      // Don't navigate while the user is renaming this row — the
+      // click on the input would otherwise bubble up and load the
+      // chat, losing their edits.
+      if (this.editingUuid === session.uuid) return;
       this.$emit("session-selected", session);
       this.isOpen = false; // Close the history panel after selecting a session
     },
+    async toggleFavorite(session) {
+      const desired = !session.is_favorited;
+      // Optimistic: flip locally so the row jumps to / leaves the
+      // pinned section immediately. Re-fetch on success to lock in
+      // the server's canonical ordering; revert on failure.
+      session.is_favorited = desired;
+      try {
+        const result = await window.apiService.setChatSessionFavorited(
+          session.uuid,
+          desired
+        );
+        if (!result || !result.success) {
+          session.is_favorited = !desired;
+          return;
+        }
+        // Reload so the new row order (favorites-first) matches the
+        // server's ordering exactly.
+        this.loadSessions(this.searchQuery);
+      } catch (err) {
+        console.error("failed to toggle favorite:", err);
+        session.is_favorited = !desired;
+      }
+    },
+    startRename(session) {
+      this.editingUuid = session.uuid;
+      // Seed the input with the curated title when one exists,
+      // otherwise leave it blank so the user starts from scratch
+      // rather than editing the context-derived preview.
+      this.editingTitle = session.has_title ? session.title : "";
+      this.$nextTick(() => {
+        const input = this.$refs[`rename-input-${session.uuid}`];
+        const el = Array.isArray(input) ? input[0] : input;
+        if (el) {
+          el.focus();
+          el.select();
+        }
+      });
+    },
+    cancelRename() {
+      this.editingUuid = null;
+      this.editingTitle = "";
+      this.savingTitle = false;
+    },
+    async saveRename(session) {
+      const trimmed = (this.editingTitle || "").trim();
+      if (!trimmed) {
+        this.cancelRename();
+        return;
+      }
+      if (session.has_title && trimmed === session.title) {
+        this.cancelRename();
+        return;
+      }
+      this.savingTitle = true;
+      try {
+        const result = await window.apiService.updateChatSessionTitle(
+          session.uuid,
+          trimmed
+        );
+        if (result && result.success) {
+          session.title = result.data.title;
+          session.has_title = true;
+        }
+      } catch (err) {
+        console.error("failed to rename chat:", err);
+      } finally {
+        this.cancelRename();
+      }
+    },
+    onRenameKeydown(session, event) {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        this.saveRename(session);
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        this.cancelRename();
+      }
+    },
     formatDate(dateString) {
       return new Date(dateString).toLocaleDateString();
+    },
+    favoriteLabel(session) {
+      return session.is_favorited ? "Unpin chat" : "Pin chat";
+    },
+    favoriteGlyph(session) {
+      // Filled vs hollow star — both render as monochrome geometric
+      // glyphs per the UI conventions (no emoji).
+      return session.is_favorited ? "★" : "☆";
     },
   },
   template: `
@@ -117,28 +239,158 @@ const ChatHistory = {
               aria-label="Clear search"
             >×</button>
           </div>
+          <div class="history-filters">
+            <button
+              type="button"
+              class="history-favorites-toggle"
+              :class="{ active: favoritesOnly }"
+              @click="toggleFavoritesFilter"
+              :title="favoritesOnly ? 'Show all chats' : 'Show favorites only'"
+              :aria-pressed="favoritesOnly"
+            >{{ favoritesOnly ? '★ Favorites only' : '☆ Show favorites only' }}</button>
+          </div>
           <div class="history-content">
             <div v-if="loading" class="loading">Loading...</div>
             <div v-else-if="error" class="error">{{ error }}</div>
             <div v-else-if="sessions.length === 0" class="empty">
-              {{ searchQuery ? 'No chats match this search' : 'No chat history yet' }}
+              {{
+                favoritesOnly
+                  ? 'No favorited chats yet'
+                  : (searchQuery ? 'No chats match this search' : 'No chat history yet')
+              }}
             </div>
             <div v-else class="sessions-list">
+              <div v-if="showPinnedSection" class="session-group-header">Pinned</div>
+              <template v-if="showPinnedSection">
+                <div
+                  v-for="session in favoritedSessions"
+                  :key="'fav-' + session.uuid"
+                  class="session-item"
+                  :class="{ favorited: session.is_favorited, renaming: editingUuid === session.uuid }"
+                  @click="selectSession(session)"
+                >
+                  <div class="session-row">
+                    <button
+                      type="button"
+                      class="session-favorite-btn favorited"
+                      @click.stop="toggleFavorite(session)"
+                      :title="favoriteLabel(session)"
+                      :aria-label="favoriteLabel(session)"
+                    >{{ favoriteGlyph(session) }}</button>
+                    <div class="session-main">
+                      <div
+                        v-if="editingUuid === session.uuid"
+                        class="session-rename"
+                        @click.stop
+                      >
+                        <input
+                          :ref="'rename-input-' + session.uuid"
+                          v-model="editingTitle"
+                          type="text"
+                          class="session-rename-input"
+                          maxlength="200"
+                          :disabled="savingTitle"
+                          @keydown="onRenameKeydown(session, $event)"
+                          @blur="saveRename(session)"
+                          aria-label="Rename chat"
+                        />
+                      </div>
+                      <div
+                        v-else
+                        class="session-title"
+                        :class="{ untitled: !session.has_title }"
+                        @dblclick.stop="startRename(session)"
+                        :title="session.has_title ? 'Double-click to rename' : ''"
+                      >{{ session.title }}</div>
+                      <div
+                        v-if="session.match_snippet"
+                        class="session-match-snippet"
+                      >{{ session.match_snippet }}</div>
+                      <div
+                        v-else-if="session.has_title && session.preview"
+                        class="session-preview"
+                      >{{ session.preview }}</div>
+                      <div class="session-meta">
+                        <span class="session-date">{{ formatDate(session.modified_at) }}</span>
+                        <span class="session-count">{{ session.message_count }} messages</span>
+                      </div>
+                    </div>
+                    <button
+                      v-if="editingUuid !== session.uuid"
+                      type="button"
+                      class="session-rename-btn"
+                      @click.stop="startRename(session)"
+                      title="Rename chat"
+                      aria-label="Rename chat"
+                    >✎</button>
+                  </div>
+                </div>
+                <div v-if="chronologicalSessions.length > 0" class="session-group-header">
+                  All chats
+                </div>
+              </template>
               <div
-                v-for="session in sessions"
+                v-for="session in (showPinnedSection ? chronologicalSessions : sessions)"
                 :key="session.uuid"
                 class="session-item"
+                :class="{ favorited: session.is_favorited, renaming: editingUuid === session.uuid }"
                 @click="selectSession(session)"
               >
-                <div class="session-title">{{ session.title }}</div>
-                <div
-                  v-if="session.match_snippet"
-                  class="session-match-snippet"
-                >{{ session.match_snippet }}</div>
-                <div v-else class="session-preview">{{ session.preview }}</div>
-                <div class="session-meta">
-                  <span class="session-date">{{ formatDate(session.modified_at) }}</span>
-                  <span class="session-count">{{ session.message_count }} messages</span>
+                <div class="session-row">
+                  <button
+                    type="button"
+                    class="session-favorite-btn"
+                    :class="{ favorited: session.is_favorited }"
+                    @click.stop="toggleFavorite(session)"
+                    :title="favoriteLabel(session)"
+                    :aria-label="favoriteLabel(session)"
+                  >{{ favoriteGlyph(session) }}</button>
+                  <div class="session-main">
+                    <div
+                      v-if="editingUuid === session.uuid"
+                      class="session-rename"
+                      @click.stop
+                    >
+                      <input
+                        :ref="'rename-input-' + session.uuid"
+                        v-model="editingTitle"
+                        type="text"
+                        class="session-rename-input"
+                        maxlength="200"
+                        :disabled="savingTitle"
+                        @keydown="onRenameKeydown(session, $event)"
+                        @blur="saveRename(session)"
+                        aria-label="Rename chat"
+                      />
+                    </div>
+                    <div
+                      v-else
+                      class="session-title"
+                      :class="{ untitled: !session.has_title }"
+                      @dblclick.stop="startRename(session)"
+                      :title="session.has_title ? 'Double-click to rename' : ''"
+                    >{{ session.title }}</div>
+                    <div
+                      v-if="session.match_snippet"
+                      class="session-match-snippet"
+                    >{{ session.match_snippet }}</div>
+                    <div
+                      v-else-if="session.has_title && session.preview"
+                      class="session-preview"
+                    >{{ session.preview }}</div>
+                    <div class="session-meta">
+                      <span class="session-date">{{ formatDate(session.modified_at) }}</span>
+                      <span class="session-count">{{ session.message_count }} messages</span>
+                    </div>
+                  </div>
+                  <button
+                    v-if="editingUuid !== session.uuid"
+                    type="button"
+                    class="session-rename-btn"
+                    @click.stop="startRename(session)"
+                    title="Rename chat"
+                    aria-label="Rename chat"
+                  >✎</button>
                 </div>
               </div>
             </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -3675,6 +3675,63 @@ const Page = {
         this.$parent?.addToast?.("failed to move selected blocks", "error");
       }
     },
+
+    async bulkMoveSelectedToPage() {
+      // Reuse the shared page-picker (same one openMovePagePicker uses
+      // for single-block moves) so users only have to learn one page
+      // typeahead. Bail out gracefully if it isn't mounted.
+      const uuids = [...this.selectedBlockUuids];
+      if (uuids.length === 0) {
+        this.$parent?.addToast?.("no blocks selected", "info");
+        return;
+      }
+      if (!window.appModals?.pickPage) {
+        console.error("appModals.pickPage is not available");
+        return;
+      }
+
+      const targetPage = await window.appModals.pickPage({
+        title: "move selected blocks to page",
+        placeholder: "search pages…",
+        confirmLabel: "move",
+      });
+      if (!targetPage) return;
+
+      try {
+        const result = await window.apiService.bulkMoveBlocksToPage(
+          uuids,
+          targetPage.uuid
+        );
+        if (!result || !result.success) {
+          throw new Error(
+            result?.errors?.non_field_errors?.[0] || "bulk move failed"
+          );
+        }
+        const moved = result.data?.moved_count ?? 0;
+        const targetTitle =
+          targetPage.title || result.data?.target_page?.title || "page";
+        if (moved > 0) {
+          this.$parent?.addToast?.(
+            `moved ${moved} block${moved === 1 ? "" : "s"} to ${targetTitle}`,
+            "success"
+          );
+        } else {
+          this.$parent?.addToast?.(
+            "selected blocks already on the target page",
+            "info"
+          );
+        }
+        this.clearBlockSelection();
+        await this.loadPage({ silent: true });
+      } catch (error) {
+        console.error("failed to bulk-move blocks to page:", error);
+        this.error = "failed to move selected blocks";
+        this.$parent?.addToast?.(
+          `failed to move selected blocks: ${error.message || error}`,
+          "error"
+        );
+      }
+    },
   },
 
   template: `
@@ -3912,6 +3969,13 @@ const Page = {
               @click="bulkMoveSelectedToToday"
               title="Move selected blocks to today's daily note"
             >move to today</button>
+            <button
+              type="button"
+              class="btn btn-outline selection-toolbar-action"
+              :disabled="selectedBlockCount === 0"
+              @click="bulkMoveSelectedToPage"
+              title="Move selected blocks to any page…"
+            >move to page…</button>
             <button
               type="button"
               class="btn btn-outline selection-toolbar-action selection-toolbar-danger"

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -355,6 +355,19 @@ class ApiService {
     });
   }
 
+  async bulkMoveBlocksToPage(blockUuids, targetPageUuid) {
+    return await this.request("/knowledge/api/blocks/bulk-move-to-page/", {
+      method: "POST",
+      body: JSON.stringify({
+        blocks: blockUuids,
+        target_page: targetPageUuid,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
   async getHistoricalData(daysBack = 30, limit = 50) {
     return await this.request(
       `/knowledge/api/historical/?days_back=${daysBack}&limit=${limit}`

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -715,16 +715,32 @@ class ApiService {
     }
   }
 
-  async getChatSessions(search) {
+  async getChatSessions(search, favoritesOnly) {
     const trimmed = (search || "").trim();
-    const path = trimmed
-      ? `/api/ai-chat/sessions/?search=${encodeURIComponent(trimmed)}`
-      : "/api/ai-chat/sessions/";
+    const params = new URLSearchParams();
+    if (trimmed) params.set("search", trimmed);
+    if (favoritesOnly) params.set("favorites_only", "true");
+    const qs = params.toString();
+    const path = qs ? `/api/ai-chat/sessions/?${qs}` : "/api/ai-chat/sessions/";
     return await this.request(path);
   }
 
   async getChatSessionDetail(sessionId) {
     return await this.request(`/api/ai-chat/sessions/${sessionId}/`);
+  }
+
+  async setChatSessionFavorited(sessionId, isFavorited) {
+    return await this.request(`/api/ai-chat/sessions/${sessionId}/favorite/`, {
+      method: "POST",
+      body: JSON.stringify({ is_favorited: !!isFavorited }),
+    });
+  }
+
+  async updateChatSessionTitle(sessionId, title) {
+    return await this.request(`/api/ai-chat/sessions/${sessionId}/title/`, {
+      method: "POST",
+      body: JSON.stringify({ title }),
+    });
   }
 
   async getAISettings() {

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -756,6 +756,13 @@ class ApiService {
     });
   }
 
+  async reorderFavoritedChatSessions(sessionUuids) {
+    return await this.request("/api/ai-chat/sessions/reorder-favorites/", {
+      method: "POST",
+      body: JSON.stringify({ session_uuids: sessionUuids }),
+    });
+  }
+
   async getAISettings() {
     return await this.request("/api/ai-chat/settings/");
   }

--- a/packages/django-app/app/knowledge/test/commands/test_bulk_move_blocks_to_page_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_bulk_move_blocks_to_page_command.py
@@ -1,0 +1,143 @@
+from django.test import TestCase
+
+from knowledge.commands import BulkMoveBlocksToPageCommand
+from knowledge.forms import BulkMoveBlocksToPageForm
+
+from ..helpers import BlockFactory, PageFactory, UserFactory
+
+
+class TestBulkMoveBlocksToPageCommand(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
+    def _form(self, *, blocks, target_page):
+        return BulkMoveBlocksToPageForm(
+            {
+                "user": self.user.id,
+                "blocks": blocks,
+                "target_page": str(target_page.uuid),
+            }
+        )
+
+    def test_should_move_blocks_to_target_page_as_siblings(self):
+        source = PageFactory(user=self.user, title="Notes", slug="notes-mp-1")
+        target = PageFactory(user=self.user, title="Backlog", slug="backlog-mp-1")
+        b1 = BlockFactory(user=self.user, page=source, content="first", order=1)
+        b2 = BlockFactory(user=self.user, page=source, content="second", order=2)
+
+        form = self._form(blocks=[str(b1.uuid), str(b2.uuid)], target_page=target)
+        self.assertTrue(form.is_valid(), form.errors)
+
+        result = BulkMoveBlocksToPageCommand(form).execute()
+
+        self.assertEqual(result["moved_count"], 2)
+        self.assertEqual(result["target_page"]["uuid"], str(target.uuid))
+
+        b1.refresh_from_db()
+        b2.refresh_from_db()
+        self.assertEqual(b1.page, target)
+        self.assertEqual(b2.page, target)
+        self.assertIsNone(b1.parent)
+        self.assertIsNone(b2.parent)
+
+    def test_should_preserve_relative_order_on_target(self):
+        source = PageFactory(user=self.user, title="Notes", slug="notes-mp-2")
+        target = PageFactory(user=self.user, title="Backlog", slug="backlog-mp-2")
+        b1 = BlockFactory(user=self.user, page=source, content="first", order=5)
+        b2 = BlockFactory(user=self.user, page=source, content="second", order=10)
+
+        form = self._form(blocks=[str(b2.uuid), str(b1.uuid)], target_page=target)
+        self.assertTrue(form.is_valid(), form.errors)
+
+        BulkMoveBlocksToPageCommand(form).execute()
+
+        b1.refresh_from_db()
+        b2.refresh_from_db()
+        self.assertLess(b1.order, b2.order)
+
+    def test_should_preserve_parent_child_relationship_within_selection(self):
+        source = PageFactory(user=self.user, title="Notes", slug="notes-mp-3")
+        target = PageFactory(user=self.user, title="Backlog", slug="backlog-mp-3")
+        parent = BlockFactory(user=self.user, page=source, content="parent", order=1)
+        child = BlockFactory(
+            user=self.user,
+            page=source,
+            parent=parent,
+            content="child",
+            order=2,
+        )
+
+        form = self._form(
+            blocks=[str(parent.uuid), str(child.uuid)], target_page=target
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        result = BulkMoveBlocksToPageCommand(form).execute()
+
+        # Only the parent moves explicitly; child rides along via the
+        # MoveBlockToPageCommand's descendants pass.
+        self.assertEqual(result["moved_count"], 1)
+
+        parent.refresh_from_db()
+        child.refresh_from_db()
+        self.assertEqual(parent.page, target)
+        self.assertEqual(child.page, target)
+        self.assertIsNone(parent.parent)
+        self.assertEqual(child.parent, parent)
+
+    def test_should_silently_skip_blocks_owned_by_another_user(self):
+        # Cross-user uuids are filtered out by the user-scoped queryset
+        # in execute(); they show up only in skipped_count and don't
+        # touch the other user's data.
+        source = PageFactory(user=self.user, title="Notes", slug="notes-mp-4")
+        target = PageFactory(user=self.user, title="Backlog", slug="backlog-mp-4")
+        mine = BlockFactory(user=self.user, page=source, content="mine", order=1)
+
+        other = UserFactory()
+        other_page = PageFactory(user=other, slug="other-page-mp")
+        theirs = BlockFactory(user=other, page=other_page, content="theirs", order=1)
+
+        form = self._form(blocks=[str(mine.uuid), str(theirs.uuid)], target_page=target)
+        self.assertTrue(form.is_valid(), form.errors)
+
+        result = BulkMoveBlocksToPageCommand(form).execute()
+
+        self.assertEqual(result["moved_count"], 1)
+        self.assertEqual(result["skipped_count"], 1)
+        theirs.refresh_from_db()
+        self.assertEqual(theirs.page, other_page)
+
+    def test_should_reject_target_page_owned_by_another_user(self):
+        # The form's clean_target_page guard rejects cross-user target
+        # pages so a hostile request can't write into someone else's
+        # page.
+        source = PageFactory(user=self.user, title="Notes", slug="notes-mp-5")
+        b = BlockFactory(user=self.user, page=source, content="x", order=1)
+
+        other = UserFactory()
+        other_target = PageFactory(user=other, slug="other-target-mp")
+
+        form = self._form(blocks=[str(b.uuid)], target_page=other_target)
+        self.assertFalse(form.is_valid())
+        self.assertIn("target_page", form.errors)
+
+    def test_should_reject_empty_blocks_list(self):
+        target = PageFactory(user=self.user, title="Backlog", slug="backlog-mp-6")
+        form = self._form(blocks=[], target_page=target)
+        self.assertFalse(form.is_valid())
+        self.assertIn("blocks", form.errors)
+
+    def test_should_no_op_when_blocks_already_on_target(self):
+        # MoveBlockToPageCommand returns moved=False for blocks already
+        # root on the target. moved_count reflects only real movements
+        # so the toast can stay accurate.
+        target = PageFactory(user=self.user, title="Backlog", slug="backlog-mp-7")
+        already = BlockFactory(user=self.user, page=target, content="x", order=1)
+
+        form = self._form(blocks=[str(already.uuid)], target_page=target)
+        self.assertTrue(form.is_valid(), form.errors)
+
+        result = BulkMoveBlocksToPageCommand(form).execute()
+        self.assertEqual(result["moved_count"], 0)
+        self.assertEqual(result["skipped_count"], 0)

--- a/packages/django-app/app/knowledge/test/commands/test_consume_reminder_action_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_consume_reminder_action_command.py
@@ -93,6 +93,54 @@ class ConsumeReminderActionCommandTests(TestCase):
             (pinned + timedelta(days=1)).replace(microsecond=0),
         )
 
+    def test_mark_doing_flips_block_to_doing_and_consumes_token(self) -> None:
+        # The block starts as "todo"; clicking Mark doing should land
+        # it in the "doing" state with the content prefix swapped and
+        # the token marked used. The reminder itself is left alone —
+        # marking doing isn't a deferral, the same reminder may fire
+        # follow-ups or the user may want to mark done later.
+        action = self._make_action(ReminderAction.ACTION_MARK_DOING)
+
+        result = self._run(action.token)
+
+        self.assertEqual(result["status"], "executed")
+        self.assertEqual(result["action"], ReminderAction.ACTION_MARK_DOING)
+        self.assertEqual(result["detail"], "Marked the block as doing.")
+        self.assertEqual(result["block_uuid"], str(self.block.uuid))
+
+        self.block.refresh_from_db()
+        self.assertEqual(self.block.block_type, "doing")
+        # "Mark doing" is not a terminal state — completed_at stays
+        # empty so the in-app pending-reminder lookup keeps working.
+        self.assertIsNone(self.block.completed_at)
+        # SetBlockTypeCommand swaps the leading "TODO" prefix to "DOING".
+        self.assertTrue(self.block.content.startswith("DOING"))
+
+        action.refresh_from_db()
+        self.assertIsNotNone(action.used_at)
+
+        self.reminder.refresh_from_db()
+        # Reminder is untouched — its sent state from setUp persists.
+        self.assertEqual(self.reminder.status, Reminder.STATUS_SENT)
+
+    def test_mark_doing_on_already_doing_block_is_idempotent(self) -> None:
+        # If the user clicks "Mark doing" twice (different tokens) or
+        # the block was already moved to doing in another channel,
+        # the second consume just marks the token used.
+        self.block.block_type = "doing"
+        self.block.content = "DOING ship"
+        self.block.save(update_fields=["block_type", "content", "modified_at"])
+
+        action = self._make_action(ReminderAction.ACTION_MARK_DOING)
+
+        result = self._run(action.token)
+
+        self.assertEqual(result["status"], "executed")
+        self.block.refresh_from_db()
+        self.assertEqual(self.block.block_type, "doing")
+        action.refresh_from_db()
+        self.assertIsNotNone(action.used_at)
+
     def test_unknown_token_returns_not_found(self) -> None:
         result = self._run("definitely-not-a-real-token-value")
         self.assertEqual(result["status"], "not_found")

--- a/packages/django-app/app/knowledge/test/commands/test_reminder_actions_service.py
+++ b/packages/django-app/app/knowledge/test/commands/test_reminder_actions_service.py
@@ -29,13 +29,14 @@ class CreateActionTokensTests(TestCase):
             set(rows.keys()),
             {
                 ReminderAction.ACTION_COMPLETE,
+                ReminderAction.ACTION_MARK_DOING,
                 ReminderAction.ACTION_SNOOZE_1H,
                 ReminderAction.ACTION_SNOOZE_1D,
             },
         )
         # Tokens are unique per row — collisions would break the
         # uniqueness constraint at write time, but assert here too.
-        self.assertEqual(len({r.token for r in rows.values()}), 3)
+        self.assertEqual(len({r.token for r in rows.values()}), 4)
 
     def test_tokens_default_expiry_uses_model_ttl(self) -> None:
         pinned = timezone.now()

--- a/packages/django-app/app/knowledge/test/commands/test_send_due_reminders_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_send_due_reminders_command.py
@@ -405,17 +405,19 @@ class TestSendDueRemindersCommand(TestCase):
         description = embed["description"]
         self.assertIn("[Open block →]", description)
         self.assertIn("[Mark done]", description)
+        self.assertIn("[Mark doing]", description)
         self.assertIn("[Snooze 1h]", description)
         self.assertIn("[Snooze 1d]", description)
 
-        # Three action rows minted, all linked to this reminder, none
+        # Four action rows minted, all linked to this reminder, none
         # consumed yet.
         actions = list(ReminderAction.objects.filter(reminder=reminder))
-        self.assertEqual(len(actions), 3)
+        self.assertEqual(len(actions), 4)
         self.assertEqual(
             {a.action for a in actions},
             {
                 ReminderAction.ACTION_COMPLETE,
+                ReminderAction.ACTION_MARK_DOING,
                 ReminderAction.ACTION_SNOOZE_1H,
                 ReminderAction.ACTION_SNOOZE_1D,
             },

--- a/packages/django-app/app/knowledge/urls.py
+++ b/packages/django-app/app/knowledge/urls.py
@@ -65,6 +65,11 @@ urlpatterns = [
         views.bulk_move_blocks,
         name="bulk_move_blocks",
     ),
+    path(
+        "api/blocks/bulk-move-to-page/",
+        views.bulk_move_blocks_to_page,
+        name="bulk_move_blocks_to_page",
+    ),
     # Page-centric API endpoints
     path("api/pages/", views.create_page, name="create_page"),
     path("api/pages/update/", views.update_page, name="update_page"),

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -14,6 +14,7 @@ from knowledge.commands import (
     AddTemplateBlocksToPageCommand,
     BulkDeleteBlocksCommand,
     BulkMoveBlocksCommand,
+    BulkMoveBlocksToPageCommand,
     ConsumeReminderActionCommand,
     CreateBlockCommand,
     CreatePageCommand,
@@ -59,6 +60,9 @@ from knowledge.commands.add_template_blocks_to_page_command import (
 )
 from knowledge.commands.bulk_delete_blocks_command import BulkDeleteBlocksData
 from knowledge.commands.bulk_move_blocks_command import BulkMoveBlocksData
+from knowledge.commands.bulk_move_blocks_to_page_command import (
+    BulkMoveBlocksToPageData,
+)
 from knowledge.commands.get_graph_data_command import GraphData
 from knowledge.commands.get_historical_data_command import HistoricalData
 from knowledge.commands.get_tag_content_command import TagContentData
@@ -69,6 +73,7 @@ from knowledge.forms import (
     AddTemplateBlocksToPageForm,
     BulkDeleteBlocksForm,
     BulkMoveBlocksForm,
+    BulkMoveBlocksToPageForm,
     ConsumeReminderActionForm,
     CreateBlockForm,
     CreatePageEmbeddedViewForm,
@@ -196,6 +201,12 @@ class BulkDeleteBlocksResponse(TypedDict):
 class BulkMoveBlocksResponse(TypedDict):
     success: bool
     data: Optional[BulkMoveBlocksData]
+    errors: Optional[Dict[str, List[str]]]
+
+
+class BulkMoveBlocksToPageResponse(TypedDict):
+    success: bool
+    data: Optional[BulkMoveBlocksToPageData]
     errors: Optional[Dict[str, List[str]]]
 
 
@@ -1623,6 +1634,49 @@ def bulk_move_blocks(request):
 
     except Exception as e:
         response: BulkMoveBlocksResponse = {
+            "success": False,
+            "data": None,
+            "errors": {"non_field_errors": [str(e)]},
+        }
+        return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def bulk_move_blocks_to_page(request):
+    """Move a list of blocks to an arbitrary target page as siblings."""
+    try:
+        data = request.data.copy()
+        data["user"] = request.user.id
+
+        form = BulkMoveBlocksToPageForm(data)
+
+        if not form.is_valid():
+            response: BulkMoveBlocksToPageResponse = {
+                "success": False,
+                "data": None,
+                "errors": form.errors,
+            }
+            return Response(response, status=status.HTTP_400_BAD_REQUEST)
+
+        command = BulkMoveBlocksToPageCommand(form)
+        result = command.execute()
+
+        response: BulkMoveBlocksToPageResponse = {
+            "success": True,
+            "data": result,
+            "errors": None,
+        }
+        return Response(response)
+
+    except ValidationError as e:
+        return Response(
+            {"success": False, "data": None, "errors": {"non_field_errors": [str(e)]}},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    except Exception as e:
+        response: BulkMoveBlocksToPageResponse = {
             "success": False,
             "data": None,
             "errors": {"non_field_errors": [str(e)]},


### PR DESCRIPTION
Add pinning/favoriting and inline renaming for chat sessions in the history dropdown. Sessions can now be marked as favorites (pinned to the top), filtered to show only favorites, and renamed inline with double-click.

**Key changes:**

- **Frontend (Vue component)**: Added favorites filter toggle, pinned section header, inline rename input with Enter/Escape/blur handlers, and favorite/rename buttons to each session row. Computed properties separate favorited and chronological sessions for flexible rendering.

- **Backend (Django)**: New `SetChatSessionFavoritedCommand` and `UpdateChatSessionTitleCommand` to handle favorite toggling and title updates. Added `is_favorited` field to `ChatSession` model with database index. Repository methods `set_favorited()` and `update_title()` handle persistence with user ownership validation via form mixins.

- **API**: New endpoints `/sessions/<id>/favorite/` (POST) and `/sessions/<id>/title/` (POST) with corresponding forms that validate user ownership before delegating to commands.

- **Auto-titling**: Sessions are now auto-labeled from the user's first message (stripped of context wrapper) via `_derive_auto_title()`. The `set_title_if_blank()` repository method is idempotent so user renames survive follow-up turns.

- **Styling**: Added `.history-filters`, `.session-group-header`, `.session-favorite-btn`, `.session-rename-input` and related classes. Favorites sort to top via `order_by("-is_favorited", "-modified_at")`.

- **Tests**: Added comprehensive test suites for auto-title derivation, favorite toggling, title updates, and list filtering behavior.

https://claude.ai/code/session_01CqrbehigSaZXd4iAuTR3TR