### PR TITLE
Allow correcting completion timestamps on done/wontdo blocks

### DIFF
--- a/packages/django-app/app/ai_chat/test/test_edit_block_completed_at.py
+++ b/packages/django-app/app/ai_chat/test/test_edit_block_completed_at.py
@@ -1,0 +1,90 @@
+from datetime import datetime
+from datetime import timezone as dt_timezone
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from ai_chat.tools.notes_handlers import _edit_block
+from core.llm_tools import ToolContext
+from knowledge.models import Block, Page
+from mcp_server.tools import _edit_block as _mcp_edit_block
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestEditBlockCompletedAt:
+    """edit_block (AI chat + MCP) folds in completed_at overrides."""
+
+    def _setup(self, **block_kwargs) -> Block:
+        user = User.objects.create_user(email="t@example.com", password="p")
+        page = Page.objects.create(title="P", user=user)
+        defaults = {
+            "page": page,
+            "user": user,
+            "content": "DONE ship",
+            "block_type": "done",
+            "order": 0,
+            "completed_at": datetime(2026, 6, 1, tzinfo=dt_timezone.utc),
+        }
+        defaults.update(block_kwargs)
+        return Block.objects.create(**defaults)
+
+    def test_ai_chat_sets_completed_at(self):
+        block = self._setup()
+        ctx = ToolContext(user=block.user)
+        result = _edit_block(
+            ctx,
+            {
+                "block_uuid": str(block.uuid),
+                "completed_at": "2026-06-20T09:00:00+00:00",
+            },
+        )
+        assert result.get("updated") is True
+        block.refresh_from_db()
+        assert block.completed_at == datetime(2026, 6, 20, 9, 0, tzinfo=dt_timezone.utc)
+
+    def test_ai_chat_mark_done_and_set_time_in_one_call(self):
+        block = self._setup(content="TODO ship", block_type="todo", completed_at=None)
+        ctx = ToolContext(user=block.user)
+        result = _edit_block(
+            ctx,
+            {
+                "block_uuid": str(block.uuid),
+                "block_type": "done",
+                "completed_at": "2026-06-20T09:00:00+00:00",
+            },
+        )
+        assert result.get("updated") is True
+        block.refresh_from_db()
+        assert block.block_type == "done"
+        # The caller's timestamp wins over the auto "now" stamp.
+        assert block.completed_at == datetime(2026, 6, 20, 9, 0, tzinfo=dt_timezone.utc)
+
+    def test_ai_chat_rejects_completed_at_on_non_terminal(self):
+        block = self._setup(content="TODO ship", block_type="todo", completed_at=None)
+        ctx = ToolContext(user=block.user)
+        result = _edit_block(
+            ctx,
+            {
+                "block_uuid": str(block.uuid),
+                "completed_at": "2026-06-20T09:00:00+00:00",
+            },
+        )
+        assert "error" in result
+        block.refresh_from_db()
+        assert block.completed_at is None
+
+    def test_mcp_sets_completed_at(self):
+        block = self._setup()
+        ctx = ToolContext(user=block.user)
+        result = _mcp_edit_block(
+            ctx,
+            {
+                "block_uuid": str(block.uuid),
+                "completed_at": "2026-06-20T09:00:00+00:00",
+            },
+        )
+        assert "block" in result
+        block.refresh_from_db()
+        assert block.completed_at == datetime(2026, 6, 20, 9, 0, tzinfo=dt_timezone.utc)

--- a/packages/django-app/app/ai_chat/tools/notes_handlers.py
+++ b/packages/django-app/app/ai_chat/tools/notes_handlers.py
@@ -72,6 +72,9 @@ from knowledge.commands.move_block_to_daily_command import MoveBlockToDailyComma
 from knowledge.commands.run_saved_view_command import RunSavedViewCommand
 from knowledge.commands.schedule_block_command import ScheduleBlockCommand
 from knowledge.commands.search_notes_command import SearchNotesCommand
+from knowledge.commands.set_block_completed_at_command import (
+    SetBlockCompletedAtCommand,
+)
 from knowledge.commands.set_block_type_command import SetBlockTypeCommand
 from knowledge.commands.snooze_block_command import SnoozeBlockCommand
 from knowledge.commands.tag_blocks_command import TagBlocksCommand, UntagBlocksCommand
@@ -114,6 +117,7 @@ from knowledge.forms.move_block_to_daily_form import MoveBlockToDailyForm
 from knowledge.forms.run_saved_view_form import RunSavedViewForm
 from knowledge.forms.schedule_block_form import ScheduleBlockForm
 from knowledge.forms.search_notes_form import SearchNotesForm
+from knowledge.forms.set_block_completed_at_form import SetBlockCompletedAtForm
 from knowledge.forms.set_block_type_form import SetBlockTypeForm
 from knowledge.forms.snooze_block_form import SnoozeBlockForm
 from knowledge.forms.tag_blocks_form import TagBlocksForm, UntagBlocksForm
@@ -637,14 +641,36 @@ def _edit_block(ctx: ToolContext, args: Dict[str, Any]) -> Dict[str, Any]:
         # this block when the caller only wanted to change content/type.
         form_data["parent"] = block.parent.uuid
 
-    if len(form_data) == 2:
+    completed_at = args.get("completed_at")
+    has_block_fields = len(form_data) > 2
+
+    if not has_block_fields and completed_at is None:
         # Only user + block — nothing to update.
         return {"error": "no fields provided to update"}
 
-    form = UpdateBlockForm(form_data)
-    if not form.is_valid():
-        return {"error": _first_form_error(form)}
-    updated = UpdateBlockCommand(form).execute()
+    updated = block
+    if has_block_fields:
+        form = UpdateBlockForm(form_data)
+        if not form.is_valid():
+            return {"error": _first_form_error(form)}
+        updated = UpdateBlockCommand(form).execute()
+
+    # Apply completed_at last: when the same call also flips the block to
+    # done/wontdo, UpdateBlockCommand has already stamped completed_at to
+    # "now", and this override replaces it with the caller's value. The
+    # block must be terminal (the form enforces it) — which it now is.
+    if completed_at is not None:
+        ca_form = SetBlockCompletedAtForm(
+            {
+                "user": ctx.user.id,
+                "block": str(updated.uuid),
+                "completed_at": completed_at,
+            }
+        )
+        if not ca_form.is_valid():
+            return {"error": _first_form_error(ca_form)}
+        updated = SetBlockCompletedAtCommand(ca_form).execute()
+
     return {
         "updated": True,
         "block": {
@@ -653,6 +679,9 @@ def _edit_block(ctx: ToolContext, args: Dict[str, Any]) -> Dict[str, Any]:
             "block_type": updated.block_type,
             "parent_uuid": (str(updated.parent.uuid) if updated.parent else None),
             "order": updated.order,
+            "completed_at": (
+                updated.completed_at.isoformat() if updated.completed_at else None
+            ),
             "page_uuid": str(updated.page.uuid) if updated.page else None,
         },
         "affected_page_uuids": ([str(updated.page.uuid)] if updated.page else []),

--- a/packages/django-app/app/ai_chat/tools/notes_tools.py
+++ b/packages/django-app/app/ai_chat/tools/notes_tools.py
@@ -640,10 +640,13 @@ _WRITE_SCHEMAS: List[Dict[str, Any]] = [
         "name": "edit_block",
         "description": (
             "Update an existing block: change its content, type, parent"
-            " (re-nest), or order. All fields except block_uuid are"
-            " optional — supply only what you want to change. To move a"
-            " block to the page root pass parent_uuid=null. Every call"
-            " pauses for explicit user approval before execution."
+            " (re-nest), order, or completion time. All fields except"
+            " block_uuid are optional — supply only what you want to"
+            " change. To move a block to the page root pass"
+            " parent_uuid=null. Use completed_at to correct when a"
+            " done / wontdo block was actually completed (e.g. a task"
+            " carried forward for days before being marked done). Every"
+            " call pauses for explicit user approval before execution."
         ),
         "input_schema": {
             "type": "object",
@@ -673,6 +676,16 @@ _WRITE_SCHEMAS: List[Dict[str, Any]] = [
                 "order": {
                     "type": "integer",
                     "description": "Optional new order within the parent.",
+                },
+                "completed_at": {
+                    "type": "string",
+                    "description": (
+                        "Optional ISO-8601 datetime to record as when the"
+                        " block was completed. Only valid when the block is"
+                        " (or is being set to) done / wontdo. Include a"
+                        " timezone offset; a naive value is interpreted in"
+                        " the user's timezone."
+                    ),
                 },
             },
             "required": ["block_uuid"],

--- a/packages/django-app/app/knowledge/commands/__init__.py
+++ b/packages/django-app/app/knowledge/commands/__init__.py
@@ -54,6 +54,7 @@ from .schedule_block_command import ScheduleBlockCommand
 from .search_notes_command import SearchNotesCommand
 from .search_pages_command import SearchPagesCommand
 from .send_due_reminders_command import SendDueRemindersCommand
+from .set_block_completed_at_command import SetBlockCompletedAtCommand
 from .set_block_type_command import SetBlockTypeCommand
 from .set_page_favorited_command import SetPageFavoritedCommand
 from .set_saved_view_pinned_command import SetSavedViewPinnedCommand

--- a/packages/django-app/app/knowledge/commands/set_block_completed_at_command.py
+++ b/packages/django-app/app/knowledge/commands/set_block_completed_at_command.py
@@ -1,0 +1,42 @@
+import pytz
+from django.utils import timezone
+
+from common.commands.abstract_base_command import AbstractBaseCommand
+from core.models import User
+
+from ..forms.set_block_completed_at_form import SetBlockCompletedAtForm
+from ..forms.touch_page_form import TouchPageForm
+from ..models import Block
+from .touch_page_command import TouchPageCommand
+
+
+class SetBlockCompletedAtCommand(AbstractBaseCommand):
+    """Override a terminal block's completed_at timestamp.
+
+    The form has already verified ownership and that the block is in a
+    terminal state (done / wontdo). A naive datetime is interpreted in the
+    user's timezone before storage so the stored UTC value matches the
+    wall-clock time the user entered.
+    """
+
+    def __init__(self, form: SetBlockCompletedAtForm) -> None:
+        self.form = form
+
+    def execute(self) -> Block:
+        super().execute()
+
+        user: User = self.form.cleaned_data["user"]
+        block: Block = self.form.cleaned_data["block"]
+        completed_at = self.form.cleaned_data["completed_at"]
+
+        if timezone.is_naive(completed_at):
+            completed_at = user.tz().localize(completed_at).astimezone(pytz.UTC)
+
+        block.completed_at = completed_at
+        block.save(update_fields=["completed_at", "modified_at"])
+
+        touch_form = TouchPageForm(data={"user": user.id, "page": str(block.page.uuid)})
+        if touch_form.is_valid():
+            TouchPageCommand(touch_form).execute()
+
+        return block

--- a/packages/django-app/app/knowledge/forms/__init__.py
+++ b/packages/django-app/app/knowledge/forms/__init__.py
@@ -54,6 +54,7 @@ from .schedule_block_form import ScheduleBlockForm
 from .search_notes_form import SearchNotesForm
 from .search_pages_form import SearchPagesForm
 from .send_due_reminders_form import SendDueRemindersForm
+from .set_block_completed_at_form import SetBlockCompletedAtForm
 from .set_block_type_form import SetBlockTypeForm
 from .set_page_favorited_form import SetPageFavoritedForm
 from .set_saved_view_pinned_form import SetSavedViewPinnedForm

--- a/packages/django-app/app/knowledge/forms/set_block_completed_at_form.py
+++ b/packages/django-app/app/knowledge/forms/set_block_completed_at_form.py
@@ -1,0 +1,62 @@
+from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.dateparse import parse_datetime
+
+from common.forms import BaseForm, UUIDModelChoiceField
+from core.models import User
+from core.repositories import UserRepository
+
+from ..models import Block
+from ..repositories import BlockRepository
+
+# Terminal states whose completion time is meaningful to edit. Mirrors
+# COMPLETED_TYPES in set_block_type_command; kept local to avoid a
+# forms -> commands import cycle.
+TERMINAL_BLOCK_TYPES = {"done", "wontdo"}
+
+
+class SetBlockCompletedAtForm(BaseForm):
+    """Override a completed block's completed_at timestamp.
+
+    Used to correct the recorded completion time — e.g. a block carried
+    over for days before it was finally marked done, leaving completed_at
+    stamped at "mark done" time rather than when the work actually wrapped.
+
+    Only blocks in a terminal state (done / wontdo) carry a completed_at,
+    so editing is rejected for any other block_type. Clearing the value is
+    intentionally not supported here — that happens automatically when a
+    block transitions out of a terminal state (see SetBlockTypeCommand).
+
+    `completed_at` accepts an ISO-8601 datetime. A trailing offset / Z is
+    honored; a naive value is interpreted in the user's timezone by the
+    command.
+    """
+
+    user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
+    block = UUIDModelChoiceField(queryset=BlockRepository.get_queryset(), required=True)
+    completed_at = forms.CharField(required=True)
+
+    def clean_block(self) -> Block:
+        block = self.cleaned_data.get("block")
+        user = self.cleaned_data.get("user")
+
+        if block and user and block.user != user:
+            raise ValidationError("Block not found")
+        if block and block.block_type not in TERMINAL_BLOCK_TYPES:
+            raise ValidationError(
+                "completed_at can only be set on a done or wontdo block"
+            )
+        return block
+
+    def clean_completed_at(self):
+        raw = (self.cleaned_data.get("completed_at") or "").strip()
+        parsed = parse_datetime(raw)
+        if parsed is None:
+            raise ValidationError("completed_at must be an ISO-8601 datetime")
+        return parsed
+
+    def clean_user(self) -> User:
+        user = self.cleaned_data.get("user")
+        if not user:
+            raise ValidationError("User is required")
+        return user

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -860,6 +860,23 @@ body {
   overflow-y: auto;
 }
 
+.block-info-completed {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.block-info-datetime-input {
+  font-family: inherit;
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-secondary);
+  border-radius: 3px;
+  padding: 0.1rem 0.3rem;
+}
+
 /* Page picker modal (window.appModals.pickPage). Wider than the
    prompt/confirm modals so longer page titles fit on one line, and
    wraps a scrollable result list under the input. */

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockInfoModal.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockInfoModal.js
@@ -9,20 +9,28 @@
 //   block      object  — the block dict whose info we're showing
 // Emits:
 //   close — user dismissed
+//   save-completed-at — { iso } user saved a corrected completion time
 window.BlockInfoModal = {
   name: "BlockInfoModal",
   props: {
     isOpen: { type: Boolean, default: false },
     block: { type: Object, default: null },
   },
-  emits: ["close"],
+  emits: ["close", "save-completed-at"],
   data() {
     return {
       uuidCopied: false,
       uuidCopyTimer: null,
+      editingCompleted: false,
+      completedDraft: "",
     };
   },
   computed: {
+    // completed_at only carries meaning for terminal blocks; gate editing
+    // to those so we never stamp a completion time on an open todo.
+    isTerminal() {
+      return ["done", "wontdo"].includes(this.block?.block_type);
+    },
     createdAtPretty() {
       return this.formatTimestamp(this.block?.created_at);
     },
@@ -56,14 +64,49 @@ window.BlockInfoModal = {
     isOpen(open) {
       if (open) {
         this.uuidCopied = false;
+        this.cancelEditCompleted();
         this.$nextTick(() => this.$refs.closeBtn?.focus());
       } else if (this.uuidCopyTimer) {
         clearTimeout(this.uuidCopyTimer);
         this.uuidCopyTimer = null;
       }
     },
+    // Parent reassigns the block object after a successful save; drop out
+    // of edit mode so the refreshed timestamp shows.
+    block() {
+      this.cancelEditCompleted();
+    },
   },
   methods: {
+    // datetime-local wants "YYYY-MM-DDTHH:MM" in local wall-clock time.
+    toDatetimeLocal(value) {
+      if (!value) return "";
+      const d = new Date(value);
+      if (Number.isNaN(d.getTime())) return "";
+      const pad = (n) => String(n).padStart(2, "0");
+      return (
+        `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+        `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+      );
+    },
+    startEditCompleted() {
+      this.completedDraft = this.toDatetimeLocal(this.block?.completed_at);
+      this.editingCompleted = true;
+    },
+    cancelEditCompleted() {
+      this.editingCompleted = false;
+      this.completedDraft = "";
+    },
+    saveCompleted() {
+      if (!this.completedDraft) return;
+      // The input is local wall-clock; toISOString() converts to the UTC
+      // instant the backend stores. A naive value would otherwise be read
+      // in server time, drifting the saved moment.
+      const d = new Date(this.completedDraft);
+      if (Number.isNaN(d.getTime())) return;
+      this.editingCompleted = false;
+      this.$emit("save-completed-at", { iso: d.toISOString() });
+    },
     formatTimestamp(value) {
       // Block info is a debug-leaning surface, so render the full
       // timestamp (date + time + seconds) in the user's locale rather
@@ -164,7 +207,38 @@ window.BlockInfoModal = {
               <dd>{{ scheduledForPretty }}</dd>
             </template>
 
-            <template v-if="completedAtPretty">
+            <template v-if="isTerminal">
+              <dt>completed</dt>
+              <dd>
+                <div v-if="!editingCompleted" class="block-info-completed">
+                  <span>{{ completedAtPretty || 'not set' }}</span>
+                  <button
+                    type="button"
+                    class="block-info-copy-btn"
+                    @click="startEditCompleted"
+                  >edit</button>
+                </div>
+                <div v-else class="block-info-completed">
+                  <input
+                    type="datetime-local"
+                    class="block-info-datetime-input"
+                    v-model="completedDraft"
+                  />
+                  <button
+                    type="button"
+                    class="block-info-copy-btn"
+                    :disabled="!completedDraft"
+                    @click="saveCompleted"
+                  >save</button>
+                  <button
+                    type="button"
+                    class="block-info-copy-btn"
+                    @click="cancelEditCompleted"
+                  >cancel</button>
+                </div>
+              </dd>
+            </template>
+            <template v-else-if="completedAtPretty">
               <dt>completed</dt>
               <dd>{{ completedAtPretty }}</dd>
             </template>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -1080,6 +1080,37 @@ const Page = {
       this.blockInfoModalBlock = null;
     },
 
+    async onSaveBlockCompletedAt({ iso }) {
+      const block = this.blockInfoModalBlock;
+      if (!block || !iso) return;
+      try {
+        const result = await window.apiService.setBlockCompletedAt(
+          block.uuid,
+          iso
+        );
+        if (result.success) {
+          // Reassign so the modal (and its watcher) pick up the new
+          // timestamp and drop out of edit mode.
+          this.blockInfoModalBlock = {
+            ...block,
+            completed_at: result.data?.completed_at || iso,
+          };
+          this.$parent?.addToast?.("completion time updated", "success");
+          document.dispatchEvent(
+            new CustomEvent("brainspread:block-changed", {
+              detail: { uuid: block.uuid },
+            })
+          );
+          await this.loadPage({ silent: true });
+        } else {
+          this.$parent?.addToast?.("failed to update completion time", "error");
+        }
+      } catch (err) {
+        console.error("setBlockCompletedAt failed:", err);
+        this.$parent?.addToast?.("failed to update completion time", "error");
+      }
+    },
+
     async openMovePagePicker(block) {
       // Defer the picker UI to the shared AppModals.pickPage typeahead
       // (added for the saved-view embed flow) so we don't ship two
@@ -4215,6 +4246,7 @@ const Page = {
         :is-open="blockInfoModalOpen"
         :block="blockInfoModalBlock"
         @close="closeBlockInfoModal"
+        @save-completed-at="onSaveBlockCompletedAt"
       />
 
       <!-- Share modal (issue #90) -->

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -668,6 +668,10 @@ const Page = {
           block.content = newContent;
           if (result.data && result.data.block_type) {
             block.block_type = result.data.block_type;
+            // A content prefix (e.g. typing "DONE ") can flip the type
+            // to/from a terminal state; mirror the server's completed_at
+            // so the block-info modal stays accurate without a reload.
+            block.completed_at = result.data.completed_at;
           }
           // Inline URL detection on save: if the user typed (or pasted
           // without the paste handler firing, e.g. mobile) a bare URL,
@@ -877,6 +881,10 @@ const Page = {
         if (result.success) {
           block.block_type = result.data.block_type;
           block.content = result.data.content;
+          // Keep completed_at in sync so the block-info modal shows the
+          // right time without a reload: entering done/wontdo stamps it,
+          // cycling back out clears it to null.
+          block.completed_at = result.data.completed_at;
           this.error = null;
           // Embeds may be showing this block — let them re-run so the
           // bullet / DONE strikethrough reflects the new state without

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -296,6 +296,22 @@ class ApiService {
     });
   }
 
+  /**
+   * Override a completed (done / wontdo) block's completed_at timestamp.
+   *   completedAt: ISO-8601 datetime string (with timezone offset; the
+   *                backend reads a naive value in the user's timezone).
+   * Only valid for terminal blocks — the backend rejects anything else.
+   */
+  async setBlockCompletedAt(blockUuid, completedAt) {
+    return await this.request("/knowledge/api/blocks/set-completed-at/", {
+      method: "POST",
+      body: JSON.stringify({
+        block: blockUuid,
+        completed_at: completedAt,
+      }),
+    });
+  }
+
   async moveUndoneTodos(targetDate = null) {
     const body = targetDate ? { target_date: targetDate } : {};
     return await this.request("/knowledge/api/blocks/move-undone-todos/", {

--- a/packages/django-app/app/knowledge/test/commands/test_set_block_completed_at_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_set_block_completed_at_command.py
@@ -1,0 +1,120 @@
+from datetime import datetime
+from datetime import timezone as dt_timezone
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.utils import timezone
+
+from knowledge.commands import SetBlockCompletedAtCommand
+from knowledge.forms import SetBlockCompletedAtForm
+from knowledge.models import Block, Page
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestSetBlockCompletedAtCommand:
+    """SetBlockCompletedAtCommand overrides a terminal block's completed_at."""
+
+    def _make_block(self, **kwargs) -> Block:
+        user = kwargs.pop("user", None) or User.objects.create_user(
+            email="test@example.com", password="password"
+        )
+        page = Page.objects.create(title="Test Page", user=user)
+        defaults = {
+            "page": page,
+            "user": user,
+            "content": "DONE ship it",
+            "block_type": "done",
+            "order": 0,
+            "completed_at": timezone.now(),
+        }
+        defaults.update(kwargs)
+        return Block.objects.create(**defaults)
+
+    def _run(self, block: Block, completed_at: str) -> Block:
+        form = SetBlockCompletedAtForm(
+            {
+                "user": block.user.id,
+                "block": str(block.uuid),
+                "completed_at": completed_at,
+            }
+        )
+        assert form.is_valid(), form.errors
+        return SetBlockCompletedAtCommand(form).execute()
+
+    def test_sets_completed_at_on_done_block(self):
+        block = self._make_block(block_type="done")
+        result = self._run(block, "2026-06-20T09:00:00+00:00")
+        assert result.completed_at == datetime(
+            2026, 6, 20, 9, 0, 0, tzinfo=dt_timezone.utc
+        )
+
+    def test_sets_completed_at_on_wontdo_block(self):
+        block = self._make_block(content="WONTDO nope", block_type="wontdo")
+        result = self._run(block, "2026-06-20T09:00:00+00:00")
+        assert result.completed_at == datetime(
+            2026, 6, 20, 9, 0, 0, tzinfo=dt_timezone.utc
+        )
+
+    def test_naive_datetime_is_read_in_user_timezone(self):
+        user = User.objects.create_user(
+            email="tz@example.com", password="p", timezone="America/New_York"
+        )
+        block = self._make_block(user=user, block_type="done")
+        # 09:00 EDT (UTC-4 in June) -> 13:00 UTC.
+        result = self._run(block, "2026-06-20T09:00:00")
+        assert result.completed_at == datetime(
+            2026, 6, 20, 13, 0, 0, tzinfo=dt_timezone.utc
+        )
+
+    def test_persists_to_db(self):
+        block = self._make_block(block_type="done")
+        self._run(block, "2026-06-20T09:00:00+00:00")
+        block.refresh_from_db()
+        assert block.completed_at == datetime(
+            2026, 6, 20, 9, 0, 0, tzinfo=dt_timezone.utc
+        )
+
+    def test_rejects_non_terminal_block(self):
+        block = self._make_block(
+            content="TODO ship it", block_type="todo", completed_at=None
+        )
+        form = SetBlockCompletedAtForm(
+            {
+                "user": block.user.id,
+                "block": str(block.uuid),
+                "completed_at": "2026-06-20T09:00:00+00:00",
+            }
+        )
+        assert not form.is_valid()
+        with pytest.raises(ValidationError):
+            SetBlockCompletedAtCommand(form).execute()
+
+    def test_rejects_invalid_datetime(self):
+        block = self._make_block(block_type="done")
+        form = SetBlockCompletedAtForm(
+            {
+                "user": block.user.id,
+                "block": str(block.uuid),
+                "completed_at": "not-a-date",
+            }
+        )
+        assert not form.is_valid()
+        assert "completed_at" in form.errors
+
+    def test_rejects_block_from_other_user(self):
+        u1 = User.objects.create_user(email="u1@example.com", password="p")
+        u2 = User.objects.create_user(email="u2@example.com", password="p")
+        block = self._make_block(user=u1, block_type="done")
+
+        form = SetBlockCompletedAtForm(
+            {
+                "user": u2.id,
+                "block": str(block.uuid),
+                "completed_at": "2026-06-20T09:00:00+00:00",
+            }
+        )
+        with pytest.raises(ValidationError, match="not found"):
+            SetBlockCompletedAtCommand(form).execute()

--- a/packages/django-app/app/knowledge/urls.py
+++ b/packages/django-app/app/knowledge/urls.py
@@ -36,6 +36,11 @@ urlpatterns = [
     path("api/blocks/toggle-todo/", views.toggle_block_todo, name="toggle_block_todo"),
     path("api/blocks/schedule/", views.schedule_block, name="schedule_block"),
     path(
+        "api/blocks/set-completed-at/",
+        views.set_block_completed_at,
+        name="set_block_completed_at",
+    ),
+    path(
         "api/blocks/move-undone-todos/",
         views.move_undone_todos,
         name="move_undone_todos",

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -47,6 +47,7 @@ from knowledge.commands import (
     ScheduleBlockCommand,
     SearchNotesCommand,
     SearchPagesCommand,
+    SetBlockCompletedAtCommand,
     SetPageFavoritedCommand,
     SetSavedViewPinnedCommand,
     SharePageCommand,
@@ -106,6 +107,7 @@ from knowledge.forms import (
     ScheduleBlockForm,
     SearchNotesForm,
     SearchPagesForm,
+    SetBlockCompletedAtForm,
     SetPageFavoritedForm,
     SetSavedViewPinnedForm,
     SharePageForm,
@@ -1139,6 +1141,48 @@ def schedule_block(request):
 
         if form.is_valid():
             block = ScheduleBlockCommand(form).execute()
+            response: BlockResponse = {
+                "success": True,
+                "data": block.to_dict(),
+                "errors": None,
+            }
+            return Response(response)
+
+        response: BlockResponse = {
+            "success": False,
+            "data": None,
+            "errors": form.errors,
+        }
+        return Response(response, status=status.HTTP_400_BAD_REQUEST)
+    except ValidationError as e:
+        return Response(
+            {"success": False, "errors": {"non_field_errors": [str(e)]}},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    except Exception as e:
+        response: BlockResponse = {
+            "success": False,
+            "data": None,
+            "errors": {"non_field_errors": [str(e)]},
+        }
+        return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def set_block_completed_at(request):
+    """Override a completed (done / wontdo) block's completed_at timestamp.
+
+    Lets a user correct the recorded completion time when a block was
+    carried forward for a while before being marked done.
+    """
+    try:
+        data = request.data.copy()
+        data["user"] = request.user.id
+        form = SetBlockCompletedAtForm(data)
+
+        if form.is_valid():
+            block = SetBlockCompletedAtCommand(form).execute()
             response: BlockResponse = {
                 "success": True,
                 "data": block.to_dict(),

--- a/packages/django-app/app/mcp_server/tools.py
+++ b/packages/django-app/app/mcp_server/tools.py
@@ -37,6 +37,9 @@ from knowledge.commands.list_overdue_blocks_command import ListOverdueBlocksComm
 from knowledge.commands.list_scheduled_blocks_command import ListScheduledBlocksCommand
 from knowledge.commands.move_block_to_daily_command import MoveBlockToDailyCommand
 from knowledge.commands.search_pages_command import SearchPagesCommand
+from knowledge.commands.set_block_completed_at_command import (
+    SetBlockCompletedAtCommand,
+)
 from knowledge.commands.tag_blocks_command import TagBlocksCommand, UntagBlocksCommand
 from knowledge.commands.update_block_command import UpdateBlockCommand
 from knowledge.forms import (
@@ -51,6 +54,7 @@ from knowledge.forms.list_scheduled_blocks_form import ListScheduledBlocksForm
 from knowledge.forms.move_block_to_daily_form import MoveBlockToDailyForm
 from knowledge.forms.search_notes_form import SearchNotesForm
 from knowledge.forms.search_pages_form import SearchPagesForm
+from knowledge.forms.set_block_completed_at_form import SetBlockCompletedAtForm
 from knowledge.forms.tag_blocks_form import TagBlocksForm, UntagBlocksForm
 from knowledge.forms.update_block_form import UpdateBlockForm
 from knowledge.models import Block
@@ -188,19 +192,38 @@ def _edit_block(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     if block_type:
         payload["block_type"] = block_type
         touched = True
-    if not touched:
-        raise ToolError("pass content and/or block_type to update")
+    completed_at = args.get("completed_at")
+    if not touched and completed_at is None:
+        raise ToolError("pass content, block_type, and/or completed_at to update")
 
-    # UpdateBlockCommand orphans the block to root when "parent" is
-    # missing — preserve the existing parent so a content-only edit
-    # doesn't restructure the tree.
-    if block.parent_id is not None:
-        payload["parent"] = str(block.parent.uuid)
+    updated = block
+    if touched:
+        # UpdateBlockCommand orphans the block to root when "parent" is
+        # missing — preserve the existing parent so a content-only edit
+        # doesn't restructure the tree.
+        if block.parent_id is not None:
+            payload["parent"] = str(block.parent.uuid)
 
-    form = UpdateBlockForm(data=payload)
-    if not form.is_valid():
-        raise ToolError(_form_errors_to_str(form))
-    updated = UpdateBlockCommand(form).execute()
+        form = UpdateBlockForm(data=payload)
+        if not form.is_valid():
+            raise ToolError(_form_errors_to_str(form))
+        updated = UpdateBlockCommand(form).execute()
+
+    # Override completion time last, so a combined "mark done + set time"
+    # call lands on the caller's timestamp rather than "now". The form
+    # rejects completed_at on non-terminal blocks.
+    if completed_at is not None:
+        ca_form = SetBlockCompletedAtForm(
+            data={
+                "user": ctx.user.id,
+                "block": str(updated.uuid),
+                "completed_at": completed_at,
+            }
+        )
+        if not ca_form.is_valid():
+            raise ToolError(_form_errors_to_str(ca_form))
+        updated = SetBlockCompletedAtCommand(ca_form).execute()
+
     return {"block": updated.to_dict(include_page_context=True)}
 
 
@@ -467,11 +490,13 @@ REGISTRY = ToolRegistry(
         Tool(
             name="edit_block",
             description=(
-                "Update a block's content and/or block_type. Pass at least"
-                " one of content / block_type. block_type accepts 'bullet',"
-                " 'todo', 'doing', 'done', 'later', 'wontdo', 'heading',"
-                " etc. Preserves the block's parent — use the UI to"
-                " re-parent."
+                "Update a block's content, block_type, and/or completion"
+                " time. Pass at least one of content / block_type /"
+                " completed_at. block_type accepts 'bullet', 'todo',"
+                " 'doing', 'done', 'later', 'wontdo', 'heading', etc."
+                " completed_at corrects when a done / wontdo block was"
+                " actually completed. Preserves the block's parent — use"
+                " the UI to re-parent."
             ),
             input_schema={
                 "type": "object",
@@ -484,6 +509,16 @@ REGISTRY = ToolRegistry(
                     "block_type": {
                         "type": "string",
                         "description": "New block_type. Omit to leave unchanged.",
+                    },
+                    "completed_at": {
+                        "type": "string",
+                        "description": (
+                            "ISO-8601 datetime to record as the completion"
+                            " time. Only valid for done / wontdo blocks."
+                            " Include a timezone offset; a naive value is"
+                            " read in the user's timezone. Omit to leave"
+                            " unchanged."
+                        ),
                     },
                 },
                 "required": ["block_uuid"],


### PR DESCRIPTION
Adds the ability to override the `completed_at` timestamp on terminal blocks (done/wontdo), letting users correct when a task was actually completed if it was carried forward for days before being marked done.

**Key changes:**

- **New command & form**: `SetBlockCompletedAtCommand` and `SetBlockCompletedAtForm` validate and apply completion time overrides. The form enforces that only terminal blocks can have their completion time edited, and interprets naive datetimes in the user's timezone before storing as UTC.
- **API endpoint**: New `POST /knowledge/api/blocks/set-completed-at/` view to accept completion time corrections from the UI.
- **AI chat & MCP integration**: Both `_edit_block` handlers now accept an optional `completed_at` parameter. When combined with a block_type change to done/wontdo, the caller's timestamp takes precedence over the auto-stamped "now" value.
- **UI modal**: `BlockInfoModal` now shows an editable completion time field for terminal blocks, with a datetime-local input that converts to ISO-8601 before sending to the backend.
- **Frontend service & page handler**: `ApiService.setBlockCompletedAt()` and `Page.onSaveBlockCompletedAt()` wire up the modal's save action to the API.

The implementation follows the command pattern: all business logic lives in the command, forms validate ownership and block type, and the command handles timezone conversion for naive inputs.

https://claude.ai/code/session_01Y6rCwrbsz7ScT2YisWS6MB