### PR TITLE
Add block actions menu to saved-view result rows

### DIFF
--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -7958,14 +7958,27 @@ a.hashtag-mention:hover,
 }
 .result-row {
   display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 0.45rem;
   padding: 0.6rem 0.8rem;
   color: var(--text-primary);
-  text-decoration: none;
 }
 .result-row:hover {
   background: var(--hover-bg);
+}
+.result-row .block-bullet {
+  flex: 0 0 auto;
+  margin-top: 0;
+}
+.result-row-link {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  color: var(--text-primary);
+  text-decoration: none;
 }
 .result-content {
   font-size: 0.95rem;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -7980,6 +7980,14 @@ a.hashtag-mention:hover,
   color: var(--text-primary);
   text-decoration: none;
 }
+.result-row .result-row-menu-btn {
+  flex: 0 0 auto;
+  margin-top: 0;
+}
+.result-row:hover .result-row-menu-btn,
+.result-row .result-row-menu-btn:focus {
+  opacity: 1;
+}
 .result-content {
   font-size: 0.95rem;
 }

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -844,14 +844,48 @@ const BlockComponent = {
         this.contextMenuPosition = { x, y };
       });
 
-      // Add click listener to close menu after a short delay
+      // Capture-phase outside-click / outside-touchend handlers so we
+      // run BEFORE the target element's own handlers. Without this:
+      // - On desktop, tapping another block both closed the menu AND
+      //   fired the block's @click → started editing.
+      // - On mobile, handleContentTouchEnd preventDefaults touchend
+      //   (to suppress iOS double-tap zoom), which also suppresses
+      //   the synthesized click — so a click-only listener never
+      //   fired and the menu was effectively undismissable except
+      //   by picking one of its items.
+      // The setTimeout keeps the same click that opened us from
+      // immediately closing us via the document handler.
       setTimeout(() => {
-        document.addEventListener("click", this.hideContextMenu);
+        document.addEventListener("click", this.handleOutsideMenuClick, true);
+        document.addEventListener(
+          "touchend",
+          this.handleOutsideMenuClick,
+          true
+        );
       }, 10);
+    },
+    handleOutsideMenuClick(event) {
+      // Skip clicks inside any context menu (this one or a sibling
+      // EmbedContextMenu / BlockComponent menu) — they need to reach
+      // their own item handlers. Capture-phase listeners fire before
+      // bubble, so the @click.stop on the menu root can't help us
+      // here; check by class instead.
+      const target = event.target;
+      if (target && target.closest && target.closest(".block-context-menu")) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      this.hideContextMenu();
     },
     hideContextMenu() {
       this.showContextMenu = false;
-      document.removeEventListener("click", this.hideContextMenu);
+      document.removeEventListener("click", this.handleOutsideMenuClick, true);
+      document.removeEventListener(
+        "touchend",
+        this.handleOutsideMenuClick,
+        true
+      );
     },
 
     hideContextMenuAndRestoreFocus() {
@@ -996,8 +1030,15 @@ const BlockComponent = {
         this.contextMenuPosition = { x, y };
       });
 
+      // Same dual-listener pattern as showContextMenuAt — see the
+      // comment block there for why click-only isn't sufficient.
       setTimeout(() => {
-        document.addEventListener("click", this.hideContextMenu);
+        document.addEventListener("click", this.handleOutsideMenuClick, true);
+        document.addEventListener(
+          "touchend",
+          this.handleOutsideMenuClick,
+          true
+        );
       }, 10);
     },
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedContextMenu.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedContextMenu.js
@@ -110,8 +110,17 @@ window.EmbedContextMenu = {
       // its own items. The setTimeout is BlockComponent's pattern —
       // without it the same click that opened us would trigger an
       // immediate close.
+      //
+      // touchend is wired too: BlockComponent.handleContentTouchEnd
+      // (line ~737) calls preventDefault on touchend, which stops
+      // iOS from synthesizing the follow-up click — so a click-only
+      // listener never fires on mobile and the menu can't be
+      // dismissed by tapping a block. Capturing touchend ourselves
+      // lets us consume the tap before BlockComponent's bubble
+      // handler enters the block into edit mode.
       setTimeout(() => {
         document.addEventListener("click", this.handleOutsideClick, true);
+        document.addEventListener("touchend", this.handleOutsideClick, true);
       }, 10);
     },
 
@@ -141,6 +150,7 @@ window.EmbedContextMenu = {
     close() {
       this.block = null;
       document.removeEventListener("click", this.handleOutsideClick, true);
+      document.removeEventListener("touchend", this.handleOutsideClick, true);
     },
 
     onAction(action) {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedContextMenu.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedContextMenu.js
@@ -100,17 +100,39 @@ window.EmbedContextMenu = {
         }
       });
 
-      // BlockComponent's delayed-add-listener pattern — without the
-      // setTimeout the same click that opened us would immediately
-      // close us via the document handler.
+      // Capture-phase outside-click handler so we run BEFORE the
+      // target element's own click handlers. Without this, tapping
+      // a result row / regular block / link while the menu is open
+      // both closes the menu AND fires the row's click (starts
+      // editing the block, follows the link). On mobile there's
+      // often no empty space to tap "between" items, so the menu
+      // becomes effectively un-dismissable except by picking one of
+      // its own items. The setTimeout is BlockComponent's pattern —
+      // without it the same click that opened us would trigger an
+      // immediate close.
       setTimeout(() => {
-        document.addEventListener("click", this.close);
+        document.addEventListener("click", this.handleOutsideClick, true);
       }, 10);
+    },
+
+    handleOutsideClick(event) {
+      // Clicks inside the menu must reach their own handlers (those
+      // drive the action emit + the menu's own close). The
+      // @click.stop on the menu root would normally suppress the
+      // document-level close on bubble, but capture-phase listeners
+      // run before bubble, so we have to skip inside clicks ourselves.
+      const el = this.$el;
+      if (el && el.nodeType === 1 && el.contains(event.target)) return;
+      // Outside click: consume the event so the target's own click
+      // handler (block-edit, link nav, row toggle) never runs.
+      event.preventDefault();
+      event.stopPropagation();
+      this.close();
     },
 
     close() {
       this.block = null;
-      document.removeEventListener("click", this.close);
+      document.removeEventListener("click", this.handleOutsideClick, true);
     },
 
     onAction(action) {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedContextMenu.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedContextMenu.js
@@ -1,0 +1,169 @@
+/**
+ * EmbedContextMenu — block actions menu for embedded saved-view results.
+ *
+ * Reuses BlockComponent's brutalist .block-context-menu styling.
+ * Owns its own open state + viewport-clamped positioning so callers
+ * just wire one ref method (`openAt(block, event)`) and an `action`
+ * listener. Items are fixed; the only knobs are which optional ones
+ * to show via `canSchedule` / `canBlockInfo` — those depend on whether
+ * the caller has the matching popover wired up (schedule and
+ * block-info both need a modal that lives on a host page).
+ *
+ * Inline content edits + tree-structural actions (indent / outdent /
+ * move up/down) stay deliberately out of scope: this menu is for
+ * surfaces that show blocks from elsewhere, so anything that would
+ * mutate the block's relationship to its source page (other than
+ * "move to") doesn't belong here.
+ */
+window.EmbedContextMenu = {
+  name: "EmbedContextMenu",
+  props: {
+    canSchedule: { type: Boolean, default: true },
+    canBlockInfo: { type: Boolean, default: true },
+  },
+  emits: ["action"],
+
+  data() {
+    return {
+      block: null, // null = menu hidden
+      position: { x: 0, y: 0 },
+    };
+  },
+
+  mounted() {
+    // Cross-instance dismiss: when any other EmbedContextMenu opens,
+    // close ourselves. Without this, opening a menu in one embed
+    // leaves a menu in another embed still visible — clicks that
+    // open the second menu call stopPropagation so the first menu's
+    // document.click close handler never fires.
+    this._onCloseOthers = (ev) => {
+      if (ev.detail?.except !== this && this.block) this.close();
+    };
+    document.addEventListener("embed-menu:close-others", this._onCloseOthers);
+  },
+
+  beforeUnmount() {
+    if (this._onCloseOthers) {
+      document.removeEventListener(
+        "embed-menu:close-others",
+        this._onCloseOthers
+      );
+    }
+    this.close();
+  },
+
+  methods: {
+    openAt(block, event) {
+      if (!block) return;
+      event.preventDefault();
+      event.stopPropagation();
+
+      document.dispatchEvent(
+        new CustomEvent("embed-menu:close-others", {
+          detail: { except: this },
+        })
+      );
+
+      // Mirrors BlockComponent.showContextMenuAt — fixed-positioned at
+      // the click point, then clamped to the viewport with extra
+      // mobile padding so the menu never tucks under the soft
+      // keyboard / browser chrome.
+      const menuWidth = 200;
+      const shadowOffset = 4;
+      const isMobile = window.innerWidth <= 768;
+      const edgePadding = isMobile ? 20 : 10;
+      const bottomPadding = isMobile ? 60 : 10;
+
+      let x = event.clientX;
+      let y = event.clientY;
+      const vw = window.innerWidth;
+      if (x + menuWidth + shadowOffset > vw - edgePadding) {
+        x = vw - menuWidth - shadowOffset - edgePadding;
+      }
+      x = Math.max(edgePadding, x);
+
+      this.position = { x, y };
+      this.block = block;
+
+      this.$nextTick(() => {
+        const el = this.$el?.querySelector?.(".block-context-menu");
+        if (!el) return;
+        const h = el.offsetHeight;
+        const vh = window.innerHeight;
+        let ny = y;
+        if (ny + h + shadowOffset > vh - bottomPadding) {
+          ny = vh - h - shadowOffset - bottomPadding;
+        }
+        ny = Math.max(edgePadding, ny);
+        if (ny !== this.position.y) {
+          this.position = { x, y: ny };
+        }
+      });
+
+      // BlockComponent's delayed-add-listener pattern — without the
+      // setTimeout the same click that opened us would immediately
+      // close us via the document handler.
+      setTimeout(() => {
+        document.addEventListener("click", this.close);
+      }, 10);
+    },
+
+    close() {
+      this.block = null;
+      document.removeEventListener("click", this.close);
+    },
+
+    onAction(action) {
+      const b = this.block;
+      this.close();
+      if (!b) return;
+      this.$emit("action", { action, block: b });
+    },
+  },
+
+  template: `
+    <div
+      v-if="block"
+      class="block-context-menu"
+      :style="{ left: position.x + 'px', top: position.y + 'px' }"
+      @click.stop
+      role="menu"
+    >
+      <button class="context-menu-item" role="menuitem" tabindex="-1" @click="onAction('moveToToday')">
+        <span class="context-menu-icon">⇨</span>
+        <span>move to today's daily</span>
+      </button>
+      <button class="context-menu-item" role="menuitem" tabindex="-1" @click="onAction('moveToPage')">
+        <span class="context-menu-icon">→</span>
+        <span>move to page…</span>
+      </button>
+      <button class="context-menu-item" role="menuitem" tabindex="-1" @click="onAction('copyLink')">
+        <span class="context-menu-icon">↗</span>
+        <span>copy link to block</span>
+      </button>
+      <template v-if="canSchedule">
+        <div class="context-menu-separator"></div>
+        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="onAction('schedule')">
+          <span class="context-menu-icon">◷</span>
+          <span>{{ block.scheduled_for ? 'reschedule…' : 'schedule…' }}</span>
+        </button>
+        <button v-if="block.scheduled_for" class="context-menu-item" role="menuitem" tabindex="-1" @click="onAction('unschedule')">
+          <span class="context-menu-icon">×</span>
+          <span>clear schedule</span>
+        </button>
+      </template>
+      <template v-if="canBlockInfo">
+        <div class="context-menu-separator"></div>
+        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="onAction('blockInfo')">
+          <span class="context-menu-icon">i</span>
+          <span>block info…</span>
+        </button>
+      </template>
+      <div class="context-menu-separator"></div>
+      <button class="context-menu-item context-menu-danger" role="menuitem" tabindex="-1" @click="onAction('delete')">
+        <span class="context-menu-icon">×</span>
+        <span>delete</span>
+      </button>
+    </div>
+  `,
+};

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedContextMenu.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedContextMenu.js
@@ -116,15 +116,23 @@ window.EmbedContextMenu = {
     },
 
     handleOutsideClick(event) {
-      // Clicks inside the menu must reach their own handlers (those
-      // drive the action emit + the menu's own close). The
-      // @click.stop on the menu root would normally suppress the
-      // document-level close on bubble, but capture-phase listeners
-      // run before bubble, so we have to skip inside clicks ourselves.
-      const el = this.$el;
-      if (el && el.nodeType === 1 && el.contains(event.target)) return;
+      // Clicks inside any context menu must reach their own
+      // handlers (item @click drives the action emit + the menu's
+      // own close). The @click.stop on the menu root only
+      // suppresses bubble, but we're in capture phase so we have
+      // to identify inside-menu clicks ourselves. Use a closest()
+      // check on the shared `.block-context-menu` class rather
+      // than `$el.contains` — $el is unreliable when v-if is at
+      // the template root (it can resolve to the comment-node
+      // placeholder), and the class check is what we actually mean
+      // semantically anyway.
+      const target = event.target;
+      if (target && target.closest && target.closest(".block-context-menu")) {
+        return;
+      }
       // Outside click: consume the event so the target's own click
-      // handler (block-edit, link nav, row toggle) never runs.
+      // handler (block-edit, link nav, row toggle) never runs, then
+      // close the menu.
       event.preventDefault();
       event.stopPropagation();
       this.close();

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
@@ -1,0 +1,277 @@
+/**
+ * EmbedResultRow — one block row in a saved-view result list.
+ *
+ * Used by every surface that renders blocks from elsewhere as a
+ * flat list (QueryEmbedBlock on pages, SavedViewsPage). Owns the
+ * row template, the bullet + click-to-cycle-todo behavior, the
+ * action handlers behind the EmbedContextMenu, and the menu itself.
+ *
+ * Parents pass the block + optional host-page-modal callbacks
+ * (`onScheduleBlock`, `onOpenBlockInfo`) and listen for `@changed`
+ * (uuid) to refresh their own state + dispatch the cross-component
+ * `brainspread:block-changed` event. Errors surface via `@error`
+ * (message) so the parent's error banner stays the single error
+ * surface — the row itself is intentionally stateless beyond the
+ * shared context menu.
+ *
+ * This intentionally stops short of editing / tree-structural
+ * behaviors (indent / outdent / add-child / drag). Those live in
+ * BlockComponent because they only make sense inside a block's
+ * home page; embed rows are display-only links into that home page.
+ */
+window.EmbedResultRow = {
+  name: "EmbedResultRow",
+
+  components: {
+    EmbedContextMenu: window.EmbedContextMenu || {},
+  },
+
+  props: {
+    block: { type: Object, required: true },
+    // Schedule + Block info both need a modal that lives on a host
+    // surface (Page.js / SavedViewsPage own the popover instances).
+    // The menu hides the matching item when the callback is missing.
+    onScheduleBlock: { type: Function, default: null },
+    onOpenBlockInfo: { type: Function, default: null },
+  },
+
+  emits: ["changed", "error"],
+
+  methods: {
+    blockHref(b) {
+      if (!b || !b.page_slug) return "#";
+      return `/knowledge/page/${encodeURIComponent(b.page_slug)}/#block-${b.uuid}`;
+    },
+    blockLabel(b) {
+      const c = (b.content || "").trim();
+      if (!c) return "(empty block)";
+      return c.length > 200 ? c.slice(0, 200) + "…" : c;
+    },
+    isTodoType(b) {
+      return ["todo", "doing", "done", "later", "wontdo"].includes(
+        b && b.block_type
+      );
+    },
+    bulletSymbol(b) {
+      switch (b && b.block_type) {
+        case "todo":
+        case "later":
+          return "☐";
+        case "doing":
+          return "◐";
+        case "done":
+          return "☑";
+        case "wontdo":
+          return "⊘";
+        default:
+          return "•";
+      }
+    },
+
+    async toggleTodo() {
+      const b = this.block;
+      if (!this.isTodoType(b)) return;
+      try {
+        const r = await window.apiService.toggleBlockTodo(b.uuid);
+        if (r && r.success && r.data) {
+          // Mutate the prop in place so the bullet + meta update
+          // without forcing a parent refetch. The row stays visible
+          // even when the new state falls outside the saved view's
+          // filter — gives immediate feedback; a real refresh
+          // happens on the next fetch via the changed listener.
+          b.block_type = r.data.block_type;
+          b.completed_at = r.data.completed_at;
+          b.content = r.data.content;
+          this.$emit("changed", b.uuid);
+        } else {
+          const errs = (r && r.errors) || {};
+          this.$emit(
+            "error",
+            (errs.non_field_errors && errs.non_field_errors[0]) ||
+              "failed to toggle todo"
+          );
+        }
+      } catch (err) {
+        console.error("toggleBlockTodo failed:", err);
+        this.$emit("error", "failed to toggle todo. please try again.");
+      }
+    },
+
+    openRowMenu(event) {
+      this.$refs.rowMenu?.openAt(this.block, event);
+    },
+
+    async onMenuAction({ action, block }) {
+      if (!block) return;
+      switch (action) {
+        case "moveToToday":
+          await this.actionMoveToToday(block);
+          break;
+        case "moveToPage":
+          await this.actionMoveToPage(block);
+          break;
+        case "copyLink":
+          await this.actionCopyLink(block);
+          break;
+        case "schedule":
+          this.actionSchedule(block, { clear: false });
+          break;
+        case "unschedule":
+          this.actionSchedule(block, { clear: true });
+          break;
+        case "blockInfo":
+          this.actionBlockInfo(block);
+          break;
+        case "delete":
+          await this.actionDelete(block);
+          break;
+      }
+    },
+
+    async actionMoveToToday(b) {
+      try {
+        const r = await window.apiService.moveBlockToDaily(b.uuid);
+        if (!r || !r.success) {
+          throw new Error(
+            r?.errors?.non_field_errors?.[0] || "move to today failed"
+          );
+        }
+        this.$emit("changed", b.uuid);
+      } catch (err) {
+        console.error("moveBlockToDaily failed:", err);
+        this.$emit("error", "failed to move block to today");
+      }
+    },
+
+    async actionMoveToPage(b) {
+      if (!window.appModals?.pickPage) {
+        console.error("appModals.pickPage is not available");
+        return;
+      }
+      const target = await window.appModals.pickPage({
+        title: "move block to page",
+        placeholder: "search pages…",
+        confirmLabel: "move",
+      });
+      if (!target) return;
+      try {
+        const r = await window.apiService.moveBlockToPage(b.uuid, target.uuid);
+        if (!r || !r.success) {
+          throw new Error(r?.errors?.non_field_errors?.[0] || "move failed");
+        }
+        this.$emit("changed", b.uuid);
+      } catch (err) {
+        console.error("moveBlockToPage failed:", err);
+        this.$emit("error", `failed to move block: ${err.message || err}`);
+      }
+    },
+
+    async actionCopyLink(b) {
+      if (!b.page_slug) {
+        this.$emit("error", "could not build block link");
+        return;
+      }
+      const url = `${window.location.origin}/knowledge/page/${encodeURIComponent(b.page_slug)}/#block-${b.uuid}`;
+      try {
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(url);
+          return;
+        }
+      } catch (err) {
+        console.warn("clipboard API failed, falling back:", err);
+      }
+      // execCommand fallback for http:// contexts where the async
+      // clipboard API is gated. Mirrors Page.js copyBlockLink.
+      try {
+        const ta = document.createElement("textarea");
+        ta.value = url;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand("copy");
+        document.body.removeChild(ta);
+      } catch (err) {
+        console.error("clipboard fallback failed:", err);
+        this.$emit("error", "could not copy link");
+      }
+    },
+
+    actionSchedule(b, opts) {
+      if (!this.onScheduleBlock) return;
+      this.onScheduleBlock(b, opts || {});
+      // No `changed` here — the host's popover fires
+      // brainspread:block-changed on save, which the parent listens
+      // to directly. Emitting `changed` here would refetch on cancel.
+    },
+
+    actionBlockInfo(b) {
+      if (!this.onOpenBlockInfo) return;
+      this.onOpenBlockInfo(b);
+    },
+
+    async actionDelete(b) {
+      const confirmed = await (window.appModals?.confirm?.({
+        title: "delete block?",
+        message: "this will also delete any child blocks and cannot be undone.",
+        confirmLabel: "delete",
+        destructive: true,
+      }) ?? Promise.resolve(window.confirm("Delete this block?")));
+      if (!confirmed) return;
+      try {
+        const r = await window.apiService.deleteBlock(b.uuid);
+        if (!r || !r.success) {
+          throw new Error(r?.errors?.non_field_errors?.[0] || "delete failed");
+        }
+        this.$emit("changed", b.uuid);
+      } catch (err) {
+        console.error("deleteBlock failed:", err);
+        this.$emit("error", `failed to delete block: ${err.message || err}`);
+      }
+    },
+  },
+
+  template: `
+    <li>
+      <div class="result-row" @contextmenu="openRowMenu($event)">
+        <div
+          class="block-bullet"
+          :class="{
+            'todo': block.block_type === 'todo',
+            'doing': block.block_type === 'doing',
+            'done': block.block_type === 'done',
+            'later': block.block_type === 'later',
+            'wontdo': block.block_type === 'wontdo'
+          }"
+          @click.stop="isTodoType(block) ? toggleTodo() : null"
+          :title="isTodoType(block) ? 'Cycle todo state' : ''"
+          :role="isTodoType(block) ? 'button' : null"
+          :aria-label="isTodoType(block) ? 'Cycle todo state' : null"
+        >{{ bulletSymbol(block) }}</div>
+        <a :href="blockHref(block)" class="result-row-link">
+          <span class="result-content">{{ blockLabel(block) }}</span>
+          <span class="result-meta">
+            <span v-if="block.block_type" class="result-block-type">{{ block.block_type }}</span>
+            <span v-if="block.scheduled_for"> · due {{ block.scheduled_for }}</span>
+            <span v-if="block.completed_at"> · done {{ block.completed_at.split('T')[0] }}</span>
+            <span v-if="block.page_title"> · {{ block.page_title }}</span>
+          </span>
+        </a>
+        <button
+          type="button"
+          class="block-menu result-row-menu-btn"
+          @click="openRowMenu($event)"
+          @contextmenu="openRowMenu($event)"
+          title="Block options"
+          aria-label="Block options"
+        >⋮</button>
+      </div>
+      <EmbedContextMenu
+        ref="rowMenu"
+        :can-schedule="!!onScheduleBlock"
+        :can-block-info="!!onOpenBlockInfo"
+        @action="onMenuAction"
+      />
+    </li>
+  `,
+};

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
@@ -7,12 +7,15 @@
  * action handlers behind the EmbedContextMenu, and the menu itself.
  *
  * Parents pass the block + optional host-page-modal callbacks
- * (`onScheduleBlock`, `onOpenBlockInfo`) and listen for `@changed`
- * (uuid) to refresh their own state + dispatch the cross-component
- * `brainspread:block-changed` event. Errors surface via `@error`
- * (message) so the parent's error banner stays the single error
- * surface — the row itself is intentionally stateless beyond the
- * shared context menu.
+ * (`onScheduleBlock`, `onOpenBlockInfo`) and an `onChanged(uuid)`
+ * async callback the row awaits after every mutation. The await
+ * matters: the parent typically refetches the saved view inside
+ * onChanged, and the row needs to wait on that before yielding —
+ * otherwise the user can re-open the menu before the prop has been
+ * replaced with the fresh block, and pick up stale page_slug etc.
+ * Errors surface via `@error` (message) so the parent's error
+ * banner stays the single error surface — the row itself is
+ * intentionally stateless beyond the shared context menu.
  *
  * This intentionally stops short of editing / tree-structural
  * behaviors (indent / outdent / add-child / drag). Those live in
@@ -40,9 +43,16 @@ window.EmbedResultRow = {
     onOpenBlockInfo: { type: Function, default: null },
     onMoveBlockToToday: { type: Function, default: null },
     onMoveBlockToPage: { type: Function, default: null },
+    // Awaitable refresh hook. Each action calls this after the
+    // backend mutation completes, and waits on the returned promise
+    // before yielding control back to the user — so by the time the
+    // user can open the menu again the row's `block` prop has been
+    // updated by the parent's refetch (otherwise a fast click would
+    // capture stale page_slug etc. from the pre-mutation block).
+    onChanged: { type: Function, default: null },
   },
 
-  emits: ["changed", "error"],
+  emits: ["error"],
 
   methods: {
     blockHref(b) {
@@ -89,7 +99,7 @@ window.EmbedResultRow = {
           b.block_type = r.data.block_type;
           b.completed_at = r.data.completed_at;
           b.content = r.data.content;
-          this.$emit("changed", b.uuid);
+          await this.notifyChanged(b.uuid);
         } else {
           const errs = (r && r.errors) || {};
           this.$emit(
@@ -106,6 +116,10 @@ window.EmbedResultRow = {
 
     openRowMenu(event) {
       this.$refs.rowMenu?.openAt(this.block, event);
+    },
+
+    async notifyChanged(uuid) {
+      if (this.onChanged) await this.onChanged(uuid);
     },
 
     async onMenuAction({ action, block }) {
@@ -141,7 +155,7 @@ window.EmbedResultRow = {
       // silently and the user has to refresh to see it.
       if (this.onMoveBlockToToday) {
         await this.onMoveBlockToToday(b);
-        this.$emit("changed", b.uuid);
+        await this.notifyChanged(b.uuid);
         return;
       }
       try {
@@ -151,7 +165,7 @@ window.EmbedResultRow = {
             r?.errors?.non_field_errors?.[0] || "move to today failed"
           );
         }
-        this.$emit("changed", b.uuid);
+        await this.notifyChanged(b.uuid);
       } catch (err) {
         console.error("moveBlockToDaily failed:", err);
         this.$emit("error", "failed to move block to today");
@@ -163,7 +177,7 @@ window.EmbedResultRow = {
       // the picker + reload when present.
       if (this.onMoveBlockToPage) {
         await this.onMoveBlockToPage(b);
-        this.$emit("changed", b.uuid);
+        await this.notifyChanged(b.uuid);
         return;
       }
       if (!window.appModals?.pickPage) {
@@ -181,7 +195,7 @@ window.EmbedResultRow = {
         if (!r || !r.success) {
           throw new Error(r?.errors?.non_field_errors?.[0] || "move failed");
         }
-        this.$emit("changed", b.uuid);
+        await this.notifyChanged(b.uuid);
       } catch (err) {
         console.error("moveBlockToPage failed:", err);
         this.$emit("error", `failed to move block: ${err.message || err}`);
@@ -245,7 +259,7 @@ window.EmbedResultRow = {
         if (!r || !r.success) {
           throw new Error(r?.errors?.non_field_errors?.[0] || "delete failed");
         }
-        this.$emit("changed", b.uuid);
+        await this.notifyChanged(b.uuid);
       } catch (err) {
         console.error("deleteBlock failed:", err);
         this.$emit("error", `failed to delete block: ${err.message || err}`);

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
@@ -28,11 +28,18 @@ window.EmbedResultRow = {
 
   props: {
     block: { type: Object, required: true },
-    // Schedule + Block info both need a modal that lives on a host
-    // surface (Page.js / SavedViewsPage own the popover instances).
-    // The menu hides the matching item when the callback is missing.
+    // Host-page delegates. Schedule + Block info both need a modal
+    // that lives on the host (Page.js / SavedViewsPage own those).
+    // Move-to-today / Move-to-page also delegate when provided so
+    // the host can reload its own block list — otherwise the moved
+    // block lands on the page silently and the user sees nothing
+    // until refresh. When a callback is missing, the row falls back
+    // to its own implementation (used by SavedViewsPage, which has
+    // no host page to update).
     onScheduleBlock: { type: Function, default: null },
     onOpenBlockInfo: { type: Function, default: null },
+    onMoveBlockToToday: { type: Function, default: null },
+    onMoveBlockToPage: { type: Function, default: null },
   },
 
   emits: ["changed", "error"],
@@ -129,6 +136,14 @@ window.EmbedResultRow = {
     },
 
     async actionMoveToToday(b) {
+      // Defer to the host when wired so the host page reloads its
+      // own block list — otherwise the moved block lands on the page
+      // silently and the user has to refresh to see it.
+      if (this.onMoveBlockToToday) {
+        await this.onMoveBlockToToday(b);
+        this.$emit("changed", b.uuid);
+        return;
+      }
       try {
         const r = await window.apiService.moveBlockToDaily(b.uuid);
         if (!r || !r.success) {
@@ -144,6 +159,13 @@ window.EmbedResultRow = {
     },
 
     async actionMoveToPage(b) {
+      // Same delegation reasoning as actionMoveToToday — host owns
+      // the picker + reload when present.
+      if (this.onMoveBlockToPage) {
+        await this.onMoveBlockToPage(b);
+        this.$emit("changed", b.uuid);
+        return;
+      }
       if (!window.appModals?.pickPage) {
         console.error("appModals.pickPage is not available");
         return;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -811,6 +811,13 @@ const Page = {
       try {
         const result = await window.apiService.deleteBlock(block.uuid);
         if (result.success) {
+          // Notify embeds that may still be displaying this block —
+          // their saved view re-run will drop the now-gone row.
+          document.dispatchEvent(
+            new CustomEvent("brainspread:block-changed", {
+              detail: { uuid: block.uuid },
+            })
+          );
           await this.loadPage();
         }
       } catch (error) {
@@ -871,6 +878,14 @@ const Page = {
           block.block_type = result.data.block_type;
           block.content = result.data.content;
           this.error = null;
+          // Embeds may be showing this block — let them re-run so the
+          // bullet / DONE strikethrough reflects the new state without
+          // a manual collapse-expand.
+          document.dispatchEvent(
+            new CustomEvent("brainspread:block-changed", {
+              detail: { uuid: block.uuid },
+            })
+          );
         } else {
           this.error =
             result.errors?.non_field_errors?.[0] || "Failed to toggle todo";
@@ -1039,6 +1054,14 @@ const Page = {
           );
         }
 
+        // Let any QueryEmbedBlock on this page re-run its saved view —
+        // the moved block's page_slug just changed and embeds keep
+        // their own copy of the block until they refetch.
+        document.dispatchEvent(
+          new CustomEvent("brainspread:block-changed", {
+            detail: { uuid: block.uuid },
+          })
+        );
         await this.loadPage({ silent: true });
       } catch (error) {
         console.error("failed to move block to today:", error);
@@ -1100,6 +1123,14 @@ const Page = {
           );
         }
 
+        // See moveBlockToToday for rationale — embeds keep their own
+        // copy of the block until they refetch, and the move just
+        // updated page_slug on the server.
+        document.dispatchEvent(
+          new CustomEvent("brainspread:block-changed", {
+            detail: { uuid: block.uuid },
+          })
+        );
         await this.loadPage({ silent: true });
       } catch (error) {
         console.error("failed to move block to page:", error);

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -4057,6 +4057,7 @@ const Page = {
             :on-move-up="idx > 0 ? moveEmbedUp : null"
             :on-move-down="idx < embeddedViews.length - 1 ? moveEmbedDown : null"
             :on-schedule-block="scheduleBlock"
+            :on-open-block-info="openBlockInfoModal"
           />
         </div>
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -2513,6 +2513,15 @@ const Page = {
             msg = `scheduled for ${scheduledFor}`;
           }
           this.$parent?.addToast?.(msg, "success");
+          // Notify any embeds on the page that show this block so
+          // they re-run their saved view — keeps the displayed
+          // scheduled_for / due meta in sync without a manual
+          // collapse-expand.
+          document.dispatchEvent(
+            new CustomEvent("brainspread:block-changed", {
+              detail: { uuid: block.uuid },
+            })
+          );
           await this.loadPage({ silent: true });
         } else {
           this.$parent?.addToast?.("failed to schedule block", "error");
@@ -4047,6 +4056,7 @@ const Page = {
             :on-toggle-collapsed="toggleEmbedCollapsed"
             :on-move-up="idx > 0 ? moveEmbedUp : null"
             :on-move-down="idx < embeddedViews.length - 1 ? moveEmbedDown : null"
+            :on-schedule-block="scheduleBlock"
           />
         </div>
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -4058,6 +4058,8 @@ const Page = {
             :on-move-down="idx < embeddedViews.length - 1 ? moveEmbedDown : null"
             :on-schedule-block="scheduleBlock"
             :on-open-block-info="openBlockInfoModal"
+            :on-move-block-to-today="moveBlockToToday"
+            :on-move-block-to-page="openMovePagePicker"
           />
         </div>
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
@@ -9,15 +9,17 @@
  * handles persistence (POST/DELETE/PUT to /api/embeds/) and refreshes
  * its own embedded_views state after each call.
  *
- * Result rows surface the block's todo-state bullet; clicking the
- * bullet cycles the block's state in place via the same endpoint
- * BlockComponent uses. Right-click (or the hover ⋮) opens an
- * EmbedContextMenu — see that component for the action list. Inline
- * content edits still require clicking through to the source page.
+ * Each matched block renders as an EmbedResultRow — that component
+ * owns the bullet, click-to-cycle-todo, the right-click menu, and
+ * the move/schedule/copy-link/delete/info action handlers. This
+ * component's job is the embed header, the loading / error / empty
+ * states, the saved-view fetch, and listening for cross-component
+ * change events so it re-runs the view when a displayed block
+ * mutates elsewhere on the page.
  */
 window.QueryEmbedBlock = {
   components: {
-    EmbedContextMenu: window.EmbedContextMenu || {},
+    EmbedResultRow: window.EmbedResultRow || {},
   },
 
   props: {
@@ -30,9 +32,8 @@ window.QueryEmbedBlock = {
     onMoveDown: { type: Function, default: null },
     // Schedule + Block info both need a modal that lives on the host
     // page (Page.js owns the ScheduleBlockPopover / BlockInfoModal
-    // instances). Caller wires these to open its modal for the given
-    // block; the embed hides the matching menu items when the
-    // callback isn't provided.
+    // instances). Forwarded to each EmbedResultRow, which hides the
+    // matching menu items when the callback isn't provided.
     onScheduleBlock: { type: Function, default: null },
     onOpenBlockInfo: { type: Function, default: null },
   },
@@ -64,12 +65,11 @@ window.QueryEmbedBlock = {
 
   mounted() {
     if (!this.collapsed) this.fetch();
-    // Re-run the saved view when any embed action elsewhere on the
-    // page mutates a block we might be displaying. The toggle bullet
-    // and the row context-menu actions all broadcast this event.
-    // We tag our own broadcasts with `source: this` so the local
-    // action path (which already refetches synchronously) doesn't
-    // also trigger a redundant fetch from the listener.
+    // Re-run the saved view when any block we might be displaying
+    // mutates elsewhere on the page (a different embed's row, the
+    // home-page editor, etc.). Our own row actions also broadcast
+    // through onRowChanged below; tag the broadcast with
+    // `source: this` so the listener skips our own refetch loop.
     this._onBlocksChanged = (ev) => {
       const uuid = ev?.detail?.uuid;
       if (!uuid || ev?.detail?.source === this) return;
@@ -131,66 +131,6 @@ window.QueryEmbedBlock = {
         this.loading = false;
       }
     },
-    blockHref(b) {
-      if (!b || !b.page_slug) return "#";
-      return `/knowledge/page/${encodeURIComponent(b.page_slug)}/#block-${
-        b.uuid
-      }`;
-    },
-    blockLabel(b) {
-      const c = (b.content || "").trim();
-      if (!c) return "(empty block)";
-      return c.length > 200 ? c.slice(0, 200) + "…" : c;
-    },
-    isTodoType(b) {
-      return ["todo", "doing", "done", "later", "wontdo"].includes(
-        b && b.block_type
-      );
-    },
-    bulletSymbol(b) {
-      switch (b && b.block_type) {
-        case "todo":
-        case "later":
-          return "☐";
-        case "doing":
-          return "◐";
-        case "done":
-          return "☑";
-        case "wontdo":
-          return "⊘";
-        default:
-          return "•";
-      }
-    },
-    async toggleTodo(b) {
-      if (!this.isTodoType(b)) return;
-      try {
-        const r = await window.apiService.toggleBlockTodo(b.uuid);
-        if (r && r.success && r.data) {
-          // Mutate in place so the bullet + meta update without
-          // refetching the whole embed. The row stays visible even
-          // when the new state falls outside the saved view's filter
-          // — gives the user immediate "yes that worked" feedback;
-          // a real refresh happens on the next fetch.
-          b.block_type = r.data.block_type;
-          b.completed_at = r.data.completed_at;
-          b.content = r.data.content;
-          this.broadcastChange(b.uuid);
-        } else {
-          const errs = (r && r.errors) || {};
-          this.error =
-            (errs.non_field_errors && errs.non_field_errors[0]) ||
-            "Failed to toggle todo";
-        }
-      } catch (err) {
-        console.error("toggleBlockTodo failed:", err);
-        this.error = "failed to toggle todo. please try again.";
-      }
-    },
-
-    openRowMenu(b, event) {
-      this.$refs.rowMenu?.openAt(b, event);
-    },
 
     broadcastChange(uuid) {
       if (!uuid) return;
@@ -201,137 +141,13 @@ window.QueryEmbedBlock = {
       );
     },
 
-    async onMenuAction({ action, block }) {
-      if (!block) return;
-      switch (action) {
-        case "moveToToday":
-          await this.actionMoveToToday(block);
-          break;
-        case "moveToPage":
-          await this.actionMoveToPage(block);
-          break;
-        case "copyLink":
-          await this.actionCopyLink(block);
-          break;
-        case "schedule":
-          this.actionSchedule(block, { clear: false });
-          break;
-        case "unschedule":
-          this.actionSchedule(block, { clear: true });
-          break;
-        case "blockInfo":
-          this.actionBlockInfo(block);
-          break;
-        case "delete":
-          await this.actionDelete(block);
-          break;
-      }
+    async onRowChanged(uuid) {
+      this.broadcastChange(uuid);
+      await this.fetch();
     },
 
-    async actionMoveToToday(b) {
-      try {
-        const r = await window.apiService.moveBlockToDaily(b.uuid);
-        if (!r || !r.success) {
-          throw new Error(
-            r?.errors?.non_field_errors?.[0] || "move to today failed"
-          );
-        }
-        this.broadcastChange(b.uuid);
-        await this.fetch();
-      } catch (err) {
-        console.error("moveBlockToDaily failed:", err);
-        this.error = "failed to move block to today";
-      }
-    },
-
-    async actionMoveToPage(b) {
-      if (!window.appModals?.pickPage) {
-        console.error("appModals.pickPage is not available");
-        return;
-      }
-      const target = await window.appModals.pickPage({
-        title: "move block to page",
-        placeholder: "search pages…",
-        confirmLabel: "move",
-      });
-      if (!target) return;
-      try {
-        const r = await window.apiService.moveBlockToPage(b.uuid, target.uuid);
-        if (!r || !r.success) {
-          throw new Error(r?.errors?.non_field_errors?.[0] || "move failed");
-        }
-        this.broadcastChange(b.uuid);
-        await this.fetch();
-      } catch (err) {
-        console.error("moveBlockToPage failed:", err);
-        this.error = `failed to move block: ${err.message || err}`;
-      }
-    },
-
-    async actionCopyLink(b) {
-      if (!b.page_slug) {
-        this.error = "could not build block link";
-        return;
-      }
-      const url = `${window.location.origin}/knowledge/page/${encodeURIComponent(b.page_slug)}/#block-${b.uuid}`;
-      try {
-        if (navigator.clipboard && window.isSecureContext) {
-          await navigator.clipboard.writeText(url);
-          return;
-        }
-      } catch (err) {
-        console.warn("clipboard API failed, falling back:", err);
-      }
-      // execCommand fallback for http:// contexts where the async
-      // clipboard API is gated. Mirrors Page.js copyBlockLink.
-      try {
-        const ta = document.createElement("textarea");
-        ta.value = url;
-        ta.style.position = "fixed";
-        ta.style.opacity = "0";
-        document.body.appendChild(ta);
-        ta.select();
-        document.execCommand("copy");
-        document.body.removeChild(ta);
-      } catch (err) {
-        console.error("clipboard fallback failed:", err);
-        this.error = "could not copy link";
-      }
-    },
-
-    actionSchedule(b, opts) {
-      // ScheduleBlockPopover lives on the host page (Page.js); defer
-      // to its handler when wired. The host dispatches the block-
-      // changed event after save, which routes us back through the
-      // shared listener for refresh.
-      if (!this.onScheduleBlock) return;
-      this.onScheduleBlock(b, opts || {});
-    },
-
-    actionBlockInfo(b) {
-      if (!this.onOpenBlockInfo) return;
-      this.onOpenBlockInfo(b);
-    },
-
-    async actionDelete(b) {
-      const confirmed = await (window.appModals?.confirm?.({
-        title: "delete block?",
-        message: "this will also delete any child blocks and cannot be undone.",
-        confirmLabel: "delete",
-        destructive: true,
-      }) ?? Promise.resolve(window.confirm("Delete this block?")));
-      if (!confirmed) return;
-      try {
-        const r = await window.apiService.deleteBlock(b.uuid);
-        if (!r || !r.success) {
-          throw new Error(r?.errors?.non_field_errors?.[0] || "delete failed");
-        }
-        this.broadcastChange(b.uuid);
-        await this.fetch();
-      } catch (err) {
-        console.error("deleteBlock failed:", err);
-        this.error = `failed to delete block: ${err.message || err}`;
-      }
+    onRowError(message) {
+      this.error = message;
     },
 
     onRemoveClick() {
@@ -401,49 +217,17 @@ window.QueryEmbedBlock = {
           No matches.
         </div>
         <ul v-else class="result-list">
-          <li v-for="b in result.results" :key="b.uuid">
-            <div class="result-row" @contextmenu="openRowMenu(b, $event)">
-              <div
-                class="block-bullet"
-                :class="{
-                  'todo': b.block_type === 'todo',
-                  'doing': b.block_type === 'doing',
-                  'done': b.block_type === 'done',
-                  'later': b.block_type === 'later',
-                  'wontdo': b.block_type === 'wontdo'
-                }"
-                @click.stop="isTodoType(b) ? toggleTodo(b) : null"
-                :title="isTodoType(b) ? 'Cycle todo state' : ''"
-                :role="isTodoType(b) ? 'button' : null"
-                :aria-label="isTodoType(b) ? 'Cycle todo state' : null"
-              >{{ bulletSymbol(b) }}</div>
-              <a :href="blockHref(b)" class="result-row-link">
-                <span class="result-content">{{ blockLabel(b) }}</span>
-                <span class="result-meta">
-                  <span v-if="b.block_type" class="result-block-type">{{ b.block_type }}</span>
-                  <span v-if="b.scheduled_for"> · due {{ b.scheduled_for }}</span>
-                  <span v-if="b.completed_at"> · done {{ b.completed_at.split('T')[0] }}</span>
-                  <span v-if="b.page_title"> · {{ b.page_title }}</span>
-                </span>
-              </a>
-              <button
-                type="button"
-                class="block-menu result-row-menu-btn"
-                @click="openRowMenu(b, $event)"
-                @contextmenu="openRowMenu(b, $event)"
-                title="Block options"
-                aria-label="Block options"
-              >⋮</button>
-            </div>
-          </li>
+          <EmbedResultRow
+            v-for="b in result.results"
+            :key="b.uuid"
+            :block="b"
+            :on-schedule-block="onScheduleBlock"
+            :on-open-block-info="onOpenBlockInfo"
+            @changed="onRowChanged"
+            @error="onRowError"
+          />
         </ul>
       </template>
-      <EmbedContextMenu
-        ref="rowMenu"
-        :can-schedule="!!onScheduleBlock"
-        :can-block-info="!!onOpenBlockInfo"
-        @action="onMenuAction"
-      />
     </div>
   `,
 };

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
@@ -30,12 +30,15 @@ window.QueryEmbedBlock = {
     onToggleCollapsed: { type: Function, default: null },
     onMoveUp: { type: Function, default: null },
     onMoveDown: { type: Function, default: null },
-    // Schedule + Block info both need a modal that lives on the host
-    // page (Page.js owns the ScheduleBlockPopover / BlockInfoModal
-    // instances). Forwarded to each EmbedResultRow, which hides the
-    // matching menu items when the callback isn't provided.
+    // Host-page delegates forwarded straight to each EmbedResultRow.
+    // Schedule + Block info need a modal that lives on the host;
+    // Move-to-today / Move-to-page need to trigger the host's own
+    // reload so the moved block shows up on the destination page
+    // without a manual refresh. See EmbedResultRow's prop comment.
     onScheduleBlock: { type: Function, default: null },
     onOpenBlockInfo: { type: Function, default: null },
+    onMoveBlockToToday: { type: Function, default: null },
+    onMoveBlockToPage: { type: Function, default: null },
   },
 
   data() {
@@ -223,6 +226,8 @@ window.QueryEmbedBlock = {
             :block="b"
             :on-schedule-block="onScheduleBlock"
             :on-open-block-info="onOpenBlockInfo"
+            :on-move-block-to-today="onMoveBlockToToday"
+            :on-move-block-to-page="onMoveBlockToPage"
             @changed="onRowChanged"
             @error="onRowError"
           />

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
@@ -11,11 +11,15 @@
  *
  * Result rows surface the block's todo-state bullet; clicking the
  * bullet cycles the block's state in place via the same endpoint
- * BlockComponent uses. The text portion remains a navigation link to
- * the source page — inline content edits still require clicking
- * through to the block on its home page.
+ * BlockComponent uses. Right-click (or the hover ⋮) opens an
+ * EmbedContextMenu — see that component for the action list. Inline
+ * content edits still require clicking through to the source page.
  */
 window.QueryEmbedBlock = {
+  components: {
+    EmbedContextMenu: window.EmbedContextMenu || {},
+  },
+
   props: {
     embed: { type: Object, required: true },
     // All optional so the embed can also render outside the page
@@ -24,11 +28,13 @@ window.QueryEmbedBlock = {
     onToggleCollapsed: { type: Function, default: null },
     onMoveUp: { type: Function, default: null },
     onMoveDown: { type: Function, default: null },
-    // Schedule needs the ScheduleBlockPopover, which lives on the host
-    // page (Page.js). Caller wires this to open its popover for the
-    // given block; the embed hides the schedule action when the
+    // Schedule + Block info both need a modal that lives on the host
+    // page (Page.js owns the ScheduleBlockPopover / BlockInfoModal
+    // instances). Caller wires these to open its modal for the given
+    // block; the embed hides the matching menu items when the
     // callback isn't provided.
     onScheduleBlock: { type: Function, default: null },
+    onOpenBlockInfo: { type: Function, default: null },
   },
 
   data() {
@@ -36,11 +42,6 @@ window.QueryEmbedBlock = {
       loading: true,
       error: null,
       result: null, // {view, count, results, truncated}
-      // Per-row context menu — one menu is rendered for the whole
-      // embed and positioned at the click point; `menuBlock` is the
-      // result row it was opened for.
-      menuBlock: null,
-      menuPosition: { x: 0, y: 0 },
     };
   },
 
@@ -90,7 +91,6 @@ window.QueryEmbedBlock = {
         this._onBlocksChanged
       );
     }
-    this.closeRowMenu();
   },
 
   watch: {
@@ -187,57 +187,9 @@ window.QueryEmbedBlock = {
         this.error = "failed to toggle todo. please try again.";
       }
     },
+
     openRowMenu(b, event) {
-      if (!b) return;
-      event.preventDefault();
-      event.stopPropagation();
-
-      // Match BlockComponent.showContextMenuAt — fixed-positioned at
-      // the click point, clamped to viewport with mobile padding so
-      // the menu never hides under the soft keyboard / browser chrome.
-      const menuWidth = 200;
-      const shadowOffset = 4;
-      const isMobile = window.innerWidth <= 768;
-      const edgePadding = isMobile ? 20 : 10;
-      const bottomPadding = isMobile ? 60 : 10;
-
-      let x = event.clientX;
-      let y = event.clientY;
-      const vw = window.innerWidth;
-
-      if (x + menuWidth + shadowOffset > vw - edgePadding) {
-        x = vw - menuWidth - shadowOffset - edgePadding;
-      }
-      x = Math.max(edgePadding, x);
-
-      this.menuPosition = { x, y };
-      this.menuBlock = b;
-
-      this.$nextTick(() => {
-        const el = this.$el?.querySelector(".block-context-menu");
-        if (!el) return;
-        const h = el.offsetHeight;
-        const vh = window.innerHeight;
-        let ny = y;
-        if (ny + h + shadowOffset > vh - bottomPadding) {
-          ny = vh - h - shadowOffset - bottomPadding;
-        }
-        ny = Math.max(edgePadding, ny);
-        if (ny !== this.menuPosition.y) {
-          this.menuPosition = { x, y: ny };
-        }
-      });
-
-      // Same delayed listener BlockComponent uses so this click
-      // doesn't immediately close its own menu.
-      setTimeout(() => {
-        document.addEventListener("click", this.closeRowMenu);
-      }, 10);
-    },
-
-    closeRowMenu() {
-      this.menuBlock = null;
-      document.removeEventListener("click", this.closeRowMenu);
+      this.$refs.rowMenu?.openAt(b, event);
     },
 
     broadcastChange(uuid) {
@@ -249,25 +201,29 @@ window.QueryEmbedBlock = {
       );
     },
 
-    async menuAction(action) {
-      const b = this.menuBlock;
-      this.closeRowMenu();
-      if (!b) return;
+    async onMenuAction({ action, block }) {
+      if (!block) return;
       switch (action) {
         case "moveToToday":
-          await this.actionMoveToToday(b);
+          await this.actionMoveToToday(block);
           break;
         case "moveToPage":
-          await this.actionMoveToPage(b);
+          await this.actionMoveToPage(block);
+          break;
+        case "copyLink":
+          await this.actionCopyLink(block);
           break;
         case "schedule":
-          this.actionSchedule(b, { clear: false });
+          this.actionSchedule(block, { clear: false });
           break;
         case "unschedule":
-          this.actionSchedule(b, { clear: true });
+          this.actionSchedule(block, { clear: true });
+          break;
+        case "blockInfo":
+          this.actionBlockInfo(block);
           break;
         case "delete":
-          await this.actionDelete(b);
+          await this.actionDelete(block);
           break;
       }
     },
@@ -312,12 +268,49 @@ window.QueryEmbedBlock = {
       }
     },
 
+    async actionCopyLink(b) {
+      if (!b.page_slug) {
+        this.error = "could not build block link";
+        return;
+      }
+      const url = `${window.location.origin}/knowledge/page/${encodeURIComponent(b.page_slug)}/#block-${b.uuid}`;
+      try {
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(url);
+          return;
+        }
+      } catch (err) {
+        console.warn("clipboard API failed, falling back:", err);
+      }
+      // execCommand fallback for http:// contexts where the async
+      // clipboard API is gated. Mirrors Page.js copyBlockLink.
+      try {
+        const ta = document.createElement("textarea");
+        ta.value = url;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand("copy");
+        document.body.removeChild(ta);
+      } catch (err) {
+        console.error("clipboard fallback failed:", err);
+        this.error = "could not copy link";
+      }
+    },
+
     actionSchedule(b, opts) {
-      // The schedule UX needs the ScheduleBlockPopover — that lives on
-      // the host page (Page.js), so defer to its handler if wired.
-      // We refresh on the broadcast event after the host's save path.
+      // ScheduleBlockPopover lives on the host page (Page.js); defer
+      // to its handler when wired. The host dispatches the block-
+      // changed event after save, which routes us back through the
+      // shared listener for refresh.
       if (!this.onScheduleBlock) return;
       this.onScheduleBlock(b, opts || {});
+    },
+
+    actionBlockInfo(b) {
+      if (!this.onOpenBlockInfo) return;
+      this.onOpenBlockInfo(b);
     },
 
     async actionDelete(b) {
@@ -445,38 +438,12 @@ window.QueryEmbedBlock = {
           </li>
         </ul>
       </template>
-      <div
-        v-if="menuBlock"
-        class="block-context-menu"
-        :style="{ left: menuPosition.x + 'px', top: menuPosition.y + 'px' }"
-        @click.stop
-        role="menu"
-      >
-        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('moveToToday')">
-          <span class="context-menu-icon">⇨</span>
-          <span>move to today's daily</span>
-        </button>
-        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('moveToPage')">
-          <span class="context-menu-icon">→</span>
-          <span>move to page…</span>
-        </button>
-        <template v-if="onScheduleBlock">
-          <div class="context-menu-separator"></div>
-          <button class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('schedule')">
-            <span class="context-menu-icon">◷</span>
-            <span>{{ menuBlock.scheduled_for ? 'reschedule…' : 'schedule…' }}</span>
-          </button>
-          <button v-if="menuBlock.scheduled_for" class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('unschedule')">
-            <span class="context-menu-icon">×</span>
-            <span>clear schedule</span>
-          </button>
-        </template>
-        <div class="context-menu-separator"></div>
-        <button class="context-menu-item context-menu-danger" role="menuitem" tabindex="-1" @click="menuAction('delete')">
-          <span class="context-menu-icon">×</span>
-          <span>delete</span>
-        </button>
-      </div>
+      <EmbedContextMenu
+        ref="rowMenu"
+        :can-schedule="!!onScheduleBlock"
+        :can-block-info="!!onOpenBlockInfo"
+        @action="onMenuAction"
+      />
     </div>
   `,
 };

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
@@ -24,6 +24,11 @@ window.QueryEmbedBlock = {
     onToggleCollapsed: { type: Function, default: null },
     onMoveUp: { type: Function, default: null },
     onMoveDown: { type: Function, default: null },
+    // Schedule needs the ScheduleBlockPopover, which lives on the host
+    // page (Page.js). Caller wires this to open its popover for the
+    // given block; the embed hides the schedule action when the
+    // callback isn't provided.
+    onScheduleBlock: { type: Function, default: null },
   },
 
   data() {
@@ -31,6 +36,11 @@ window.QueryEmbedBlock = {
       loading: true,
       error: null,
       result: null, // {view, count, results, truncated}
+      // Per-row context menu — one menu is rendered for the whole
+      // embed and positioned at the click point; `menuBlock` is the
+      // result row it was opened for.
+      menuBlock: null,
+      menuPosition: { x: 0, y: 0 },
     };
   },
 
@@ -53,6 +63,34 @@ window.QueryEmbedBlock = {
 
   mounted() {
     if (!this.collapsed) this.fetch();
+    // Re-run the saved view when any embed action elsewhere on the
+    // page mutates a block we might be displaying. The toggle bullet
+    // and the row context-menu actions all broadcast this event.
+    // We tag our own broadcasts with `source: this` so the local
+    // action path (which already refetches synchronously) doesn't
+    // also trigger a redundant fetch from the listener.
+    this._onBlocksChanged = (ev) => {
+      const uuid = ev?.detail?.uuid;
+      if (!uuid || ev?.detail?.source === this) return;
+      if (this.collapsed || !this.result?.results) return;
+      if (this.result.results.some((b) => b.uuid === uuid)) {
+        this.fetch();
+      }
+    };
+    document.addEventListener(
+      "brainspread:block-changed",
+      this._onBlocksChanged
+    );
+  },
+
+  beforeUnmount() {
+    if (this._onBlocksChanged) {
+      document.removeEventListener(
+        "brainspread:block-changed",
+        this._onBlocksChanged
+      );
+    }
+    this.closeRowMenu();
   },
 
   watch: {
@@ -137,6 +175,7 @@ window.QueryEmbedBlock = {
           b.block_type = r.data.block_type;
           b.completed_at = r.data.completed_at;
           b.content = r.data.content;
+          this.broadcastChange(b.uuid);
         } else {
           const errs = (r && r.errors) || {};
           this.error =
@@ -148,6 +187,160 @@ window.QueryEmbedBlock = {
         this.error = "failed to toggle todo. please try again.";
       }
     },
+    openRowMenu(b, event) {
+      if (!b) return;
+      event.preventDefault();
+      event.stopPropagation();
+
+      // Match BlockComponent.showContextMenuAt — fixed-positioned at
+      // the click point, clamped to viewport with mobile padding so
+      // the menu never hides under the soft keyboard / browser chrome.
+      const menuWidth = 200;
+      const shadowOffset = 4;
+      const isMobile = window.innerWidth <= 768;
+      const edgePadding = isMobile ? 20 : 10;
+      const bottomPadding = isMobile ? 60 : 10;
+
+      let x = event.clientX;
+      let y = event.clientY;
+      const vw = window.innerWidth;
+
+      if (x + menuWidth + shadowOffset > vw - edgePadding) {
+        x = vw - menuWidth - shadowOffset - edgePadding;
+      }
+      x = Math.max(edgePadding, x);
+
+      this.menuPosition = { x, y };
+      this.menuBlock = b;
+
+      this.$nextTick(() => {
+        const el = this.$el?.querySelector(".block-context-menu");
+        if (!el) return;
+        const h = el.offsetHeight;
+        const vh = window.innerHeight;
+        let ny = y;
+        if (ny + h + shadowOffset > vh - bottomPadding) {
+          ny = vh - h - shadowOffset - bottomPadding;
+        }
+        ny = Math.max(edgePadding, ny);
+        if (ny !== this.menuPosition.y) {
+          this.menuPosition = { x, y: ny };
+        }
+      });
+
+      // Same delayed listener BlockComponent uses so this click
+      // doesn't immediately close its own menu.
+      setTimeout(() => {
+        document.addEventListener("click", this.closeRowMenu);
+      }, 10);
+    },
+
+    closeRowMenu() {
+      this.menuBlock = null;
+      document.removeEventListener("click", this.closeRowMenu);
+    },
+
+    broadcastChange(uuid) {
+      if (!uuid) return;
+      document.dispatchEvent(
+        new CustomEvent("brainspread:block-changed", {
+          detail: { uuid, source: this },
+        })
+      );
+    },
+
+    async menuAction(action) {
+      const b = this.menuBlock;
+      this.closeRowMenu();
+      if (!b) return;
+      switch (action) {
+        case "moveToToday":
+          await this.actionMoveToToday(b);
+          break;
+        case "moveToPage":
+          await this.actionMoveToPage(b);
+          break;
+        case "schedule":
+          this.actionSchedule(b, { clear: false });
+          break;
+        case "unschedule":
+          this.actionSchedule(b, { clear: true });
+          break;
+        case "delete":
+          await this.actionDelete(b);
+          break;
+      }
+    },
+
+    async actionMoveToToday(b) {
+      try {
+        const r = await window.apiService.moveBlockToDaily(b.uuid);
+        if (!r || !r.success) {
+          throw new Error(
+            r?.errors?.non_field_errors?.[0] || "move to today failed"
+          );
+        }
+        this.broadcastChange(b.uuid);
+        await this.fetch();
+      } catch (err) {
+        console.error("moveBlockToDaily failed:", err);
+        this.error = "failed to move block to today";
+      }
+    },
+
+    async actionMoveToPage(b) {
+      if (!window.appModals?.pickPage) {
+        console.error("appModals.pickPage is not available");
+        return;
+      }
+      const target = await window.appModals.pickPage({
+        title: "move block to page",
+        placeholder: "search pages…",
+        confirmLabel: "move",
+      });
+      if (!target) return;
+      try {
+        const r = await window.apiService.moveBlockToPage(b.uuid, target.uuid);
+        if (!r || !r.success) {
+          throw new Error(r?.errors?.non_field_errors?.[0] || "move failed");
+        }
+        this.broadcastChange(b.uuid);
+        await this.fetch();
+      } catch (err) {
+        console.error("moveBlockToPage failed:", err);
+        this.error = `failed to move block: ${err.message || err}`;
+      }
+    },
+
+    actionSchedule(b, opts) {
+      // The schedule UX needs the ScheduleBlockPopover — that lives on
+      // the host page (Page.js), so defer to its handler if wired.
+      // We refresh on the broadcast event after the host's save path.
+      if (!this.onScheduleBlock) return;
+      this.onScheduleBlock(b, opts || {});
+    },
+
+    async actionDelete(b) {
+      const confirmed = await (window.appModals?.confirm?.({
+        title: "delete block?",
+        message: "this will also delete any child blocks and cannot be undone.",
+        confirmLabel: "delete",
+        destructive: true,
+      }) ?? Promise.resolve(window.confirm("Delete this block?")));
+      if (!confirmed) return;
+      try {
+        const r = await window.apiService.deleteBlock(b.uuid);
+        if (!r || !r.success) {
+          throw new Error(r?.errors?.non_field_errors?.[0] || "delete failed");
+        }
+        this.broadcastChange(b.uuid);
+        await this.fetch();
+      } catch (err) {
+        console.error("deleteBlock failed:", err);
+        this.error = `failed to delete block: ${err.message || err}`;
+      }
+    },
+
     onRemoveClick() {
       if (!this.onDelete) return;
       this.onDelete(this.embed);
@@ -216,7 +409,7 @@ window.QueryEmbedBlock = {
         </div>
         <ul v-else class="result-list">
           <li v-for="b in result.results" :key="b.uuid">
-            <div class="result-row">
+            <div class="result-row" @contextmenu="openRowMenu(b, $event)">
               <div
                 class="block-bullet"
                 :class="{
@@ -240,10 +433,50 @@ window.QueryEmbedBlock = {
                   <span v-if="b.page_title"> · {{ b.page_title }}</span>
                 </span>
               </a>
+              <button
+                type="button"
+                class="block-menu result-row-menu-btn"
+                @click="openRowMenu(b, $event)"
+                @contextmenu="openRowMenu(b, $event)"
+                title="Block options"
+                aria-label="Block options"
+              >⋮</button>
             </div>
           </li>
         </ul>
       </template>
+      <div
+        v-if="menuBlock"
+        class="block-context-menu"
+        :style="{ left: menuPosition.x + 'px', top: menuPosition.y + 'px' }"
+        @click.stop
+        role="menu"
+      >
+        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('moveToToday')">
+          <span class="context-menu-icon">⇨</span>
+          <span>move to today's daily</span>
+        </button>
+        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('moveToPage')">
+          <span class="context-menu-icon">→</span>
+          <span>move to page…</span>
+        </button>
+        <template v-if="onScheduleBlock">
+          <div class="context-menu-separator"></div>
+          <button class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('schedule')">
+            <span class="context-menu-icon">◷</span>
+            <span>{{ menuBlock.scheduled_for ? 'reschedule…' : 'schedule…' }}</span>
+          </button>
+          <button v-if="menuBlock.scheduled_for" class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('unschedule')">
+            <span class="context-menu-icon">×</span>
+            <span>clear schedule</span>
+          </button>
+        </template>
+        <div class="context-menu-separator"></div>
+        <button class="context-menu-item context-menu-danger" role="menuitem" tabindex="-1" @click="menuAction('delete')">
+          <span class="context-menu-icon">×</span>
+          <span>delete</span>
+        </button>
+      </div>
     </div>
   `,
 };

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
@@ -228,7 +228,7 @@ window.QueryEmbedBlock = {
             :on-open-block-info="onOpenBlockInfo"
             :on-move-block-to-today="onMoveBlockToToday"
             :on-move-block-to-page="onMoveBlockToPage"
-            @changed="onRowChanged"
+            :on-changed="onRowChanged"
             @error="onRowError"
           />
         </ul>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
@@ -9,8 +9,11 @@
  * handles persistence (POST/DELETE/PUT to /api/embeds/) and refreshes
  * its own embedded_views state after each call.
  *
- * The result list itself is read-only — clicking a row jumps to that
- * block on its source page so the user can interact with it there.
+ * Result rows surface the block's todo-state bullet; clicking the
+ * bullet cycles the block's state in place via the same endpoint
+ * BlockComponent uses. The text portion remains a navigation link to
+ * the source page — inline content edits still require clicking
+ * through to the block on its home page.
  */
 window.QueryEmbedBlock = {
   props: {
@@ -101,6 +104,50 @@ window.QueryEmbedBlock = {
       if (!c) return "(empty block)";
       return c.length > 200 ? c.slice(0, 200) + "…" : c;
     },
+    isTodoType(b) {
+      return ["todo", "doing", "done", "later", "wontdo"].includes(
+        b && b.block_type
+      );
+    },
+    bulletSymbol(b) {
+      switch (b && b.block_type) {
+        case "todo":
+        case "later":
+          return "☐";
+        case "doing":
+          return "◐";
+        case "done":
+          return "☑";
+        case "wontdo":
+          return "⊘";
+        default:
+          return "•";
+      }
+    },
+    async toggleTodo(b) {
+      if (!this.isTodoType(b)) return;
+      try {
+        const r = await window.apiService.toggleBlockTodo(b.uuid);
+        if (r && r.success && r.data) {
+          // Mutate in place so the bullet + meta update without
+          // refetching the whole embed. The row stays visible even
+          // when the new state falls outside the saved view's filter
+          // — gives the user immediate "yes that worked" feedback;
+          // a real refresh happens on the next fetch.
+          b.block_type = r.data.block_type;
+          b.completed_at = r.data.completed_at;
+          b.content = r.data.content;
+        } else {
+          const errs = (r && r.errors) || {};
+          this.error =
+            (errs.non_field_errors && errs.non_field_errors[0]) ||
+            "Failed to toggle todo";
+        }
+      } catch (err) {
+        console.error("toggleBlockTodo failed:", err);
+        this.error = "failed to toggle todo. please try again.";
+      }
+    },
     onRemoveClick() {
       if (!this.onDelete) return;
       this.onDelete(this.embed);
@@ -169,15 +216,31 @@ window.QueryEmbedBlock = {
         </div>
         <ul v-else class="result-list">
           <li v-for="b in result.results" :key="b.uuid">
-            <a :href="blockHref(b)" class="result-row">
-              <span class="result-content">{{ blockLabel(b) }}</span>
-              <span class="result-meta">
-                <span v-if="b.block_type" class="result-block-type">{{ b.block_type }}</span>
-                <span v-if="b.scheduled_for"> · due {{ b.scheduled_for }}</span>
-                <span v-if="b.completed_at"> · done {{ b.completed_at.split('T')[0] }}</span>
-                <span v-if="b.page_title"> · {{ b.page_title }}</span>
-              </span>
-            </a>
+            <div class="result-row">
+              <div
+                class="block-bullet"
+                :class="{
+                  'todo': b.block_type === 'todo',
+                  'doing': b.block_type === 'doing',
+                  'done': b.block_type === 'done',
+                  'later': b.block_type === 'later',
+                  'wontdo': b.block_type === 'wontdo'
+                }"
+                @click.stop="isTodoType(b) ? toggleTodo(b) : null"
+                :title="isTodoType(b) ? 'Cycle todo state' : ''"
+                :role="isTodoType(b) ? 'button' : null"
+                :aria-label="isTodoType(b) ? 'Cycle todo state' : null"
+              >{{ bulletSymbol(b) }}</div>
+              <a :href="blockHref(b)" class="result-row-link">
+                <span class="result-content">{{ blockLabel(b) }}</span>
+                <span class="result-meta">
+                  <span v-if="b.block_type" class="result-block-type">{{ b.block_type }}</span>
+                  <span v-if="b.scheduled_for"> · due {{ b.scheduled_for }}</span>
+                  <span v-if="b.completed_at"> · done {{ b.completed_at.split('T')[0] }}</span>
+                  <span v-if="b.page_title"> · {{ b.page_title }}</span>
+                </span>
+              </a>
+            </div>
           </li>
         </ul>
       </template>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
@@ -1059,7 +1059,7 @@ const SavedViewsPage = {
                 :block="b"
                 :on-schedule-block="scheduleBlock"
                 :on-open-block-info="openBlockInfoModal"
-                @changed="onRowChanged"
+                :on-changed="onRowChanged"
                 @error="onRowError"
               />
             </ul>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
@@ -19,7 +19,7 @@ const SavedViewsPage = {
   components: {
     ScheduleBlockPopover: window.ScheduleBlockPopover || {},
     BlockInfoModal: window.BlockInfoModal || {},
-    EmbedContextMenu: window.EmbedContextMenu || {},
+    EmbedResultRow: window.EmbedResultRow || {},
   },
 
   data() {
@@ -802,65 +802,6 @@ const SavedViewsPage = {
       this.prefillMatch = null;
     },
 
-    blockHref(block) {
-      if (!block || !block.page_slug) return "#";
-      return `/knowledge/page/${encodeURIComponent(block.page_slug)}/#block-${
-        block.uuid
-      }`;
-    },
-
-    blockLabel(block) {
-      if (!block) return "";
-      const content = (block.content || "").trim();
-      if (content)
-        return content.length > 200 ? content.slice(0, 200) + "…" : content;
-      return "(empty block)";
-    },
-
-    isTodoType(b) {
-      return ["todo", "doing", "done", "later", "wontdo"].includes(
-        b && b.block_type
-      );
-    },
-
-    bulletSymbol(b) {
-      switch (b && b.block_type) {
-        case "todo":
-        case "later":
-          return "☐";
-        case "doing":
-          return "◐";
-        case "done":
-          return "☑";
-        case "wontdo":
-          return "⊘";
-        default:
-          return "•";
-      }
-    },
-
-    async toggleResultTodo(b) {
-      if (!this.isTodoType(b)) return;
-      try {
-        const r = await window.apiService.toggleBlockTodo(b.uuid);
-        if (r && r.success && r.data) {
-          // Update in place — see QueryEmbedBlock for rationale.
-          b.block_type = r.data.block_type;
-          b.completed_at = r.data.completed_at;
-          b.content = r.data.content;
-          this.broadcastChange(b.uuid);
-        } else {
-          const errs = (r && r.errors) || {};
-          this.runError =
-            (errs.non_field_errors && errs.non_field_errors[0]) ||
-            "Failed to toggle todo";
-        }
-      } catch (err) {
-        console.error("toggleBlockTodo failed:", err);
-        this.runError = "failed to toggle todo. please try again.";
-      }
-    },
-
     broadcastChange(uuid) {
       if (!uuid) return;
       document.dispatchEvent(
@@ -870,40 +811,9 @@ const SavedViewsPage = {
       );
     },
 
-    openRowMenu(b, event) {
-      this.$refs.rowMenu?.openAt(b, event);
-    },
-
-    async onMenuAction({ action, block }) {
-      if (!block) return;
-      switch (action) {
-        case "moveToToday":
-          await this.actionMoveToToday(block);
-          break;
-        case "moveToPage":
-          await this.actionMoveToPage(block);
-          break;
-        case "copyLink":
-          await this.actionCopyLink(block);
-          break;
-        case "schedule":
-          this.actionSchedule(block, { clear: false });
-          break;
-        case "unschedule":
-          this.actionSchedule(block, { clear: true });
-          break;
-        case "blockInfo":
-          this.actionBlockInfo(block);
-          break;
-        case "delete":
-          await this.actionDelete(block);
-          break;
-      }
-    },
-
     async refreshResults() {
       // Re-runs the active saved view so the results list reflects
-      // backend changes. Used by every action handler + by the
+      // backend changes. Called from onRowChanged below and from the
       // brainspread:block-changed event listener.
       if (!this.activeView || !this.activeView.uuid) return;
       try {
@@ -920,76 +830,21 @@ const SavedViewsPage = {
       }
     },
 
-    async actionMoveToToday(b) {
-      try {
-        const r = await window.apiService.moveBlockToDaily(b.uuid);
-        if (!r || !r.success) {
-          throw new Error(
-            r?.errors?.non_field_errors?.[0] || "move to today failed"
-          );
-        }
-        this.broadcastChange(b.uuid);
-        await this.refreshResults();
-      } catch (err) {
-        console.error("moveBlockToDaily failed:", err);
-        this.runError = "failed to move block to today";
-      }
+    async onRowChanged(uuid) {
+      this.broadcastChange(uuid);
+      await this.refreshResults();
     },
 
-    async actionMoveToPage(b) {
-      if (!window.appModals?.pickPage) {
-        console.error("appModals.pickPage is not available");
-        return;
-      }
-      const target = await window.appModals.pickPage({
-        title: "move block to page",
-        placeholder: "search pages…",
-        confirmLabel: "move",
-      });
-      if (!target) return;
-      try {
-        const r = await window.apiService.moveBlockToPage(b.uuid, target.uuid);
-        if (!r || !r.success) {
-          throw new Error(r?.errors?.non_field_errors?.[0] || "move failed");
-        }
-        this.broadcastChange(b.uuid);
-        await this.refreshResults();
-      } catch (err) {
-        console.error("moveBlockToPage failed:", err);
-        this.runError = `failed to move block: ${err.message || err}`;
-      }
+    onRowError(message) {
+      this.runError = message;
     },
 
-    async actionCopyLink(b) {
-      if (!b.page_slug) {
-        this.runError = "could not build block link";
-        return;
-      }
-      const url = `${window.location.origin}/knowledge/page/${encodeURIComponent(b.page_slug)}/#block-${b.uuid}`;
-      try {
-        if (navigator.clipboard && window.isSecureContext) {
-          await navigator.clipboard.writeText(url);
-          return;
-        }
-      } catch (err) {
-        console.warn("clipboard API failed, falling back:", err);
-      }
-      try {
-        const ta = document.createElement("textarea");
-        ta.value = url;
-        ta.style.position = "fixed";
-        ta.style.opacity = "0";
-        document.body.appendChild(ta);
-        ta.select();
-        document.execCommand("copy");
-        document.body.removeChild(ta);
-      } catch (err) {
-        console.error("clipboard fallback failed:", err);
-        this.runError = "could not copy link";
-      }
-    },
+    // ── Host-page modal owners (wired into EmbedResultRow as
+    // onScheduleBlock + onOpenBlockInfo). Schedule + block info
+    // both render their own popover/modal at this level so the
+    // saved-views page can stand alone without a parent surface.
 
-    actionBlockInfo(b) {
+    openBlockInfoModal(b) {
       this.blockInfoModalBlock = b;
       this.blockInfoModalOpen = true;
     },
@@ -999,7 +854,7 @@ const SavedViewsPage = {
       this.blockInfoModalBlock = null;
     },
 
-    actionSchedule(b, { clear = false } = {}) {
+    scheduleBlock(b, { clear = false } = {}) {
       if (clear) {
         this._submitSchedule(b, "", "", "");
         return;
@@ -1042,27 +897,6 @@ const SavedViewsPage = {
       } catch (err) {
         console.error("scheduleBlock failed:", err);
         this.runError = `failed to schedule: ${err.message || err}`;
-      }
-    },
-
-    async actionDelete(b) {
-      const confirmed = await (window.appModals?.confirm?.({
-        title: "delete block?",
-        message: "this will also delete any child blocks and cannot be undone.",
-        confirmLabel: "delete",
-        destructive: true,
-      }) ?? Promise.resolve(window.confirm("Delete this block?")));
-      if (!confirmed) return;
-      try {
-        const r = await window.apiService.deleteBlock(b.uuid);
-        if (!r || !r.success) {
-          throw new Error(r?.errors?.non_field_errors?.[0] || "delete failed");
-        }
-        this.broadcastChange(b.uuid);
-        await this.refreshResults();
-      } catch (err) {
-        console.error("deleteBlock failed:", err);
-        this.runError = `failed to delete block: ${err.message || err}`;
       }
     },
   },
@@ -1219,52 +1053,19 @@ const SavedViewsPage = {
             <div v-else-if="!runResult" class="empty-state">Loading…</div>
             <div v-else-if="!runResult.results.length" class="empty-state">No matches.</div>
             <ul v-else class="result-list">
-              <li v-for="b in runResult.results" :key="b.uuid">
-                <div class="result-row" @contextmenu="openRowMenu(b, $event)">
-                  <div
-                    class="block-bullet"
-                    :class="{
-                      'todo': b.block_type === 'todo',
-                      'doing': b.block_type === 'doing',
-                      'done': b.block_type === 'done',
-                      'later': b.block_type === 'later',
-                      'wontdo': b.block_type === 'wontdo'
-                    }"
-                    @click.stop="isTodoType(b) ? toggleResultTodo(b) : null"
-                    :title="isTodoType(b) ? 'Cycle todo state' : ''"
-                    :role="isTodoType(b) ? 'button' : null"
-                    :aria-label="isTodoType(b) ? 'Cycle todo state' : null"
-                  >{{ bulletSymbol(b) }}</div>
-                  <a :href="blockHref(b)" class="result-row-link">
-                    <span class="result-content">{{ blockLabel(b) }}</span>
-                    <span class="result-meta">
-                      <span v-if="b.block_type" class="result-block-type">{{ b.block_type }}</span>
-                      <span v-if="b.scheduled_for"> · due {{ b.scheduled_for }}</span>
-                      <span v-if="b.completed_at"> · done {{ b.completed_at.split('T')[0] }}</span>
-                      <span v-if="b.page_title"> · {{ b.page_title }}</span>
-                    </span>
-                  </a>
-                  <button
-                    type="button"
-                    class="block-menu result-row-menu-btn"
-                    @click="openRowMenu(b, $event)"
-                    @contextmenu="openRowMenu(b, $event)"
-                    title="Block options"
-                    aria-label="Block options"
-                  >⋮</button>
-                </div>
-              </li>
+              <EmbedResultRow
+                v-for="b in runResult.results"
+                :key="b.uuid"
+                :block="b"
+                :on-schedule-block="scheduleBlock"
+                :on-open-block-info="openBlockInfoModal"
+                @changed="onRowChanged"
+                @error="onRowError"
+              />
             </ul>
           </div>
         </template>
       </div>
-
-      <EmbedContextMenu
-        ref="rowMenu"
-        :can-schedule="true"
-        :can-block-info="true"
-        @action="onMenuAction"
-      />
 
       <ScheduleBlockPopover
         :is-open="schedulePopoverOpen"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
@@ -18,6 +18,8 @@ const SavedViewsPage = {
 
   components: {
     ScheduleBlockPopover: window.ScheduleBlockPopover || {},
+    BlockInfoModal: window.BlockInfoModal || {},
+    EmbedContextMenu: window.EmbedContextMenu || {},
   },
 
   data() {
@@ -47,12 +49,6 @@ const SavedViewsPage = {
       // "you already have a view for this" banner above the editor.
       prefillMatch: null,
 
-      // Per-row context menu — one menu is rendered for the whole
-      // results list and positioned at the click point; `menuBlock`
-      // is the row it was opened for.
-      menuBlock: null,
-      menuPosition: { x: 0, y: 0 },
-
       // Schedule popover state — mirrors Page.js. SavedViewsPage owns
       // its own popover so the schedule action works on this surface
       // without depending on a host page.
@@ -61,6 +57,10 @@ const SavedViewsPage = {
       schedulePopoverInitialDate: "",
       schedulePopoverInitialReminderDate: "",
       schedulePopoverInitialTime: "",
+
+      // Block info modal — same rationale as the schedule popover.
+      blockInfoModalOpen: false,
+      blockInfoModalBlock: null,
     };
   },
 
@@ -325,7 +325,6 @@ const SavedViewsPage = {
         this._onBlocksChanged
       );
     }
-    this.closeRowMenu();
   },
 
   methods: {
@@ -872,74 +871,32 @@ const SavedViewsPage = {
     },
 
     openRowMenu(b, event) {
-      if (!b) return;
-      event.preventDefault();
-      event.stopPropagation();
-
-      // Position math mirrors BlockComponent.showContextMenuAt so the
-      // menu clamps to the viewport on mobile / narrow windows.
-      const menuWidth = 200;
-      const shadowOffset = 4;
-      const isMobile = window.innerWidth <= 768;
-      const edgePadding = isMobile ? 20 : 10;
-      const bottomPadding = isMobile ? 60 : 10;
-
-      let x = event.clientX;
-      let y = event.clientY;
-      const vw = window.innerWidth;
-
-      if (x + menuWidth + shadowOffset > vw - edgePadding) {
-        x = vw - menuWidth - shadowOffset - edgePadding;
-      }
-      x = Math.max(edgePadding, x);
-
-      this.menuPosition = { x, y };
-      this.menuBlock = b;
-
-      this.$nextTick(() => {
-        const el = this.$el?.querySelector(".block-context-menu");
-        if (!el) return;
-        const h = el.offsetHeight;
-        const vh = window.innerHeight;
-        let ny = y;
-        if (ny + h + shadowOffset > vh - bottomPadding) {
-          ny = vh - h - shadowOffset - bottomPadding;
-        }
-        ny = Math.max(edgePadding, ny);
-        if (ny !== this.menuPosition.y) {
-          this.menuPosition = { x, y: ny };
-        }
-      });
-
-      setTimeout(() => {
-        document.addEventListener("click", this.closeRowMenu);
-      }, 10);
+      this.$refs.rowMenu?.openAt(b, event);
     },
 
-    closeRowMenu() {
-      this.menuBlock = null;
-      document.removeEventListener("click", this.closeRowMenu);
-    },
-
-    async menuAction(action) {
-      const b = this.menuBlock;
-      this.closeRowMenu();
-      if (!b) return;
+    async onMenuAction({ action, block }) {
+      if (!block) return;
       switch (action) {
         case "moveToToday":
-          await this.actionMoveToToday(b);
+          await this.actionMoveToToday(block);
           break;
         case "moveToPage":
-          await this.actionMoveToPage(b);
+          await this.actionMoveToPage(block);
+          break;
+        case "copyLink":
+          await this.actionCopyLink(block);
           break;
         case "schedule":
-          this.actionSchedule(b, { clear: false });
+          this.actionSchedule(block, { clear: false });
           break;
         case "unschedule":
-          this.actionSchedule(b, { clear: true });
+          this.actionSchedule(block, { clear: true });
+          break;
+        case "blockInfo":
+          this.actionBlockInfo(block);
           break;
         case "delete":
-          await this.actionDelete(b);
+          await this.actionDelete(block);
           break;
       }
     },
@@ -1001,6 +958,45 @@ const SavedViewsPage = {
         console.error("moveBlockToPage failed:", err);
         this.runError = `failed to move block: ${err.message || err}`;
       }
+    },
+
+    async actionCopyLink(b) {
+      if (!b.page_slug) {
+        this.runError = "could not build block link";
+        return;
+      }
+      const url = `${window.location.origin}/knowledge/page/${encodeURIComponent(b.page_slug)}/#block-${b.uuid}`;
+      try {
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(url);
+          return;
+        }
+      } catch (err) {
+        console.warn("clipboard API failed, falling back:", err);
+      }
+      try {
+        const ta = document.createElement("textarea");
+        ta.value = url;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand("copy");
+        document.body.removeChild(ta);
+      } catch (err) {
+        console.error("clipboard fallback failed:", err);
+        this.runError = "could not copy link";
+      }
+    },
+
+    actionBlockInfo(b) {
+      this.blockInfoModalBlock = b;
+      this.blockInfoModalOpen = true;
+    },
+
+    closeBlockInfoModal() {
+      this.blockInfoModalOpen = false;
+      this.blockInfoModalBlock = null;
     },
 
     actionSchedule(b, { clear = false } = {}) {
@@ -1263,37 +1259,12 @@ const SavedViewsPage = {
         </template>
       </div>
 
-      <!-- Row context menu (shared across all result rows) -->
-      <div
-        v-if="menuBlock"
-        class="block-context-menu"
-        :style="{ left: menuPosition.x + 'px', top: menuPosition.y + 'px' }"
-        @click.stop
-        role="menu"
-      >
-        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('moveToToday')">
-          <span class="context-menu-icon">⇨</span>
-          <span>move to today's daily</span>
-        </button>
-        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('moveToPage')">
-          <span class="context-menu-icon">→</span>
-          <span>move to page…</span>
-        </button>
-        <div class="context-menu-separator"></div>
-        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('schedule')">
-          <span class="context-menu-icon">◷</span>
-          <span>{{ menuBlock.scheduled_for ? 'reschedule…' : 'schedule…' }}</span>
-        </button>
-        <button v-if="menuBlock.scheduled_for" class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('unschedule')">
-          <span class="context-menu-icon">×</span>
-          <span>clear schedule</span>
-        </button>
-        <div class="context-menu-separator"></div>
-        <button class="context-menu-item context-menu-danger" role="menuitem" tabindex="-1" @click="menuAction('delete')">
-          <span class="context-menu-icon">×</span>
-          <span>delete</span>
-        </button>
-      </div>
+      <EmbedContextMenu
+        ref="rowMenu"
+        :can-schedule="true"
+        :can-block-info="true"
+        @action="onMenuAction"
+      />
 
       <ScheduleBlockPopover
         :is-open="schedulePopoverOpen"
@@ -1302,6 +1273,12 @@ const SavedViewsPage = {
         :initial-time="schedulePopoverInitialTime"
         @save="onSchedulePopoverSave"
         @cancel="onSchedulePopoverCancel"
+      />
+
+      <BlockInfoModal
+        :is-open="blockInfoModalOpen"
+        :block="blockInfoModalBlock"
+        @close="closeBlockInfoModal"
       />
     </div>
   `,

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
@@ -16,6 +16,10 @@ const SavedViewsPage = {
     initialSlug: { type: String, default: null },
   },
 
+  components: {
+    ScheduleBlockPopover: window.ScheduleBlockPopover || {},
+  },
+
   data() {
     return {
       loading: true,
@@ -42,6 +46,21 @@ const SavedViewsPage = {
       // filter matches the clicked property — drives the dismissible
       // "you already have a view for this" banner above the editor.
       prefillMatch: null,
+
+      // Per-row context menu — one menu is rendered for the whole
+      // results list and positioned at the click point; `menuBlock`
+      // is the row it was opened for.
+      menuBlock: null,
+      menuPosition: { x: 0, y: 0 },
+
+      // Schedule popover state — mirrors Page.js. SavedViewsPage owns
+      // its own popover so the schedule action works on this surface
+      // without depending on a host page.
+      schedulePopoverOpen: false,
+      schedulePopoverBlock: null,
+      schedulePopoverInitialDate: "",
+      schedulePopoverInitialReminderDate: "",
+      schedulePopoverInitialTime: "",
     };
   },
 
@@ -279,10 +298,34 @@ const SavedViewsPage = {
       this._maybePrefillFromQuery();
     }
     window.addEventListener("popstate", this.onPopState);
+
+    // Refresh the visible saved-view when a block displayed in it is
+    // mutated from elsewhere (e.g. an embed on another tab fired the
+    // same event). Skips refresh if the changed block isn't in our
+    // current results to avoid pointless re-runs.
+    this._onBlocksChanged = (ev) => {
+      const uuid = ev?.detail?.uuid;
+      if (!uuid || ev?.detail?.source === this) return;
+      if (!this.runResult?.results) return;
+      if (this.runResult.results.some((b) => b.uuid === uuid)) {
+        this.refreshResults();
+      }
+    };
+    document.addEventListener(
+      "brainspread:block-changed",
+      this._onBlocksChanged
+    );
   },
 
   beforeUnmount() {
     window.removeEventListener("popstate", this.onPopState);
+    if (this._onBlocksChanged) {
+      document.removeEventListener(
+        "brainspread:block-changed",
+        this._onBlocksChanged
+      );
+    }
+    this.closeRowMenu();
   },
 
   methods: {
@@ -806,6 +849,7 @@ const SavedViewsPage = {
           b.block_type = r.data.block_type;
           b.completed_at = r.data.completed_at;
           b.content = r.data.content;
+          this.broadcastChange(b.uuid);
         } else {
           const errs = (r && r.errors) || {};
           this.runError =
@@ -815,6 +859,214 @@ const SavedViewsPage = {
       } catch (err) {
         console.error("toggleBlockTodo failed:", err);
         this.runError = "failed to toggle todo. please try again.";
+      }
+    },
+
+    broadcastChange(uuid) {
+      if (!uuid) return;
+      document.dispatchEvent(
+        new CustomEvent("brainspread:block-changed", {
+          detail: { uuid, source: this },
+        })
+      );
+    },
+
+    openRowMenu(b, event) {
+      if (!b) return;
+      event.preventDefault();
+      event.stopPropagation();
+
+      // Position math mirrors BlockComponent.showContextMenuAt so the
+      // menu clamps to the viewport on mobile / narrow windows.
+      const menuWidth = 200;
+      const shadowOffset = 4;
+      const isMobile = window.innerWidth <= 768;
+      const edgePadding = isMobile ? 20 : 10;
+      const bottomPadding = isMobile ? 60 : 10;
+
+      let x = event.clientX;
+      let y = event.clientY;
+      const vw = window.innerWidth;
+
+      if (x + menuWidth + shadowOffset > vw - edgePadding) {
+        x = vw - menuWidth - shadowOffset - edgePadding;
+      }
+      x = Math.max(edgePadding, x);
+
+      this.menuPosition = { x, y };
+      this.menuBlock = b;
+
+      this.$nextTick(() => {
+        const el = this.$el?.querySelector(".block-context-menu");
+        if (!el) return;
+        const h = el.offsetHeight;
+        const vh = window.innerHeight;
+        let ny = y;
+        if (ny + h + shadowOffset > vh - bottomPadding) {
+          ny = vh - h - shadowOffset - bottomPadding;
+        }
+        ny = Math.max(edgePadding, ny);
+        if (ny !== this.menuPosition.y) {
+          this.menuPosition = { x, y: ny };
+        }
+      });
+
+      setTimeout(() => {
+        document.addEventListener("click", this.closeRowMenu);
+      }, 10);
+    },
+
+    closeRowMenu() {
+      this.menuBlock = null;
+      document.removeEventListener("click", this.closeRowMenu);
+    },
+
+    async menuAction(action) {
+      const b = this.menuBlock;
+      this.closeRowMenu();
+      if (!b) return;
+      switch (action) {
+        case "moveToToday":
+          await this.actionMoveToToday(b);
+          break;
+        case "moveToPage":
+          await this.actionMoveToPage(b);
+          break;
+        case "schedule":
+          this.actionSchedule(b, { clear: false });
+          break;
+        case "unschedule":
+          this.actionSchedule(b, { clear: true });
+          break;
+        case "delete":
+          await this.actionDelete(b);
+          break;
+      }
+    },
+
+    async refreshResults() {
+      // Re-runs the active saved view so the results list reflects
+      // backend changes. Used by every action handler + by the
+      // brainspread:block-changed event listener.
+      if (!this.activeView || !this.activeView.uuid) return;
+      try {
+        const r = await window.apiService.runSavedView({
+          uuid: this.activeView.uuid,
+          limit: 100,
+        });
+        if (r && r.success) {
+          this.runResult = r.data;
+          this.runError = null;
+        }
+      } catch (err) {
+        console.error("runSavedView refresh failed:", err);
+      }
+    },
+
+    async actionMoveToToday(b) {
+      try {
+        const r = await window.apiService.moveBlockToDaily(b.uuid);
+        if (!r || !r.success) {
+          throw new Error(
+            r?.errors?.non_field_errors?.[0] || "move to today failed"
+          );
+        }
+        this.broadcastChange(b.uuid);
+        await this.refreshResults();
+      } catch (err) {
+        console.error("moveBlockToDaily failed:", err);
+        this.runError = "failed to move block to today";
+      }
+    },
+
+    async actionMoveToPage(b) {
+      if (!window.appModals?.pickPage) {
+        console.error("appModals.pickPage is not available");
+        return;
+      }
+      const target = await window.appModals.pickPage({
+        title: "move block to page",
+        placeholder: "search pages…",
+        confirmLabel: "move",
+      });
+      if (!target) return;
+      try {
+        const r = await window.apiService.moveBlockToPage(b.uuid, target.uuid);
+        if (!r || !r.success) {
+          throw new Error(r?.errors?.non_field_errors?.[0] || "move failed");
+        }
+        this.broadcastChange(b.uuid);
+        await this.refreshResults();
+      } catch (err) {
+        console.error("moveBlockToPage failed:", err);
+        this.runError = `failed to move block: ${err.message || err}`;
+      }
+    },
+
+    actionSchedule(b, { clear = false } = {}) {
+      if (clear) {
+        this._submitSchedule(b, "", "", "");
+        return;
+      }
+      this.schedulePopoverBlock = b;
+      this.schedulePopoverInitialDate = b.scheduled_for || "";
+      this.schedulePopoverInitialReminderDate = b.pending_reminder_date || "";
+      this.schedulePopoverInitialTime = b.pending_reminder_time || "";
+      this.schedulePopoverOpen = true;
+    },
+
+    onSchedulePopoverSave({ scheduledFor, reminderDate, reminderTime }) {
+      const b = this.schedulePopoverBlock;
+      this.schedulePopoverOpen = false;
+      this.schedulePopoverBlock = null;
+      if (!b) return;
+      this._submitSchedule(b, scheduledFor, reminderDate, reminderTime);
+    },
+
+    onSchedulePopoverCancel() {
+      this.schedulePopoverOpen = false;
+      this.schedulePopoverBlock = null;
+    },
+
+    async _submitSchedule(block, scheduledFor, reminderDate, reminderTime) {
+      try {
+        const r = await window.apiService.scheduleBlock(
+          block.uuid,
+          scheduledFor,
+          reminderDate,
+          reminderTime
+        );
+        if (!r || !r.success) {
+          throw new Error(
+            r?.errors?.non_field_errors?.[0] || "failed to schedule"
+          );
+        }
+        this.broadcastChange(block.uuid);
+        await this.refreshResults();
+      } catch (err) {
+        console.error("scheduleBlock failed:", err);
+        this.runError = `failed to schedule: ${err.message || err}`;
+      }
+    },
+
+    async actionDelete(b) {
+      const confirmed = await (window.appModals?.confirm?.({
+        title: "delete block?",
+        message: "this will also delete any child blocks and cannot be undone.",
+        confirmLabel: "delete",
+        destructive: true,
+      }) ?? Promise.resolve(window.confirm("Delete this block?")));
+      if (!confirmed) return;
+      try {
+        const r = await window.apiService.deleteBlock(b.uuid);
+        if (!r || !r.success) {
+          throw new Error(r?.errors?.non_field_errors?.[0] || "delete failed");
+        }
+        this.broadcastChange(b.uuid);
+        await this.refreshResults();
+      } catch (err) {
+        console.error("deleteBlock failed:", err);
+        this.runError = `failed to delete block: ${err.message || err}`;
       }
     },
   },
@@ -972,7 +1224,7 @@ const SavedViewsPage = {
             <div v-else-if="!runResult.results.length" class="empty-state">No matches.</div>
             <ul v-else class="result-list">
               <li v-for="b in runResult.results" :key="b.uuid">
-                <div class="result-row">
+                <div class="result-row" @contextmenu="openRowMenu(b, $event)">
                   <div
                     class="block-bullet"
                     :class="{
@@ -996,12 +1248,61 @@ const SavedViewsPage = {
                       <span v-if="b.page_title"> · {{ b.page_title }}</span>
                     </span>
                   </a>
+                  <button
+                    type="button"
+                    class="block-menu result-row-menu-btn"
+                    @click="openRowMenu(b, $event)"
+                    @contextmenu="openRowMenu(b, $event)"
+                    title="Block options"
+                    aria-label="Block options"
+                  >⋮</button>
                 </div>
               </li>
             </ul>
           </div>
         </template>
       </div>
+
+      <!-- Row context menu (shared across all result rows) -->
+      <div
+        v-if="menuBlock"
+        class="block-context-menu"
+        :style="{ left: menuPosition.x + 'px', top: menuPosition.y + 'px' }"
+        @click.stop
+        role="menu"
+      >
+        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('moveToToday')">
+          <span class="context-menu-icon">⇨</span>
+          <span>move to today's daily</span>
+        </button>
+        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('moveToPage')">
+          <span class="context-menu-icon">→</span>
+          <span>move to page…</span>
+        </button>
+        <div class="context-menu-separator"></div>
+        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('schedule')">
+          <span class="context-menu-icon">◷</span>
+          <span>{{ menuBlock.scheduled_for ? 'reschedule…' : 'schedule…' }}</span>
+        </button>
+        <button v-if="menuBlock.scheduled_for" class="context-menu-item" role="menuitem" tabindex="-1" @click="menuAction('unschedule')">
+          <span class="context-menu-icon">×</span>
+          <span>clear schedule</span>
+        </button>
+        <div class="context-menu-separator"></div>
+        <button class="context-menu-item context-menu-danger" role="menuitem" tabindex="-1" @click="menuAction('delete')">
+          <span class="context-menu-icon">×</span>
+          <span>delete</span>
+        </button>
+      </div>
+
+      <ScheduleBlockPopover
+        :is-open="schedulePopoverOpen"
+        :initial-date="schedulePopoverInitialDate"
+        :initial-reminder-date="schedulePopoverInitialReminderDate"
+        :initial-time="schedulePopoverInitialTime"
+        @save="onSchedulePopoverSave"
+        @cancel="onSchedulePopoverCancel"
+      />
     </div>
   `,
 };

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/SavedViewsPage.js
@@ -774,6 +774,49 @@ const SavedViewsPage = {
         return content.length > 200 ? content.slice(0, 200) + "…" : content;
       return "(empty block)";
     },
+
+    isTodoType(b) {
+      return ["todo", "doing", "done", "later", "wontdo"].includes(
+        b && b.block_type
+      );
+    },
+
+    bulletSymbol(b) {
+      switch (b && b.block_type) {
+        case "todo":
+        case "later":
+          return "☐";
+        case "doing":
+          return "◐";
+        case "done":
+          return "☑";
+        case "wontdo":
+          return "⊘";
+        default:
+          return "•";
+      }
+    },
+
+    async toggleResultTodo(b) {
+      if (!this.isTodoType(b)) return;
+      try {
+        const r = await window.apiService.toggleBlockTodo(b.uuid);
+        if (r && r.success && r.data) {
+          // Update in place — see QueryEmbedBlock for rationale.
+          b.block_type = r.data.block_type;
+          b.completed_at = r.data.completed_at;
+          b.content = r.data.content;
+        } else {
+          const errs = (r && r.errors) || {};
+          this.runError =
+            (errs.non_field_errors && errs.non_field_errors[0]) ||
+            "Failed to toggle todo";
+        }
+      } catch (err) {
+        console.error("toggleBlockTodo failed:", err);
+        this.runError = "failed to toggle todo. please try again.";
+      }
+    },
   },
 
   template: `
@@ -929,15 +972,31 @@ const SavedViewsPage = {
             <div v-else-if="!runResult.results.length" class="empty-state">No matches.</div>
             <ul v-else class="result-list">
               <li v-for="b in runResult.results" :key="b.uuid">
-                <a :href="blockHref(b)" class="result-row">
-                  <span class="result-content">{{ blockLabel(b) }}</span>
-                  <span class="result-meta">
-                    <span v-if="b.block_type" class="result-block-type">{{ b.block_type }}</span>
-                    <span v-if="b.scheduled_for"> · due {{ b.scheduled_for }}</span>
-                    <span v-if="b.completed_at"> · done {{ b.completed_at.split('T')[0] }}</span>
-                    <span v-if="b.page_title"> · {{ b.page_title }}</span>
-                  </span>
-                </a>
+                <div class="result-row">
+                  <div
+                    class="block-bullet"
+                    :class="{
+                      'todo': b.block_type === 'todo',
+                      'doing': b.block_type === 'doing',
+                      'done': b.block_type === 'done',
+                      'later': b.block_type === 'later',
+                      'wontdo': b.block_type === 'wontdo'
+                    }"
+                    @click.stop="isTodoType(b) ? toggleResultTodo(b) : null"
+                    :title="isTodoType(b) ? 'Cycle todo state' : ''"
+                    :role="isTodoType(b) ? 'button' : null"
+                    :aria-label="isTodoType(b) ? 'Cycle todo state' : null"
+                  >{{ bulletSymbol(b) }}</div>
+                  <a :href="blockHref(b)" class="result-row-link">
+                    <span class="result-content">{{ blockLabel(b) }}</span>
+                    <span class="result-meta">
+                      <span v-if="b.block_type" class="result-block-type">{{ b.block_type }}</span>
+                      <span v-if="b.scheduled_for"> · due {{ b.scheduled_for }}</span>
+                      <span v-if="b.completed_at"> · done {{ b.completed_at.split('T')[0] }}</span>
+                      <span v-if="b.page_title"> · {{ b.page_title }}</span>
+                    </span>
+                  </a>
+                </div>
               </li>
             </ul>
           </div>

--- a/packages/django-app/app/knowledge/templates/knowledge/base.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/base.html
@@ -75,6 +75,7 @@
     <script src="{% static 'knowledge/js/components/ScheduleBlockPopover.js' %}?v={{ STATIC_VERSION }}"></script>
     <script src="{% static 'knowledge/js/components/BlockChatPopover.js' %}?v={{ STATIC_VERSION }}"></script>
     <script src="{% static 'knowledge/js/components/BlockInfoModal.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/components/EmbedContextMenu.js' %}?v={{ STATIC_VERSION }}"></script>
     <script src="{% static 'knowledge/js/components/QueryEmbedBlock.js' %}?v={{ STATIC_VERSION }}"></script>
     <script src="{% static 'knowledge/js/components/Page.js' %}?v={{ STATIC_VERSION }}"></script>
     <script src="{% static 'knowledge/js/components/TaggedBlockDisplay.js' %}?v={{ STATIC_VERSION }}"></script>

--- a/packages/django-app/app/knowledge/templates/knowledge/base.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/base.html
@@ -76,6 +76,7 @@
     <script src="{% static 'knowledge/js/components/BlockChatPopover.js' %}?v={{ STATIC_VERSION }}"></script>
     <script src="{% static 'knowledge/js/components/BlockInfoModal.js' %}?v={{ STATIC_VERSION }}"></script>
     <script src="{% static 'knowledge/js/components/EmbedContextMenu.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/components/EmbedResultRow.js' %}?v={{ STATIC_VERSION }}"></script>
     <script src="{% static 'knowledge/js/components/QueryEmbedBlock.js' %}?v={{ STATIC_VERSION }}"></script>
     <script src="{% static 'knowledge/js/components/Page.js' %}?v={{ STATIC_VERSION }}"></script>
     <script src="{% static 'knowledge/js/components/TaggedBlockDisplay.js' %}?v={{ STATIC_VERSION }}"></script>


### PR DESCRIPTION
Adds a context menu to result rows in both SavedViewsPage and QueryEmbedBlock, enabling users to perform block actions (move, schedule, delete, etc.) directly from embedded saved-view results without navigating to the source page.

**Key changes:**

- **New EmbedContextMenu component** — A reusable context menu for block actions, styled to match BlockComponent's brutalist design. Handles viewport-clamped positioning and cross-instance dismissal.
- **SavedViewsPage enhancements** — Adds todo-state bullet symbols to result rows with click-to-toggle functionality. Right-click or click the ⋮ menu button opens EmbedContextMenu. Implements all action handlers (move to today/page, schedule, delete, copy link, block info). Owns its own ScheduleBlockPopover and BlockInfoModal instances so scheduling works without a host page.
- **QueryEmbedBlock enhancements** — Same UI and action handlers as SavedViewsPage. Defers schedule/block-info actions to host-page callbacks when wired (via new `onScheduleBlock` / `onOpenBlockInfo` props), allowing embeds to reuse the page's modals.
- **Block-changed event listener** — Both components now listen for `brainspread:block-changed` events and refresh their results when a displayed block is mutated elsewhere (e.g., an embed on another tab). Prevents redundant refreshes by tagging broadcasts with `source: this`.
- **CSS updates** — Restructured `.result-row` layout to accommodate bullet, content, and menu button in a horizontal flex layout. Added `.result-row-link` wrapper and `.result-row-menu-btn` styling with hover opacity.
- **Page.js integration** — Dispatches `brainspread:block-changed` after scheduling a block so embeds stay in sync.

Result rows now surface todo-state bullets (☐/◐/☑/⊘) and a context menu for common block operations, matching the interaction model of BlockComponent while keeping inline edits and tree-structural changes scoped to the source page.

https://claude.ai/code/session_01TGqQfahAa2xeSixiossegg