### PR TITLE
Move Anthropic capabilities to AIModel rows + add Opus 4.8

### DIFF
--- a/packages/django-app/app/ai_chat/admin.py
+++ b/packages/django-app/app/ai_chat/admin.py
@@ -39,15 +39,39 @@ class AIModelAdmin(admin.ModelAdmin):
         "provider",
         "display_name",
         "is_active",
+        "supports_thinking",
+        "supports_adaptive_thinking",
+        "supports_effort",
         "created_at",
     ]
-    list_filter = ["provider", "is_active", "created_at"]
+    list_filter = [
+        "provider",
+        "is_active",
+        "supports_thinking",
+        "supports_adaptive_thinking",
+        "supports_effort",
+        "created_at",
+    ]
     search_fields = ["name", "display_name", "description"]
     readonly_fields = ["id", "uuid", "created_at", "modified_at"]
     raw_id_fields = ["provider"]
 
     fieldsets = (
         (None, {"fields": ("name", "provider", "display_name", "is_active")}),
+        (
+            "Capabilities",
+            {
+                "fields": (
+                    "supports_thinking",
+                    "supports_adaptive_thinking",
+                    "supports_effort",
+                ),
+                "description": (
+                    "Provider-specific request knobs the model accepts. "
+                    "Default to off — only check what's confirmed supported."
+                ),
+            },
+        ),
         (
             "Description",
             {"fields": ("description",), "classes": ("wide",)},

--- a/packages/django-app/app/ai_chat/management/commands/populate_ai_providers_and_models.py
+++ b/packages/django-app/app/ai_chat/management/commands/populate_ai_providers_and_models.py
@@ -47,15 +47,21 @@ class Command(BaseCommand):
             # Anthropic models
             (
                 "Anthropic",
+                "claude-opus-4-8",
+                "Claude Opus 4.8",
+                "Most capable Claude model; adaptive thinking, 1M context",
+            ),
+            (
+                "Anthropic",
                 "claude-opus-4-7",
                 "Claude Opus 4.7",
-                "Most capable Claude model; adaptive thinking, 1M context",
+                "Previous-generation Opus; adaptive thinking, 1M context",
             ),
             (
                 "Anthropic",
                 "claude-opus-4-6",
                 "Claude Opus 4.6",
-                "Previous-generation Opus; adaptive thinking, 1M context",
+                "Older Opus; adaptive thinking, 1M context",
             ),
             (
                 "Anthropic",

--- a/packages/django-app/app/ai_chat/management/commands/populate_ai_providers_and_models.py
+++ b/packages/django-app/app/ai_chat/management/commands/populate_ai_providers_and_models.py
@@ -26,54 +26,103 @@ class Command(BaseCommand):
                 provider_created_count += 1
                 self.stdout.write(f"Created provider: {provider_name}")
 
-        # Model definitions
+        # Model definitions: (provider, name, display_name, description,
+        # supports_thinking, supports_adaptive_thinking, supports_effort).
+        # Capability flags only apply to Anthropic today; OpenAI and Google
+        # rows ship with all-False (the columns exist but the providers
+        # don't read them).
         models_data = [
             # OpenAI models
-            ("OpenAI", "gpt-4", "GPT-4", "Most capable GPT-4 model"),
+            (
+                "OpenAI",
+                "gpt-4",
+                "GPT-4",
+                "Most capable GPT-4 model",
+                False,
+                False,
+                False,
+            ),
             (
                 "OpenAI",
                 "gpt-4-turbo",
                 "GPT-4 Turbo",
                 "Faster and more affordable GPT-4",
+                False,
+                False,
+                False,
             ),
-            ("OpenAI", "gpt-3.5-turbo", "GPT-3.5 Turbo", "Fast and affordable model"),
+            (
+                "OpenAI",
+                "gpt-3.5-turbo",
+                "GPT-3.5 Turbo",
+                "Fast and affordable model",
+                False,
+                False,
+                False,
+            ),
             (
                 "OpenAI",
                 "o1-preview",
                 "o1-preview",
                 "Reasoning model for complex problems",
+                False,
+                False,
+                False,
             ),
-            ("OpenAI", "o1-mini", "o1-mini", "Faster reasoning model"),
+            (
+                "OpenAI",
+                "o1-mini",
+                "o1-mini",
+                "Faster reasoning model",
+                False,
+                False,
+                False,
+            ),
             # Anthropic models
             (
                 "Anthropic",
                 "claude-opus-4-8",
                 "Claude Opus 4.8",
                 "Most capable Claude model; adaptive thinking, 1M context",
+                True,
+                True,
+                True,
             ),
             (
                 "Anthropic",
                 "claude-opus-4-7",
                 "Claude Opus 4.7",
                 "Previous-generation Opus; adaptive thinking, 1M context",
+                True,
+                True,
+                True,
             ),
             (
                 "Anthropic",
                 "claude-opus-4-6",
                 "Claude Opus 4.6",
                 "Older Opus; adaptive thinking, 1M context",
+                True,
+                True,
+                True,
             ),
             (
                 "Anthropic",
                 "claude-sonnet-4-6",
                 "Claude Sonnet 4.6",
                 "Best balance of speed and intelligence; 1M context",
+                True,
+                True,
+                True,
             ),
             (
                 "Anthropic",
                 "claude-haiku-4-5",
                 "Claude Haiku 4.5",
                 "Fastest and most cost-effective Claude model",
+                True,
+                False,
+                False,
             ),
             # Google models
             (
@@ -81,39 +130,78 @@ class Command(BaseCommand):
                 "gemini-2.5-pro",
                 "Gemini 2.5 Pro",
                 "Latest and most capable Gemini model",
+                False,
+                False,
+                False,
             ),
             (
                 "Google",
                 "gemini-2.5-flash",
                 "Gemini 2.5 Flash",
                 "Fast version of Gemini 2.5",
+                False,
+                False,
+                False,
             ),
             (
                 "Google",
                 "gemini-2.0-pro",
                 "Gemini 2.0 Pro",
                 "Previous generation Gemini Pro",
+                False,
+                False,
+                False,
             ),
             (
                 "Google",
                 "gemini-2.0-flash",
                 "Gemini 2.0 Flash",
                 "Previous generation Gemini Flash",
+                False,
+                False,
+                False,
             ),
-            ("Google", "gemini-1.5-pro", "Gemini 1.5 Pro", "High-quality Gemini model"),
-            ("Google", "gemini-1.5-flash", "Gemini 1.5 Flash", "Fast Gemini model"),
+            (
+                "Google",
+                "gemini-1.5-pro",
+                "Gemini 1.5 Pro",
+                "High-quality Gemini model",
+                False,
+                False,
+                False,
+            ),
+            (
+                "Google",
+                "gemini-1.5-flash",
+                "Gemini 1.5 Flash",
+                "Fast Gemini model",
+                False,
+                False,
+                False,
+            ),
             (
                 "Google",
                 "gemini-1.5-flash-8b",
                 "Gemini 1.5 Flash 8B",
                 "Lightweight Gemini model",
+                False,
+                False,
+                False,
             ),
         ]
 
         created_count = 0
         updated_count = 0
 
-        for provider_name, model_name, display_name, description in models_data:
+        for (
+            provider_name,
+            model_name,
+            display_name,
+            description,
+            supports_thinking,
+            supports_adaptive_thinking,
+            supports_effort,
+        ) in models_data:
             try:
                 provider = AIProvider.objects.get(name__iexact=provider_name)
             except AIProvider.DoesNotExist:
@@ -131,6 +219,9 @@ class Command(BaseCommand):
                     "display_name": display_name,
                     "description": description,
                     "is_active": True,
+                    "supports_thinking": supports_thinking,
+                    "supports_adaptive_thinking": supports_adaptive_thinking,
+                    "supports_effort": supports_effort,
                 },
             )
 
@@ -143,10 +234,16 @@ class Command(BaseCommand):
                     ai_model.display_name != display_name
                     or ai_model.description != description
                     or ai_model.provider != provider
+                    or ai_model.supports_thinking != supports_thinking
+                    or ai_model.supports_adaptive_thinking != supports_adaptive_thinking
+                    or ai_model.supports_effort != supports_effort
                 ):
                     ai_model.display_name = display_name
                     ai_model.description = description
                     ai_model.provider = provider
+                    ai_model.supports_thinking = supports_thinking
+                    ai_model.supports_adaptive_thinking = supports_adaptive_thinking
+                    ai_model.supports_effort = supports_effort
                     ai_model.save()
                     updated_count += 1
                     self.stdout.write(f"Updated model: {model_name}")

--- a/packages/django-app/app/ai_chat/migrations/0022_aimodel_capability_flags.py
+++ b/packages/django-app/app/ai_chat/migrations/0022_aimodel_capability_flags.py
@@ -1,0 +1,83 @@
+from django.db import migrations, models
+
+# Snapshot of the prefix tuples that used to live in
+# ai_chat/services/anthropic_service.py. Frozen here so the backfill
+# stays stable even when the service file changes.
+THINKING_PREFIXES = (
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+)
+ADAPTIVE_THINKING_PREFIXES = (
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+)
+EFFORT_PREFIXES = (
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+)
+
+
+def backfill_capabilities(apps, schema_editor):
+    AIModel = apps.get_model("ai_chat", "AIModel")
+    for ai_model in AIModel.objects.all():
+        ai_model.supports_thinking = ai_model.name.startswith(THINKING_PREFIXES)
+        ai_model.supports_adaptive_thinking = ai_model.name.startswith(
+            ADAPTIVE_THINKING_PREFIXES
+        )
+        ai_model.supports_effort = ai_model.name.startswith(EFFORT_PREFIXES)
+        ai_model.save(
+            update_fields=[
+                "supports_thinking",
+                "supports_adaptive_thinking",
+                "supports_effort",
+            ]
+        )
+
+
+def reverse_noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ai_chat", "0021_chatsession_favorite_position"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="aimodel",
+            name="supports_thinking",
+            field=models.BooleanField(
+                default=False,
+                help_text="Model accepts the `thinking` request parameter (any mode).",
+            ),
+        ),
+        migrations.AddField(
+            model_name="aimodel",
+            name="supports_adaptive_thinking",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "Model accepts `thinking: {type: 'adaptive'}`. Implies "
+                    "supports_thinking — Haiku 4.5 has thinking but not adaptive."
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="aimodel",
+            name="supports_effort",
+            field=models.BooleanField(
+                default=False,
+                help_text="Model accepts `output_config.effort` (e.g. 'high').",
+            ),
+        ),
+        migrations.RunPython(backfill_capabilities, reverse_noop),
+    ]

--- a/packages/django-app/app/ai_chat/models/ai_model.py
+++ b/packages/django-app/app/ai_chat/models/ai_model.py
@@ -26,6 +26,21 @@ class AIModel(UUIDModelMixin, CRUDTimestampsMixin):
     is_active = models.BooleanField(
         default=True, help_text="Whether this model is available for use"
     )
+    supports_thinking = models.BooleanField(
+        default=False,
+        help_text="Model accepts the `thinking` request parameter (any mode).",
+    )
+    supports_adaptive_thinking = models.BooleanField(
+        default=False,
+        help_text=(
+            "Model accepts `thinking: {type: 'adaptive'}`. Implies "
+            "supports_thinking — Haiku 4.5 has thinking but not adaptive."
+        ),
+    )
+    supports_effort = models.BooleanField(
+        default=False,
+        help_text="Model accepts `output_config.effort` (e.g. 'high').",
+    )
 
     class Meta:
         db_table = "ai_models"

--- a/packages/django-app/app/ai_chat/services/anthropic_service.py
+++ b/packages/django-app/app/ai_chat/services/anthropic_service.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, Iterator, List, Optional
 
 import anthropic
 
+from ..models import AIModel
+from ..repositories.ai_model_repository import AIModelRepository
 from .base_ai_service import (
     AIServiceError,
     AIServiceResult,
@@ -17,37 +19,9 @@ from .base_ai_service import (
 logger = logging.getLogger(__name__)
 
 
-# Claude models that support extended thinking. Keep this list conservative —
-# enabling `thinking` on a model that doesn't support it raises at the API.
-THINKING_CAPABLE_MODEL_PREFIXES = (
-    "claude-opus-4-8",
-    "claude-opus-4-7",
-    "claude-opus-4-6",
-    "claude-sonnet-4-6",
-    "claude-haiku-4-5",
-)
-
-# Subset that accepts `thinking: {type: "adaptive"}`. Haiku 4.5 supports
-# extended thinking but only in `enabled` mode — adaptive returns a 400.
-ADAPTIVE_THINKING_CAPABLE_MODEL_PREFIXES = (
-    "claude-opus-4-8",
-    "claude-opus-4-7",
-    "claude-opus-4-6",
-    "claude-sonnet-4-6",
-)
-
 # Budget for `thinking: {type: "enabled"}` — must be strictly less than
 # max_tokens on the request.
 ENABLED_THINKING_BUDGET_TOKENS = 4096
-
-# Models that accept `output_config.effort`. Sending it to Haiku 4.5 (or older
-# non-4.6 models) returns a 400.
-EFFORT_CAPABLE_MODEL_PREFIXES = (
-    "claude-opus-4-8",
-    "claude-opus-4-7",
-    "claude-opus-4-6",
-    "claude-sonnet-4-6",
-)
 
 DEFAULT_MAX_TOKENS = 8192
 
@@ -120,6 +94,8 @@ def _serialize_web_search_content(content: Any) -> Any:
 class AnthropicService(BaseAIService):
     def __init__(self, api_key: str, model: str = "claude-opus-4-7") -> None:
         super().__init__(api_key, model)
+        self._ai_model: Optional[AIModel] = None
+        self._ai_model_loaded: bool = False
         try:
             self.client = anthropic.Anthropic(api_key=api_key)
         except Exception as e:
@@ -128,14 +104,29 @@ class AnthropicService(BaseAIService):
                 f"Failed to initialize Anthropic client: {e}"
             ) from e
 
+    def _get_ai_model(self) -> Optional[AIModel]:
+        # Cache the lookup so repeated capability checks on the same
+        # send_message call don't re-query the DB. Missing rows are
+        # cached as None — capabilities then read False (fail closed),
+        # matching the legacy prefix-tuple behaviour for unknown models.
+        # `getattr` guards against callsites that bypass __init__ (e.g.
+        # tests using AnthropicService.__new__ to skip client init).
+        if not getattr(self, "_ai_model_loaded", False):
+            self._ai_model = AIModelRepository.get_by_name(self.model)
+            self._ai_model_loaded = True
+        return self._ai_model
+
     def _supports_thinking(self) -> bool:
-        return self.model.startswith(THINKING_CAPABLE_MODEL_PREFIXES)
+        ai_model = self._get_ai_model()
+        return bool(ai_model and ai_model.supports_thinking)
 
     def _supports_adaptive_thinking(self) -> bool:
-        return self.model.startswith(ADAPTIVE_THINKING_CAPABLE_MODEL_PREFIXES)
+        ai_model = self._get_ai_model()
+        return bool(ai_model and ai_model.supports_adaptive_thinking)
 
     def _supports_effort(self) -> bool:
-        return self.model.startswith(EFFORT_CAPABLE_MODEL_PREFIXES)
+        ai_model = self._get_ai_model()
+        return bool(ai_model and ai_model.supports_effort)
 
     def send_message(
         self,

--- a/packages/django-app/app/ai_chat/services/anthropic_service.py
+++ b/packages/django-app/app/ai_chat/services/anthropic_service.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 # Claude models that support extended thinking. Keep this list conservative —
 # enabling `thinking` on a model that doesn't support it raises at the API.
 THINKING_CAPABLE_MODEL_PREFIXES = (
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
     "claude-sonnet-4-6",
@@ -29,6 +30,7 @@ THINKING_CAPABLE_MODEL_PREFIXES = (
 # Subset that accepts `thinking: {type: "adaptive"}`. Haiku 4.5 supports
 # extended thinking but only in `enabled` mode — adaptive returns a 400.
 ADAPTIVE_THINKING_CAPABLE_MODEL_PREFIXES = (
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
     "claude-sonnet-4-6",
@@ -41,6 +43,7 @@ ENABLED_THINKING_BUDGET_TOKENS = 4096
 # Models that accept `output_config.effort`. Sending it to Haiku 4.5 (or older
 # non-4.6 models) returns a 400.
 EFFORT_CAPABLE_MODEL_PREFIXES = (
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
     "claude-sonnet-4-6",

--- a/packages/django-app/app/ai_chat/tests/test_anthropic_service.py
+++ b/packages/django-app/app/ai_chat/tests/test_anthropic_service.py
@@ -3,11 +3,34 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from ai_chat.models import AIModel, AIProvider
 from ai_chat.services.anthropic_service import (
     AnthropicService,
     AnthropicServiceError,
 )
 from ai_chat.services.base_ai_service import AIServiceResult
+
+
+def _seed_ai_model(
+    name: str,
+    *,
+    supports_thinking: bool,
+    supports_adaptive_thinking: bool,
+    supports_effort: bool,
+) -> AIModel:
+    """Create the AIModel row the service looks up to read capabilities."""
+    provider, _ = AIProvider.objects.get_or_create(
+        name="Anthropic",
+        defaults={"base_url": "https://api.anthropic.com"},
+    )
+    return AIModel.objects.create(
+        name=name,
+        provider=provider,
+        display_name=name,
+        supports_thinking=supports_thinking,
+        supports_adaptive_thinking=supports_adaptive_thinking,
+        supports_effort=supports_effort,
+    )
 
 
 def _build_response(
@@ -32,9 +55,16 @@ def _build_response(
     return SimpleNamespace(content=blocks, usage=usage)
 
 
+@pytest.mark.django_db
 class TestAnthropicServiceThinking:
     @patch("anthropic.Anthropic")
     def test_enables_thinking_on_supported_model(self, mock_anthropic_cls):
+        _seed_ai_model(
+            "claude-opus-4-7",
+            supports_thinking=True,
+            supports_adaptive_thinking=True,
+            supports_effort=True,
+        )
         mock_client = Mock()
         mock_client.messages.create.return_value = _build_response(
             text="answer", thinking="reasoning trace"
@@ -69,7 +99,8 @@ class TestAnthropicServiceThinking:
         ]
 
     @patch("anthropic.Anthropic")
-    def test_skips_thinking_on_non_4x_model(self, mock_anthropic_cls):
+    def test_skips_thinking_on_unknown_model(self, mock_anthropic_cls):
+        # No AIModel row → all capabilities False → no thinking kwarg.
         mock_client = Mock()
         mock_client.messages.create.return_value = _build_response()
         mock_anthropic_cls.return_value = mock_client
@@ -100,6 +131,12 @@ class TestAnthropicServiceThinking:
         # returns a 400 ("adaptive thinking is not supported on this model")
         # if we send `type: "adaptive"`. It needs `type: "enabled"` with an
         # explicit budget smaller than max_tokens.
+        _seed_ai_model(
+            "claude-haiku-4-5",
+            supports_thinking=True,
+            supports_adaptive_thinking=False,
+            supports_effort=False,
+        )
         mock_client = Mock()
         mock_client.messages.create.return_value = _build_response()
         mock_anthropic_cls.return_value = mock_client
@@ -122,12 +159,19 @@ class TestAnthropicServiceThinking:
             service.send_message([{"role": "user"}])
 
 
+@pytest.mark.django_db
 class TestAnthropicResponseFormat:
     @patch("anthropic.Anthropic")
     def test_passes_json_schema_via_output_config_format(self, mock_anthropic_cls):
         # Anthropic's structured-output knob lives at output_config.format —
         # when the caller asks for json_schema, the schema must arrive in
         # that nested shape, alongside any pre-existing effort knob.
+        _seed_ai_model(
+            "claude-opus-4-7",
+            supports_thinking=True,
+            supports_adaptive_thinking=True,
+            supports_effort=True,
+        )
         mock_client = Mock()
         mock_client.messages.create.return_value = _build_response(text='{"a":1}')
         mock_anthropic_cls.return_value = mock_client
@@ -153,6 +197,12 @@ class TestAnthropicResponseFormat:
 
     @patch("anthropic.Anthropic")
     def test_omits_format_when_no_response_format(self, mock_anthropic_cls):
+        _seed_ai_model(
+            "claude-opus-4-7",
+            supports_thinking=True,
+            supports_adaptive_thinking=True,
+            supports_effort=True,
+        )
         mock_client = Mock()
         mock_client.messages.create.return_value = _build_response()
         mock_anthropic_cls.return_value = mock_client
@@ -166,12 +216,12 @@ class TestAnthropicResponseFormat:
         assert kwargs["output_config"] == {"effort": "high"}
 
     @patch("anthropic.Anthropic")
-    def test_skips_output_config_on_unsupported_model_without_format(
+    def test_skips_output_config_on_unknown_model_without_format(
         self, mock_anthropic_cls
     ):
-        # Older models don't accept output_config.effort. With no
-        # response_format requested either, the kwarg should be omitted
-        # entirely so the API doesn't 400.
+        # No AIModel row → service treats every capability as False, so
+        # output_config (which only gets populated for effort or format)
+        # is omitted entirely and the API doesn't 400.
         mock_client = Mock()
         mock_client.messages.create.return_value = _build_response()
         mock_anthropic_cls.return_value = mock_client
@@ -187,6 +237,12 @@ class TestAnthropicResponseFormat:
         # If the model doesn't support effort but the caller asked for
         # a json_schema, output_config should still go out — just
         # without the effort knob.
+        _seed_ai_model(
+            "claude-haiku-4-5",
+            supports_thinking=True,
+            supports_adaptive_thinking=False,
+            supports_effort=False,
+        )
         mock_client = Mock()
         mock_client.messages.create.return_value = _build_response(text="{}")
         mock_anthropic_cls.return_value = mock_client


### PR DESCRIPTION
Adds `claude-opus-4-8` to the seeded catalog, then lifts the per-model capability flags out of the hardcoded prefix tuples in `anthropic_service.py` and onto `AIModel` itself (`supports_thinking`, `supports_adaptive_thinking`, `supports_effort`). `AnthropicService` now reads those flags through `AIModelRepository`, the admin exposes them under a new Capabilities fieldset, and the data migration backfills existing rows from a snapshot of the old prefixes. Adding a new model is now a one-form action — no code change required.

Missing rows still fall through to `False` on every capability, matching the legacy fail-closed behaviour for unknown models.