### PR TITLE
Add block reordering via edit_block and reorder_blocks tools

### DIFF
--- a/packages/django-app/app/mcp_server/test/test_mcp_endpoint.py
+++ b/packages/django-app/app/mcp_server/test/test_mcp_endpoint.py
@@ -89,6 +89,7 @@ class MCPEndpointTestCase(TestCase):
                 "create_block",
                 "create_page",
                 "edit_block",
+                "reorder_blocks",
                 "list_today_todos",
                 "list_overdue",
                 "list_scheduled",
@@ -376,6 +377,100 @@ class MCPEndpointTestCase(TestCase):
         self.assertTrue(response.json()["result"]["isError"])
         block.refresh_from_db()
         self.assertEqual(block.content, "theirs")
+
+    def test_edit_block_updates_order(self):
+        page = PageFactory(user=self.user)
+        block = BlockFactory(user=self.user, page=page, content="x", order=0)
+        response = self.client.post(
+            "/api/mcp/",
+            _tool_call("edit_block", {"block_uuid": str(block.uuid), "order": 3}),
+            format="json",
+        )
+        self.assertFalse(response.json()["result"]["isError"])
+        block.refresh_from_db()
+        self.assertEqual(block.order, 3)
+
+    def test_edit_block_rejects_non_integer_order(self):
+        page = PageFactory(user=self.user)
+        block = BlockFactory(user=self.user, page=page, content="x", order=0)
+        response = self.client.post(
+            "/api/mcp/",
+            _tool_call("edit_block", {"block_uuid": str(block.uuid), "order": "abc"}),
+            format="json",
+        )
+        body = response.json()
+        self.assertTrue(body["result"]["isError"])
+        self.assertIn("order", body["result"]["content"][0]["text"])
+        block.refresh_from_db()
+        self.assertEqual(block.order, 0)
+
+    # --- reorder_blocks ----------------------------------------------
+
+    def test_reorder_blocks_resequences_siblings(self):
+        page = PageFactory(user=self.user)
+        first = BlockFactory(user=self.user, page=page, content="a", order=0)
+        second = BlockFactory(user=self.user, page=page, content="b", order=1)
+        third = BlockFactory(user=self.user, page=page, content="c", order=2)
+        response = self.client.post(
+            "/api/mcp/",
+            _tool_call(
+                "reorder_blocks",
+                {
+                    "blocks": [
+                        {"block_uuid": str(third.uuid), "order": 0},
+                        {"block_uuid": str(first.uuid), "order": 1},
+                        {"block_uuid": str(second.uuid), "order": 2},
+                    ]
+                },
+            ),
+            format="json",
+        )
+        body = response.json()
+        self.assertFalse(body["result"]["isError"], body)
+        payload = _content_json(body)
+        self.assertTrue(payload["reordered"])
+        self.assertEqual(payload["count"], 3)
+        first.refresh_from_db()
+        second.refresh_from_db()
+        third.refresh_from_db()
+        self.assertEqual(third.order, 0)
+        self.assertEqual(first.order, 1)
+        self.assertEqual(second.order, 2)
+
+    def test_reorder_blocks_rejects_empty_list(self):
+        response = self.client.post(
+            "/api/mcp/",
+            _tool_call("reorder_blocks", {"blocks": []}),
+            format="json",
+        )
+        body = response.json()
+        self.assertTrue(body["result"]["isError"])
+        self.assertIn("non-empty", body["result"]["content"][0]["text"])
+
+    def test_reorder_blocks_user_isolation(self):
+        other = UserFactory(email="reorder-other@example.com")
+        mine = BlockFactory(user=self.user, content="mine", order=0)
+        theirs = BlockFactory(user=other, content="theirs", order=0)
+        response = self.client.post(
+            "/api/mcp/",
+            _tool_call(
+                "reorder_blocks",
+                {
+                    "blocks": [
+                        {"block_uuid": str(mine.uuid), "order": 1},
+                        {"block_uuid": str(theirs.uuid), "order": 0},
+                    ]
+                },
+            ),
+            format="json",
+        )
+        # The whole reorder is rejected when any block isn't owned, leaving
+        # every order untouched.
+        self.assertTrue(response.json()["result"]["isError"])
+        mine.refresh_from_db()
+        theirs.refresh_from_db()
+        self.assertEqual(mine.order, 0)
+        self.assertEqual(theirs.order, 0)
 
     # --- create_block nesting ----------------------------------------
 

--- a/packages/django-app/app/mcp_server/tools.py
+++ b/packages/django-app/app/mcp_server/tools.py
@@ -15,6 +15,8 @@ Add new tools by appending to ``REGISTRY`` at the bottom.
 
 from typing import Any
 
+from django.core.exceptions import ValidationError
+
 from core.commands.get_current_time_command import GetCurrentTimeCommand
 from core.forms import GetCurrentTimeForm
 from core.llm_tools import (
@@ -29,6 +31,7 @@ from knowledge.commands import (
     CreateBlockCommand,
     CreatePageCommand,
     GetPageWithBlocksCommand,
+    ReorderBlocksCommand,
     ScheduleBlockCommand,
     SearchNotesCommand,
     ToggleBlockTodoCommand,
@@ -46,6 +49,7 @@ from knowledge.forms import (
     CreateBlockForm,
     CreatePageForm,
     GetPageWithBlocksForm,
+    ReorderBlocksForm,
     ScheduleBlockForm,
     ToggleBlockTodoForm,
 )
@@ -192,9 +196,18 @@ def _edit_block(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
     if block_type:
         payload["block_type"] = block_type
         touched = True
+    order = args.get("order")
+    if order is not None:
+        try:
+            payload["order"] = int(order)
+        except (TypeError, ValueError) as e:
+            raise ToolError("order must be an integer") from e
+        touched = True
     completed_at = args.get("completed_at")
     if not touched and completed_at is None:
-        raise ToolError("pass content, block_type, and/or completed_at to update")
+        raise ToolError(
+            "pass content, block_type, order, and/or completed_at to update"
+        )
 
     updated = block
     if touched:
@@ -225,6 +238,39 @@ def _edit_block(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
         updated = SetBlockCompletedAtCommand(ca_form).execute()
 
     return {"block": updated.to_dict(include_page_context=True)}
+
+
+def _reorder_blocks(ctx: ToolContext, args: dict[str, Any]) -> dict[str, Any]:
+    items = args.get("blocks") or []
+    if not isinstance(items, list) or not items:
+        raise ToolError("blocks must be a non-empty list")
+
+    payload_blocks: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            raise ToolError("each blocks entry must be an object")
+        block_uuid = (item.get("block_uuid") or "").strip()
+        if not block_uuid:
+            raise ToolError("each entry needs block_uuid")
+        if block_uuid in seen:
+            raise ToolError(f"duplicate block_uuid {block_uuid}")
+        seen.add(block_uuid)
+        try:
+            order = int(item.get("order"))
+        except (TypeError, ValueError) as e:
+            raise ToolError("each entry needs an integer order") from e
+        payload_blocks.append({"uuid": block_uuid, "order": order})
+
+    form = ReorderBlocksForm(data={"user": ctx.user.id, "blocks": payload_blocks})
+    if not form.is_valid():
+        raise ToolError(_form_errors_to_str(form))
+    try:
+        ReorderBlocksCommand(form).execute()
+    except ValidationError as e:
+        raise ToolError("; ".join(e.messages)) from e
+
+    return {"reordered": True, "count": len(payload_blocks)}
 
 
 def _list_today_todos(ctx: ToolContext, _args: dict[str, Any]) -> dict[str, Any]:
@@ -490,13 +536,15 @@ REGISTRY = ToolRegistry(
         Tool(
             name="edit_block",
             description=(
-                "Update a block's content, block_type, and/or completion"
-                " time. Pass at least one of content / block_type /"
-                " completed_at. block_type accepts 'bullet', 'todo',"
-                " 'doing', 'done', 'later', 'wontdo', 'heading', etc."
-                " completed_at corrects when a done / wontdo block was"
-                " actually completed. Preserves the block's parent — use"
-                " the UI to re-parent."
+                "Update a block's content, block_type, order, and/or"
+                " completion time. Pass at least one of content / block_type"
+                " / order / completed_at. block_type accepts 'bullet',"
+                " 'todo', 'doing', 'done', 'later', 'wontdo', 'heading', etc."
+                " order moves the block among its siblings (lower sorts"
+                " first); to resequence several siblings at once prefer"
+                " reorder_blocks. completed_at corrects when a done / wontdo"
+                " block was actually completed. Preserves the block's"
+                " parent — use the UI to re-parent."
             ),
             input_schema={
                 "type": "object",
@@ -509,6 +557,14 @@ REGISTRY = ToolRegistry(
                     "block_type": {
                         "type": "string",
                         "description": "New block_type. Omit to leave unchanged.",
+                    },
+                    "order": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": (
+                            "New sort position among siblings (0-based, lower"
+                            " sorts first). Omit to leave unchanged."
+                        ),
                     },
                     "completed_at": {
                         "type": "string",
@@ -524,6 +580,41 @@ REGISTRY = ToolRegistry(
                 "required": ["block_uuid"],
             },
             handler=_edit_block,
+        ),
+        Tool(
+            name="reorder_blocks",
+            description=(
+                "Resequence a set of sibling blocks in one call. Pass the"
+                " full ordered list of blocks (each with its new 0-based"
+                " order); the lowest order sorts first. Use this to move a"
+                " block up/down or sort a list — it only changes ordering,"
+                " not parents or pages. All blocks must belong to the"
+                " caller. Read the current orders first (e.g. via get_page)"
+                " so the new sequence is contiguous and gap-free."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "blocks": {
+                        "type": "array",
+                        "description": (
+                            "Ordered list of blocks to resequence. Each item"
+                            " is {block_uuid, order}."
+                        ),
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "block_uuid": {"type": "string"},
+                                "order": {"type": "integer", "minimum": 0},
+                            },
+                            "required": ["block_uuid", "order"],
+                        },
+                        "minItems": 1,
+                    },
+                },
+                "required": ["blocks"],
+            },
+            handler=_reorder_blocks,
         ),
         Tool(
             name="list_today_todos",


### PR DESCRIPTION
Adds support for reordering blocks through the MCP tools interface. Users can now update a block's sort position individually via `edit_block`, or resequence multiple sibling blocks at once via a new `reorder_blocks` tool.

**Key changes:**

- Extended `edit_block` tool to accept an `order` parameter (0-based integer) for repositioning a block among its siblings
- Added new `reorder_blocks` tool to atomically resequence a set of sibling blocks in a single call
- Imported `ReorderBlocksCommand` and `ReorderBlocksForm` to handle the reordering business logic
- Added `ValidationError` import for proper error handling
- Updated `edit_block` error message to mention `order` as an available parameter
- Comprehensive test coverage for both tools, including validation, user isolation, and edge cases

The `reorder_blocks` tool validates that all blocks belong to the caller and rejects the entire operation if any block is not owned, ensuring data integrity.

https://claude.ai/code/session_0135B2Q9s81yfNqwNoAuqyzs