### PR TITLE
Add dates_relative_to_daily flag to rebase date filters on daily pages

### DIFF
--- a/packages/django-app/app/knowledge/commands/create_saved_view_command.py
+++ b/packages/django-app/app/knowledge/commands/create_saved_view_command.py
@@ -29,6 +29,9 @@ class CreateSavedViewCommand(AbstractBaseCommand):
         description = self.form.cleaned_data.get("description", "") or ""
         filter_spec = self.form.cleaned_data["filter"]
         sort = self.form.cleaned_data.get("sort") or []
+        dates_relative_to_daily = bool(
+            self.form.cleaned_data.get("dates_relative_to_daily")
+        )
 
         if not slug:
             raise ValidationError("slug is required (or supply a name to auto-slug)")
@@ -49,4 +52,5 @@ class CreateSavedViewCommand(AbstractBaseCommand):
             filter_spec=filter_spec,
             sort=sort,
             is_system=False,
+            dates_relative_to_daily=dates_relative_to_daily,
         )

--- a/packages/django-app/app/knowledge/commands/duplicate_saved_view_command.py
+++ b/packages/django-app/app/knowledge/commands/duplicate_saved_view_command.py
@@ -39,6 +39,7 @@ class DuplicateSavedViewCommand(AbstractBaseCommand):
             filter_spec=original.filter,
             sort=original.sort,
             is_system=False,
+            dates_relative_to_daily=original.dates_relative_to_daily,
         )
 
     @staticmethod

--- a/packages/django-app/app/knowledge/commands/run_saved_view_command.py
+++ b/packages/django-app/app/knowledge/commands/run_saved_view_command.py
@@ -28,6 +28,7 @@ class RunSavedViewCommand(AbstractBaseCommand):
         limit = self.form.cleaned_data.get("limit") or 100
         view_uuid = self.form.cleaned_data.get("view_uuid")
         view_slug = self.form.cleaned_data.get("view_slug")
+        context_date = self.form.cleaned_data.get("context_date")
 
         view = (
             SavedViewRepository.get_by_uuid(str(view_uuid), user=user)
@@ -37,8 +38,21 @@ class RunSavedViewCommand(AbstractBaseCommand):
         if not view:
             raise ValidationError("Saved view not found")
 
+        # Only honor ``context_date`` when the view opts in via
+        # ``dates_relative_to_daily``. Without the gate a stray
+        # ``context_date`` from a daily-page embed would rebase
+        # date tokens on every view — defeating the explicit toggle
+        # the user picked. When the toggle is off the engine falls
+        # back to ``user.today()`` regardless of what the caller sent.
+        effective_context_date = context_date if view.dates_relative_to_daily else None
+
         try:
-            compiled = query_engine.compile(view.filter, user=user, sort=view.sort)
+            compiled = query_engine.compile(
+                view.filter,
+                user=user,
+                sort=view.sort,
+                context_date=effective_context_date,
+            )
         except query_engine.QueryEngineError as exc:
             raise ValidationError(str(exc)) from exc
 

--- a/packages/django-app/app/knowledge/commands/update_saved_view_command.py
+++ b/packages/django-app/app/knowledge/commands/update_saved_view_command.py
@@ -48,6 +48,10 @@ class UpdateSavedViewCommand(AbstractBaseCommand):
             updates["filter"] = cleaned["filter"]
         if "sort" in cleaned and cleaned["sort"] is not None:
             updates["sort"] = cleaned["sort"]
+        if "dates_relative_to_daily" in cleaned:
+            updates["dates_relative_to_daily"] = bool(
+                cleaned["dates_relative_to_daily"]
+            )
 
         # Re-compile against the proposed filter/sort to catch broken
         # specs before they hit the DB. We pull the merged values so a

--- a/packages/django-app/app/knowledge/forms/create_saved_view_form.py
+++ b/packages/django-app/app/knowledge/forms/create_saved_view_form.py
@@ -19,6 +19,7 @@ class CreateSavedViewForm(UserForm):
     description = forms.CharField(max_length=500, required=False)
     filter = forms.JSONField()
     sort = forms.JSONField(required=False)
+    dates_relative_to_daily = forms.BooleanField(required=False)
 
     def clean_filter(self):
         v = self.cleaned_data.get("filter")

--- a/packages/django-app/app/knowledge/forms/run_saved_view_form.py
+++ b/packages/django-app/app/knowledge/forms/run_saved_view_form.py
@@ -9,6 +9,10 @@ class RunSavedViewForm(UserForm):
     view_uuid = forms.UUIDField(required=False)
     view_slug = forms.SlugField(required=False, max_length=200)
     limit = forms.IntegerField(min_value=1, max_value=500, required=False, initial=100)
+    # ISO YYYY-MM-DD. Only honored when the view has
+    # ``dates_relative_to_daily=True``; otherwise the command ignores it
+    # so a stray context_date can't shift a "live today" view.
+    context_date = forms.DateField(required=False)
 
     def clean(self):
         cleaned = super().clean()

--- a/packages/django-app/app/knowledge/forms/update_saved_view_form.py
+++ b/packages/django-app/app/knowledge/forms/update_saved_view_form.py
@@ -14,6 +14,7 @@ class UpdateSavedViewForm(UserForm):
     description = forms.CharField(max_length=500, required=False)
     filter = forms.JSONField(required=False)
     sort = forms.JSONField(required=False)
+    dates_relative_to_daily = forms.BooleanField(required=False)
 
     def clean_filter(self):
         v = self.cleaned_data.get("filter")

--- a/packages/django-app/app/knowledge/migrations/0036_savedview_dates_relative_to_daily.py
+++ b/packages/django-app/app/knowledge/migrations/0036_savedview_dates_relative_to_daily.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("knowledge", "0035_reminderaction_mark_doing"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="savedview",
+            name="dates_relative_to_daily",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "When True, date tokens (today/yesterday/N days ago) in "
+                    "this view's filter resolve against the daily page the "
+                    "embed is rendered on, rather than the actual current "
+                    "date. No-op when the view is rendered outside a daily "
+                    "page context."
+                ),
+            ),
+        ),
+    ]

--- a/packages/django-app/app/knowledge/models/saved_view.py
+++ b/packages/django-app/app/knowledge/models/saved_view.py
@@ -55,6 +55,15 @@ class SavedView(UUIDModelMixin, CRUDTimestampsMixin):
         default=False,
         help_text="Pinned views surface in the left-nav for one-click access",
     )
+    dates_relative_to_daily = models.BooleanField(
+        default=False,
+        help_text=(
+            "When True, date tokens (today/yesterday/N days ago) in this "
+            "view's filter resolve against the daily page the embed is "
+            "rendered on, rather than the actual current date. No-op when "
+            "the view is rendered outside a daily page context."
+        ),
+    )
 
     class Meta:
         db_table = "saved_views"
@@ -77,6 +86,7 @@ class SavedView(UUIDModelMixin, CRUDTimestampsMixin):
             "sort": self.sort or [],
             "is_system": self.is_system,
             "pinned": self.pinned,
+            "dates_relative_to_daily": self.dates_relative_to_daily,
             "user_uuid": str(self.user.uuid),
             "created_at": self.created_at.isoformat(),
             "modified_at": self.modified_at.isoformat(),
@@ -92,6 +102,7 @@ class SavedViewData(TypedDict):
     sort: List[Dict[str, Any]]
     is_system: bool
     pinned: bool
+    dates_relative_to_daily: bool
     user_uuid: str
     created_at: str
     modified_at: str

--- a/packages/django-app/app/knowledge/repositories/saved_view_repository.py
+++ b/packages/django-app/app/knowledge/repositories/saved_view_repository.py
@@ -68,6 +68,7 @@ class SavedViewRepository(BaseRepository):
         sort: list,
         description: str = "",
         is_system: bool = False,
+        dates_relative_to_daily: bool = False,
     ) -> SavedView:
         return cls.model.objects.create(
             user=user,
@@ -77,6 +78,7 @@ class SavedViewRepository(BaseRepository):
             filter=filter_spec,
             sort=sort,
             is_system=is_system,
+            dates_relative_to_daily=dates_relative_to_daily,
         )
 
     @classmethod

--- a/packages/django-app/app/knowledge/services/query_engine.py
+++ b/packages/django-app/app/knowledge/services/query_engine.py
@@ -80,9 +80,17 @@ _DAYS_AGO_RE = re.compile(r"^(\d+)\s+days?\s+ago$")
 _DAYS_FROM_NOW_RE = re.compile(r"^(?:in\s+(\d+)\s+days?|(\d+)\s+days?\s+from\s+now)$")
 
 
-def _resolve_date_token(raw: Any, user) -> date:
+def _resolve_date_token(raw: Any, user, context_date: "date | None" = None) -> date:
     """Turn a token (``"today"``, ``"3 days ago"``, ``"2026-05-01"``, or a
-    ``date``/``datetime``) into a concrete date in the user's timezone."""
+    ``date``/``datetime``) into a concrete date in the user's timezone.
+
+    When ``context_date`` is provided it's used as the anchor for relative
+    tokens (``today`` / ``yesterday`` / ``N days ago`` / ``N days from
+    now``) instead of ``user.today()``. The "Dates relative to daily"
+    flag on SavedView drives this — embedded views on a daily page pass
+    that daily's date so date filters rebase to the page in view.
+    ISO date strings ignore ``context_date`` (they're absolute by
+    construction)."""
     if isinstance(raw, datetime):
         return raw.date()
     if isinstance(raw, date):
@@ -93,7 +101,7 @@ def _resolve_date_token(raw: Any, user) -> date:
         )
 
     s = raw.strip().lower()
-    today = user.today()
+    today = context_date if context_date is not None else user.today()
 
     if s == "today":
         return today
@@ -131,7 +139,7 @@ def _start_of_local_day(d: date, user) -> datetime:
 _BLOCK_TYPES = {choice[0] for choice in Block._meta.get_field("block_type").choices}
 
 
-def _block_type_q(value: Any, user) -> Q:
+def _block_type_q(value: Any, user, context_date: "date | None" = None) -> Q:
     if isinstance(value, str):
         value = {"eq": value}
     if not isinstance(value, dict):
@@ -157,7 +165,13 @@ def _block_type_q(value: Any, user) -> Q:
     return q
 
 
-def _date_field_q(field_name: str, value: Any, user, is_datetime: bool) -> Q:
+def _date_field_q(
+    field_name: str,
+    value: Any,
+    user,
+    is_datetime: bool,
+    context_date: "date | None" = None,
+) -> Q:
     """Shared compiler for date / datetime predicates.
 
     DateField predicates compare directly. DateTimeField predicates
@@ -179,30 +193,30 @@ def _date_field_q(field_name: str, value: Any, user, is_datetime: bool) -> Q:
                 raise QueryEngineError(f"is_null must be bool: {arg!r}")
             q &= Q(**{f"{field_name}__isnull": arg})
         elif op == "eq":
-            d = _resolve_date_token(arg, user)
+            d = _resolve_date_token(arg, user, context_date)
             q &= _date_eq_q(field_name, d, user, is_datetime)
         elif op == "lt":
-            d = _resolve_date_token(arg, user)
+            d = _resolve_date_token(arg, user, context_date)
             if is_datetime:
                 q &= Q(**{f"{field_name}__lt": _start_of_local_day(d, user)})
             else:
                 q &= Q(**{f"{field_name}__lt": d})
         elif op == "lte":
-            d = _resolve_date_token(arg, user)
+            d = _resolve_date_token(arg, user, context_date)
             if is_datetime:
                 next_day = _start_of_local_day(d + timedelta(days=1), user)
                 q &= Q(**{f"{field_name}__lt": next_day})
             else:
                 q &= Q(**{f"{field_name}__lte": d})
         elif op == "gt":
-            d = _resolve_date_token(arg, user)
+            d = _resolve_date_token(arg, user, context_date)
             if is_datetime:
                 next_day = _start_of_local_day(d + timedelta(days=1), user)
                 q &= Q(**{f"{field_name}__gte": next_day})
             else:
                 q &= Q(**{f"{field_name}__gt": d})
         elif op == "gte":
-            d = _resolve_date_token(arg, user)
+            d = _resolve_date_token(arg, user, context_date)
             if is_datetime:
                 q &= Q(**{f"{field_name}__gte": _start_of_local_day(d, user)})
             else:
@@ -210,8 +224,8 @@ def _date_field_q(field_name: str, value: Any, user, is_datetime: bool) -> Q:
         elif op == "between":
             if not isinstance(arg, list) or len(arg) != 2:
                 raise QueryEngineError(f"between must be [start, end] (got {arg!r})")
-            start_d = _resolve_date_token(arg[0], user)
-            end_d = _resolve_date_token(arg[1], user)
+            start_d = _resolve_date_token(arg[0], user, context_date)
+            end_d = _resolve_date_token(arg[1], user, context_date)
             if is_datetime:
                 q &= Q(
                     **{
@@ -241,15 +255,19 @@ def _date_eq_q(field_name: str, d: date, user, is_datetime: bool) -> Q:
     return Q(**{field_name: d})
 
 
-def _scheduled_for_q(value: Any, user) -> Q:
-    return _date_field_q("scheduled_for", value, user, is_datetime=False)
+def _scheduled_for_q(value: Any, user, context_date: "date | None" = None) -> Q:
+    return _date_field_q(
+        "scheduled_for", value, user, is_datetime=False, context_date=context_date
+    )
 
 
-def _completed_at_q(value: Any, user) -> Q:
-    return _date_field_q("completed_at", value, user, is_datetime=True)
+def _completed_at_q(value: Any, user, context_date: "date | None" = None) -> Q:
+    return _date_field_q(
+        "completed_at", value, user, is_datetime=True, context_date=context_date
+    )
 
 
-def _has_tag_q(value: Any, user) -> Q:
+def _has_tag_q(value: Any, user, context_date: "date | None" = None) -> Q:
     """Compose-friendly tag predicate.
 
     Matches a block when *either*:
@@ -320,14 +338,14 @@ def _validate_property_key(key: Any, predicate: str) -> str:
     return key
 
 
-def _has_property_q(value: Any, user) -> Q:
+def _has_property_q(value: Any, user, context_date: "date | None" = None) -> Q:
     if isinstance(value, dict):
         value = value.get("eq")
     key = _validate_property_key(value, "has_property")
     return Q(properties__has_key=key)
 
 
-def _property_eq_q(value: Any, user) -> Q:
+def _property_eq_q(value: Any, user, context_date: "date | None" = None) -> Q:
     """Op-dict predicate against ``Block.properties[key]``.
 
     Shorthand ``{"key": K, "value": V}`` is treated as ``{"key": K,
@@ -417,7 +435,7 @@ def _property_eq_q(value: Any, user) -> Q:
     return q
 
 
-def _content_contains_q(value: Any, user) -> Q:
+def _content_contains_q(value: Any, user, context_date: "date | None" = None) -> Q:
     if isinstance(value, dict):
         value = value.get("eq")
     if not isinstance(value, str) or not value:
@@ -435,7 +453,7 @@ def _page_types() -> "set[str]":
     return {choice[0] for choice in Page._meta.get_field("page_type").choices}
 
 
-def _page_type_q(value: Any, user) -> Q:
+def _page_type_q(value: Any, user, context_date: "date | None" = None) -> Q:
     """Filter blocks by their page's ``page_type``.
 
     Shorthand ``"template"`` is treated as ``{"eq": "template"}``. The
@@ -472,7 +490,7 @@ def _page_type_q(value: Any, user) -> Q:
     return q
 
 
-PREDICATE_HANDLERS: Dict[str, Callable[[Any, Any], Q]] = {
+PREDICATE_HANDLERS: Dict[str, Callable[..., Q]] = {
     "block_type": _block_type_q,
     "scheduled_for": _scheduled_for_q,
     "completed_at": _completed_at_q,
@@ -491,7 +509,7 @@ COMBINATORS = ("all", "any", "not")
 # ---------------------------------------------------------------------------
 
 
-def _compile_node(spec: Any, user) -> Q:
+def _compile_node(spec: Any, user, context_date: "date | None" = None) -> Q:
     if not isinstance(spec, dict):
         raise QueryEngineError(
             f"Filter node must be a dict, got {type(spec).__name__}: {spec!r}"
@@ -518,13 +536,13 @@ def _compile_node(spec: Any, user) -> Q:
                     "'not' combinator requires a single non-empty filter "
                     "node as its value"
                 )
-            return ~_compile_node(value, user)
+            return ~_compile_node(value, user, context_date)
 
         if not isinstance(value, list) or not value:
             raise QueryEngineError(
                 f"{key!r} combinator requires a non-empty list of children"
             )
-        children = [_compile_node(child, user) for child in value]
+        children = [_compile_node(child, user, context_date) for child in value]
         if key == "all":
             combined = Q()
             for child_q in children:
@@ -539,7 +557,7 @@ def _compile_node(spec: Any, user) -> Q:
     handler = PREDICATE_HANDLERS.get(key)
     if handler is None:
         raise QueryEngineError(f"Unknown filter field/combinator: {key!r}")
-    return handler(value, user)
+    return handler(value, user, context_date)
 
 
 _SORT_FIELDS = {
@@ -612,16 +630,27 @@ def _spec_mentions_page_type(spec: Any) -> bool:
     return False
 
 
-def compile(spec: Any, user, sort: Any = None) -> CompiledQuery:
+def compile(
+    spec: Any,
+    user,
+    sort: Any = None,
+    context_date: "date | None" = None,
+) -> CompiledQuery:
     """Compile a filter spec (and optional sort spec) into a CompiledQuery.
 
     Resolution of relative date tokens happens here against
-    ``user.today()`` — meaning "today" snaps at compile time, not at
-    queryset evaluation, so a freshly-compiled query is always evaluated
-    against a stable today.
+    ``user.today()`` (or ``context_date`` if provided) — meaning "today"
+    snaps at compile time, not at queryset evaluation, so a freshly-
+    compiled query is always evaluated against a stable today.
+
+    ``context_date`` is the "Dates relative to daily" plumbing: when a
+    saved view is rendered as an embed on a daily page, the caller (the
+    Run command) passes that daily's date so date tokens rebase to the
+    page in view instead of the live current date. Pass ``None`` (the
+    default) to keep the live-today semantics.
     """
     return CompiledQuery(
-        filter_q=_compile_node(spec, user),
+        filter_q=_compile_node(spec, user, context_date),
         order_by=_compile_sort(sort),
         includes_page_type=_spec_mentions_page_type(spec),
     )

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -8061,6 +8061,33 @@ a.hashtag-mention:hover,
   color: var(--text-secondary);
   font-family: var(--font-mono, monospace);
 }
+.block-query-embed-anchor {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  font-family: var(--font-mono, monospace);
+  color: var(--text-secondary);
+  background: var(--tag-bg, var(--bg-primary));
+  border: 1px solid var(--border-primary);
+  border-radius: 3px;
+  padding: 0.05rem 0.35rem;
+  cursor: help;
+}
+.block-query-embed-anchor.is-anchored {
+  color: var(--text-primary);
+}
+.block-query-embed-anchor.is-unanchored {
+  opacity: 0.7;
+  font-style: italic;
+}
+.block-query-embed-anchor-icon {
+  flex: none;
+  display: block;
+}
+.block-query-embed-anchor-label {
+  white-space: nowrap;
+}
 .block-query-embed-actions {
   display: inline-flex;
   gap: 0.25rem;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -7820,6 +7820,26 @@ a.hashtag-mention:hover,
   margin-top: 0.5rem;
 }
 
+.saved-view-editor .checkbox-label {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.saved-view-editor .checkbox-label input[type="checkbox"] {
+  margin: 0;
+}
+
+.saved-view-editor .form-hint {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
 .saved-view-editor .form-error {
   color: var(--error-text, #d24);
   font-size: 0.85rem;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -8067,15 +8067,12 @@ a.hashtag-mention:hover,
   gap: 0.25rem;
   font-size: 0.75rem;
   font-family: var(--font-mono, monospace);
-  color: var(--text-secondary);
+  color: var(--tag-text);
   background: var(--tag-bg, var(--bg-primary));
   border: 1px solid var(--border-primary);
   border-radius: 3px;
   padding: 0.05rem 0.35rem;
   cursor: help;
-}
-.block-query-embed-anchor.is-anchored {
-  color: var(--text-primary);
 }
 .block-query-embed-anchor.is-unanchored {
   opacity: 0.7;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -4043,6 +4043,7 @@ const Page = {
             v-for="(embed, idx) in embeddedViews"
             :key="embed.uuid"
             :embed="embed"
+            :context-date="currentDate"
             :on-delete="deleteEmbed"
             :on-toggle-collapsed="toggleEmbedCollapsed"
             :on-move-up="idx > 0 ? moveEmbedUp : null"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
@@ -15,6 +15,13 @@
 window.QueryEmbedBlock = {
   props: {
     embed: { type: Object, required: true },
+    // ISO YYYY-MM-DD when the embed renders inside a daily page; null
+    // otherwise. Forwarded to /api/views/run/ as ``context_date`` so a
+    // saved view with ``dates_relative_to_daily`` rebases its date
+    // tokens to the daily in view rather than the live current date.
+    // The server gates on the view's flag, so this is a safe no-op for
+    // saved views that haven't opted in.
+    contextDate: { type: String, default: null },
     // All optional so the embed can also render outside the page
     // surface (e.g. preview) without forcing a caller to wire them up.
     onDelete: { type: Function, default: null },
@@ -59,9 +66,32 @@ window.QueryEmbedBlock = {
       // load.
       if (prev && !now && !this.result) this.fetch();
     },
+    contextDate(now, prev) {
+      // ``scope="daily"`` embeds are the same DB row across every daily,
+      // so navigating between dailies can reuse this component instance
+      // rather than remount it. Refetch so the results rebase to the
+      // new daily — but only when the view actually cares about
+      // context_date. Without the dates_relative_to_daily check we'd
+      // re-run every "live today" embed on every daily nav for no
+      // visible reason.
+      if (now !== prev && !this.collapsed && this._viewRebases()) {
+        this.fetch();
+      }
+    },
   },
 
   methods: {
+    _viewRebases() {
+      // The saved view payload includes ``dates_relative_to_daily`` once
+      // the embed has been fetched at least once; before then we'd have
+      // nothing to gate on, but the initial fetch ran in mounted() so
+      // contextDate changes only matter after that.
+      return !!(
+        this.result &&
+        this.result.view &&
+        this.result.view.dates_relative_to_daily
+      );
+    },
     async fetch() {
       if (!this.savedView || !this.savedView.uuid) {
         this.loading = false;
@@ -73,6 +103,7 @@ window.QueryEmbedBlock = {
         const r = await window.apiService.runSavedView({
           uuid: this.savedView.uuid,
           limit: 25,
+          contextDate: this.contextDate || null,
         });
         if (r && r.success) {
           this.result = r.data;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
@@ -53,6 +53,44 @@ window.QueryEmbedBlock = {
     collapsed() {
       return !!(this.embed && this.embed.collapsed);
     },
+    // The date-anchor badge: tells the reader whether this embed's date
+    // tokens resolved against the daily it's on, or against live today.
+    // Falls back to ``null`` until the first fetch lands, since we need
+    // the view payload's ``dates_relative_to_daily`` to know which mode
+    // we're in. Until then there's nothing to show, which is fine —
+    // the header loads in milliseconds and the badge appears with the
+    // results.
+    dateAnchor() {
+      if (!this.result || !this.result.view) return null;
+      const rebases = !!this.result.view.dates_relative_to_daily;
+      if (rebases && this.contextDate) {
+        return {
+          kind: "anchored",
+          label: this.contextDate,
+          tooltip:
+            `Date tokens (today / yesterday / N days ago) resolve to ` +
+            `${this.contextDate} for this embed — the daily page's date.`,
+        };
+      }
+      if (rebases) {
+        return {
+          kind: "unanchored",
+          label: "today",
+          tooltip:
+            `This view is set to "Dates relative to daily", but there's ` +
+            `no daily page in scope — date tokens fall back to the ` +
+            `current date.`,
+        };
+      }
+      return {
+        kind: "live",
+        label: "live",
+        tooltip:
+          `Date tokens (today / yesterday / N days ago) resolve to the ` +
+          `current date. Turn on "Dates relative to daily" in the saved ` +
+          `view editor to anchor them to the daily page instead.`,
+      };
+    },
   },
 
   mounted() {
@@ -162,6 +200,23 @@ window.QueryEmbedBlock = {
           :aria-label="collapsed ? 'Expand embed' : 'Collapse embed'"
         >{{ collapsed ? '▶' : '▼' }}</button>
         <a class="block-query-embed-title" :href="viewLink">≡ {{ title }}</a>
+        <span
+          v-if="dateAnchor && !collapsed"
+          class="block-query-embed-anchor"
+          :class="'is-' + dateAnchor.kind"
+          :title="dateAnchor.tooltip"
+        >
+          <svg
+            v-if="dateAnchor.kind !== 'live'"
+            class="block-query-embed-anchor-icon"
+            viewBox="0 0 16 16"
+            width="11"
+            height="11"
+            aria-hidden="true"
+            focusable="false"
+          ><path fill="currentColor" d="M8 1.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3ZM7.25 5.92V7.5H5.5a.5.5 0 0 0 0 1h1.75v4.97c-1.49-.18-2.62-1.07-3.13-1.91l.72-.43a.4.4 0 0 0-.15-.74L2.5 9.85a.4.4 0 0 0-.5.4v2.34a.4.4 0 0 0 .65.31l.7-.55C4.05 13.55 5.83 14.5 8 14.5s3.95-.95 4.65-2.15l.7.55a.4.4 0 0 0 .65-.31v-2.34a.4.4 0 0 0-.5-.4l-2.19.54a.4.4 0 0 0-.15.74l.72.43c-.51.84-1.64 1.73-3.13 1.91V8.5h1.75a.5.5 0 0 0 0-1H8.75V5.92a2.5 2.5 0 1 0-1.5 0Z"/></svg>
+          <span class="block-query-embed-anchor-label">{{ dateAnchor.label }}</span>
+        </span>
         <span v-if="result && !collapsed" class="block-query-embed-meta">
           {{ result.count }}<span v-if="result.truncated">+ truncated</span>
         </span>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
@@ -297,6 +297,7 @@ const SavedViewsPage = {
         // is immediately useful — matches the backend's empty-sort
         // default and saves the user a copy-paste from the cheatsheet.
         sort: '[\n  { "field": "created_at", "dir": "desc" }\n]',
+        dates_relative_to_daily: false,
       };
     },
 
@@ -354,6 +355,7 @@ const SavedViewsPage = {
         description: view.description || "",
         filter: JSON.stringify(view.filter || {}, null, 2),
         sort: JSON.stringify(view.sort || [], null, 2),
+        dates_relative_to_daily: !!view.dates_relative_to_daily,
       };
       this.editorErrors = {};
       this.saveError = null;
@@ -501,6 +503,7 @@ const SavedViewsPage = {
           description: this.editor.description.trim(),
           filter: parsed.filter,
           sort: parsed.sort,
+          dates_relative_to_daily: !!this.editor.dates_relative_to_daily,
         };
         if (this.editor.slug.trim()) {
           payload.slug = this.editor.slug.trim();
@@ -537,6 +540,7 @@ const SavedViewsPage = {
           description: this.editor.description.trim(),
           filter: parsed.filter,
           sort: parsed.sort,
+          dates_relative_to_daily: !!this.editor.dates_relative_to_daily,
         };
         if (this.editor.slug.trim()) {
           payload.slug = this.editor.slug.trim();
@@ -819,6 +823,15 @@ const SavedViewsPage = {
             <textarea v-model="editor.sort" rows="4" spellcheck="false"></textarea>
             <div v-if="editorErrors.sort" class="form-error">{{ editorErrors.sort }}</div>
           </div>
+          <div class="form-row">
+            <label class="checkbox-label">
+              <input v-model="editor.dates_relative_to_daily" type="checkbox" />
+              <span>Dates relative to daily</span>
+            </label>
+            <div class="form-hint">
+              When embedded on a daily page, "today" / "yesterday" / "N days ago" resolve to that daily's date instead of the actual current date. Useful for views like "Done today" so past dailies show what was done on that day, not zero. Leave off for live views like a current grocery list.
+            </div>
+          </div>
           <div class="form-row form-actions">
             <button class="btn btn-primary" @click="createView" :disabled="saving">
               {{ saving ? "Saving…" : "Create view" }}
@@ -909,6 +922,15 @@ const SavedViewsPage = {
               <label>Sort (JSON)</label>
               <textarea v-model="editor.sort" rows="4" spellcheck="false"></textarea>
               <div v-if="editorErrors.sort" class="form-error">{{ editorErrors.sort }}</div>
+            </div>
+            <div class="form-row">
+              <label class="checkbox-label">
+                <input v-model="editor.dates_relative_to_daily" type="checkbox" />
+                <span>Dates relative to daily</span>
+              </label>
+              <div class="form-hint">
+                When embedded on a daily page, "today" / "yesterday" / "N days ago" resolve to that daily's date instead of the actual current date. Useful for views like "Done today" so past dailies show what was done on that day, not zero. Leave off for live views like a current grocery list.
+              </div>
             </div>
             <div class="form-row form-actions">
               <button class="btn btn-primary" @click="saveEdits" :disabled="saving">

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -865,11 +865,21 @@ class ApiService {
     return await this.request(`/knowledge/api/views/get/?${qs}`);
   }
 
-  async runSavedView({ uuid = null, slug = null, limit = 100 } = {}) {
+  async runSavedView({
+    uuid = null,
+    slug = null,
+    limit = 100,
+    contextDate = null,
+  } = {}) {
     const params = new URLSearchParams();
     if (uuid) params.set("view_uuid", uuid);
     if (slug) params.set("view_slug", slug);
     params.set("limit", String(limit));
+    // contextDate (ISO YYYY-MM-DD) is sent when the embed is rendered
+    // inside a daily page. The server only honors it when the saved
+    // view's ``dates_relative_to_daily`` flag is on; otherwise it's a
+    // no-op. Pass null for non-daily surfaces.
+    if (contextDate) params.set("context_date", contextDate);
     return await this.request(`/knowledge/api/views/run/?${params.toString()}`);
   }
 

--- a/packages/django-app/app/knowledge/test/commands/test_saved_view_commands.py
+++ b/packages/django-app/app/knowledge/test/commands/test_saved_view_commands.py
@@ -89,6 +89,16 @@ class CreateSavedViewTests(_SavedViewTestBase):
         with self.assertRaises(ValidationError):
             self._make(filter={"never_heard_of_it": 1})
 
+    def test_dates_relative_to_daily_defaults_off(self):
+        view = self._make()
+        self.assertFalse(view.dates_relative_to_daily)
+
+    def test_dates_relative_to_daily_persists_when_set(self):
+        view = self._make(dates_relative_to_daily=True)
+        self.assertTrue(view.dates_relative_to_daily)
+        # Round-trip through to_dict so the API payload matches.
+        self.assertTrue(view.to_dict()["dates_relative_to_daily"])
+
 
 class UpdateSavedViewTests(_SavedViewTestBase):
     def _create_user_view(self):
@@ -116,6 +126,32 @@ class UpdateSavedViewTests(_SavedViewTestBase):
         updated = UpdateSavedViewCommand(form).execute()
         self.assertEqual(updated.name, "Renamed")
         self.assertEqual(updated.filter, {"block_type": "doing"})
+
+    def test_can_toggle_dates_relative_to_daily(self):
+        view = self._create_user_view()
+        self.assertFalse(view.dates_relative_to_daily)
+        form = UpdateSavedViewForm(
+            {
+                "user": self.user.id,
+                "view_uuid": str(view.uuid),
+                "dates_relative_to_daily": True,
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        updated = UpdateSavedViewCommand(form).execute()
+        self.assertTrue(updated.dates_relative_to_daily)
+
+        # And it can be turned back off.
+        off_form = UpdateSavedViewForm(
+            {
+                "user": self.user.id,
+                "view_uuid": str(view.uuid),
+                "dates_relative_to_daily": False,
+            }
+        )
+        self.assertTrue(off_form.is_valid())
+        off = UpdateSavedViewCommand(off_form).execute()
+        self.assertFalse(off.dates_relative_to_daily)
 
     def test_cannot_edit_system_view(self):
         sys_view = SavedView.objects.get(
@@ -249,6 +285,120 @@ class RunSavedViewTests(_SavedViewTestBase):
         self.assertTrue(form.is_valid())
         with self.assertRaises(ValidationError):
             RunSavedViewCommand(form).execute()
+
+    def test_context_date_rebases_today_when_view_opts_in(self):
+        # "Done today" with dates_relative_to_daily=True, run with
+        # context_date=2026-04-20 → counts blocks completed on that day,
+        # not on the live today (2026-04-24).
+        view = SavedView.objects.create(
+            user=self.user,
+            name="Done today",
+            slug="done-today",
+            filter={
+                "all": [
+                    {"block_type": {"in": ["done", "wontdo"]}},
+                    {"completed_at": "today"},
+                ]
+            },
+            dates_relative_to_daily=True,
+        )
+        rebased_match = BlockFactory(
+            user=self.user,
+            page=self.page,
+            block_type="done",
+            completed_at=_utc_noon(date(2026, 4, 20)),
+        )
+        BlockFactory(
+            user=self.user,
+            page=self.page,
+            block_type="done",
+            completed_at=_utc_noon(self.today),
+        )
+        form = RunSavedViewForm(
+            {
+                "user": self.user.id,
+                "view_uuid": str(view.uuid),
+                "context_date": "2026-04-20",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        result = RunSavedViewCommand(form).execute()
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["results"][0]["uuid"], str(rebased_match.uuid))
+
+    def test_context_date_ignored_when_view_does_not_opt_in(self):
+        # Same view but without the flag — context_date is sent by the
+        # client (every daily-page embed sends it) but the command must
+        # ignore it, leaving "today" resolved to the live current date.
+        view = SavedView.objects.create(
+            user=self.user,
+            name="Done today (live)",
+            slug="done-today-live",
+            filter={
+                "all": [
+                    {"block_type": {"in": ["done", "wontdo"]}},
+                    {"completed_at": "today"},
+                ]
+            },
+            dates_relative_to_daily=False,
+        )
+        BlockFactory(
+            user=self.user,
+            page=self.page,
+            block_type="done",
+            completed_at=_utc_noon(date(2026, 4, 20)),
+        )
+        live_match = BlockFactory(
+            user=self.user,
+            page=self.page,
+            block_type="done",
+            completed_at=_utc_noon(self.today),
+        )
+        form = RunSavedViewForm(
+            {
+                "user": self.user.id,
+                "view_uuid": str(view.uuid),
+                "context_date": "2026-04-20",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        result = RunSavedViewCommand(form).execute()
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["results"][0]["uuid"], str(live_match.uuid))
+
+    def test_no_context_date_with_flag_falls_back_to_today(self):
+        # The toggle is on but no context_date is sent (the standalone
+        # /views runner has no daily context). Should resolve to today
+        # like normal — the flag without a date is harmless.
+        view = SavedView.objects.create(
+            user=self.user,
+            name="Done today (rebases)",
+            slug="done-today-rebases",
+            filter={
+                "all": [
+                    {"block_type": {"in": ["done", "wontdo"]}},
+                    {"completed_at": "today"},
+                ]
+            },
+            dates_relative_to_daily=True,
+        )
+        live_match = BlockFactory(
+            user=self.user,
+            page=self.page,
+            block_type="done",
+            completed_at=_utc_noon(self.today),
+        )
+        BlockFactory(
+            user=self.user,
+            page=self.page,
+            block_type="done",
+            completed_at=_utc_noon(date(2026, 4, 20)),
+        )
+        form = RunSavedViewForm({"user": self.user.id, "view_uuid": str(view.uuid)})
+        self.assertTrue(form.is_valid(), form.errors)
+        result = RunSavedViewCommand(form).execute()
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["results"][0]["uuid"], str(live_match.uuid))
 
 
 class ListGetSavedViewTests(_SavedViewTestBase):

--- a/packages/django-app/app/knowledge/test/services/test_query_engine.py
+++ b/packages/django-app/app/knowledge/test/services/test_query_engine.py
@@ -797,3 +797,94 @@ class TopLevelTests(_EngineTestBase):
     def test_combinator_empty_list_rejected(self):
         with self.assertRaises(query_engine.QueryEngineError):
             query_engine.compile({"all": []}, user=self.user)
+
+
+class ContextDateTests(_EngineTestBase):
+    """``compile(context_date=...)`` rebases relative date tokens.
+
+    The Run command passes the daily-page's date through as context_date
+    when a SavedView has ``dates_relative_to_daily=True``. Tokens that
+    are absolute by construction (ISO ``YYYY-MM-DD``) ignore it.
+    """
+
+    def _run_with_context(self, spec, context_date):
+        compiled = query_engine.compile(spec, user=self.user, context_date=context_date)
+        return list(BlockRepository.run_compiled_query(self.user, compiled))
+
+    def test_today_resolves_to_context_date(self):
+        # ``self.today`` (pinned via the base class) is 2026-04-24. A
+        # context_date of 2026-04-20 should make ``today`` resolve to
+        # that date instead.
+        match = BlockFactory(
+            user=self.user, page=self.page, scheduled_for=date(2026, 4, 20)
+        )
+        BlockFactory(user=self.user, page=self.page, scheduled_for=date(2026, 4, 24))
+        out = self._run_with_context(
+            {"scheduled_for": "today"}, context_date=date(2026, 4, 20)
+        )
+        self.assertEqual([b.id for b in out], [match.id])
+
+    def test_yesterday_rebases_off_context_date(self):
+        # context_date=2026-04-20 → yesterday=2026-04-19
+        match = BlockFactory(
+            user=self.user, page=self.page, scheduled_for=date(2026, 4, 19)
+        )
+        BlockFactory(user=self.user, page=self.page, scheduled_for=date(2026, 4, 23))
+        out = self._run_with_context(
+            {"scheduled_for": "yesterday"}, context_date=date(2026, 4, 20)
+        )
+        self.assertEqual([b.id for b in out], [match.id])
+
+    def test_n_days_ago_rebases_off_context_date(self):
+        # context_date=2026-04-20, "3 days ago" → 2026-04-17
+        match = BlockFactory(
+            user=self.user, page=self.page, scheduled_for=date(2026, 4, 17)
+        )
+        BlockFactory(user=self.user, page=self.page, scheduled_for=date(2026, 4, 21))
+        out = self._run_with_context(
+            {"scheduled_for": {"eq": "3 days ago"}}, context_date=date(2026, 4, 20)
+        )
+        self.assertEqual([b.id for b in out], [match.id])
+
+    def test_iso_date_is_absolute_and_ignores_context(self):
+        match = BlockFactory(
+            user=self.user, page=self.page, scheduled_for=date(2026, 5, 1)
+        )
+        BlockFactory(user=self.user, page=self.page, scheduled_for=date(2026, 4, 20))
+        out = self._run_with_context(
+            {"scheduled_for": "2026-05-01"}, context_date=date(2026, 4, 20)
+        )
+        self.assertEqual([b.id for b in out], [match.id])
+
+    def test_completed_at_today_rebases_to_context_local_day(self):
+        # ``completed_at`` is a DateTimeField — the engine compares
+        # against user-local day boundaries. With context_date=2026-04-20
+        # and user.timezone=UTC, ``completed_at eq today`` should match
+        # the block completed during 2026-04-20 UTC and exclude one
+        # completed on 2026-04-24 (the live today).
+        rebased_match = BlockFactory(
+            user=self.user,
+            page=self.page,
+            completed_at=_utc_noon(date(2026, 4, 20)),
+        )
+        BlockFactory(
+            user=self.user,
+            page=self.page,
+            completed_at=_utc_noon(self.today),  # 2026-04-24
+        )
+        out = self._run_with_context(
+            {"completed_at": "today"}, context_date=date(2026, 4, 20)
+        )
+        self.assertEqual([b.id for b in out], [rebased_match.id])
+
+    def test_none_context_falls_back_to_user_today(self):
+        # Sanity: passing context_date=None (or omitting it) keeps the
+        # existing "live today" semantics, so non-rebased views still
+        # behave as before.
+        match = BlockFactory(user=self.user, page=self.page, scheduled_for=self.today)
+        BlockFactory(user=self.user, page=self.page, scheduled_for=date(2026, 4, 20))
+        compiled = query_engine.compile(
+            {"scheduled_for": "today"}, user=self.user, context_date=None
+        )
+        out = list(BlockRepository.run_compiled_query(self.user, compiled))
+        self.assertEqual([b.id for b in out], [match.id])


### PR DESCRIPTION
Adds a `dates_relative_to_daily` toggle to SavedView that allows date tokens ("today", "yesterday", "N days ago") in filter expressions to resolve against a daily page's date instead of the live current date. This enables views like "Done today" to show accurate results when viewing past dailies.

**Key changes:**

- **Model & Migration**: Added `dates_relative_to_daily` BooleanField to SavedView (defaults to False for backward compatibility)
- **Query Engine**: Extended `compile()` and all date-handling functions to accept optional `context_date` parameter that overrides `user.today()` for relative date token resolution. ISO date strings remain absolute and ignore context_date.
- **Run Command**: Gates context_date honor on the view's opt-in flag — only passes it to the query engine when `dates_relative_to_daily=True`, preventing unintended rebasing on views that haven't opted in
- **Forms & Commands**: Updated CreateSavedViewForm, UpdateSavedViewForm, and their corresponding commands to handle the new field
- **Frontend**: 
  - QueryEmbedBlock now accepts `contextDate` prop (passed from daily pages) and refetches when it changes if the view has opted in
  - SavedViewsPage editor includes checkbox to toggle the flag with explanatory hint text
  - API service passes contextDate to /api/views/run/ endpoint
  - Page component forwards currentDate to embedded QueryEmbedBlock instances
- **Styling**: Added checkbox-label and form-hint CSS classes for the editor UI

**Implementation details:**

The feature is fully backward compatible — views without the flag set continue to use live `user.today()` regardless of any context_date sent by the client. The server-side gate ensures daily-page embeds can safely send context_date on every request without affecting non-opted-in views. Tests cover creation, toggling, persistence, and the three execution scenarios (rebased, ignored, and fallback-to-today).

https://claude.ai/code/session_01BQtD3We2miLuHKxPYo5TJ1