### PR TITLE
Include children in referenced blocks on tag pages

### DIFF
--- a/packages/django-app/app/knowledge/commands/get_page_with_blocks_command.py
+++ b/packages/django-app/app/knowledge/commands/get_page_with_blocks_command.py
@@ -62,13 +62,11 @@ class GetPageWithBlocksCommand(AbstractBaseCommand):
         # Get direct blocks (blocks that belong directly to this page)
         direct_blocks = BlockRepository.get_root_blocks(page)
 
-        # Get referenced blocks (blocks from other pages that reference this page)
-        # Look for blocks that have this page in their M2M tags relationship, but don't belong to this page
-        referenced_blocks = (
-            page.tagged_blocks.exclude(page=page)
-            .select_related("user", "page")
-            .prefetch_related("reminders")
-        )
+        # Get referenced blocks (blocks from other pages that reference this
+        # page via the M2M tag relationship). Descendants whose ancestor is
+        # also tagged are dropped — they already render nested under that
+        # ancestor's reference, so a standalone entry would just duplicate.
+        referenced_blocks = BlockRepository.get_referenced_blocks(page)
 
         overdue_blocks: List[Block] = []
         if page.page_type == "daily" and page.date == today:

--- a/packages/django-app/app/knowledge/commands/get_tag_content_command.py
+++ b/packages/django-app/app/knowledge/commands/get_tag_content_command.py
@@ -5,7 +5,7 @@ from core.models import User
 
 from ..forms import GetTagContentForm
 from ..models import BlockData, PageData
-from ..repositories import PageRepository
+from ..repositories import BlockRepository, PageRepository
 
 
 class GetTagContentCommand(AbstractBaseCommand):
@@ -31,8 +31,10 @@ class GetTagContentCommand(AbstractBaseCommand):
         # Get direct blocks (blocks that belong directly to this page)
         direct_blocks = tag_page.blocks.all().order_by("order")
 
-        # Get referenced blocks (blocks from other pages that reference this tag)
-        referenced_blocks = tag_page.tagged_blocks.exclude(page=tag_page)
+        # Get referenced blocks (blocks from other pages that reference this
+        # tag). Descendants whose ancestor is also tagged are dropped so they
+        # aren't shown twice — once nested, once standalone.
+        referenced_blocks = BlockRepository.get_referenced_blocks(tag_page)
 
         # Get all pages that have blocks with this tag (excluding the tag page itself)
         pages = []

--- a/packages/django-app/app/knowledge/repositories/block_repository.py
+++ b/packages/django-app/app/knowledge/repositories/block_repository.py
@@ -47,6 +47,69 @@ class BlockRepository(BaseRepository):
         )
 
     @classmethod
+    def get_referenced_blocks(
+        cls, page: Page, order_by: Iterable[str] = ()
+    ) -> List[Block]:
+        """Blocks on *other* pages tagged with ``page`` (its "linked
+        references"), with redundant descendants removed.
+
+        A tagged block is dropped when one of its ancestors is also tagged
+        with the same page: the references list renders each reference's
+        full subtree, so the descendant already shows up nested under that
+        ancestor. Surfacing it again as its own top-level entry would just
+        duplicate it.
+
+        ``order_by`` is applied to the underlying query (defaults to the
+        model's Meta ordering). The ancestor walk fetches intermediate
+        (untagged) ancestors in bulk per depth level, so it costs one
+        query per level rather than one per block.
+        """
+        qs = (
+            cls.get_queryset()
+            .filter(pages=page)
+            .exclude(page=page)
+            .select_related("user", "page", "asset")
+            .prefetch_related("reminders")
+        )
+        if order_by:
+            qs = qs.order_by(*order_by)
+        tagged = list(qs)
+        if not tagged:
+            return []
+
+        tagged_ids = {b.id for b in tagged}
+
+        parent_of: Dict[int, Optional[int]] = {b.id: b.parent_id for b in tagged}
+        frontier = {
+            b.parent_id
+            for b in tagged
+            if b.parent_id is not None and b.parent_id not in parent_of
+        }
+        while frontier:
+            rows = list(
+                cls.get_queryset()
+                .filter(id__in=frontier)
+                .values_list("id", "parent_id")
+            )
+            for block_id, parent_id in rows:
+                parent_of[block_id] = parent_id
+            frontier = {
+                parent_id
+                for _block_id, parent_id in rows
+                if parent_id is not None and parent_id not in parent_of
+            }
+
+        def has_tagged_ancestor(block_id: int) -> bool:
+            parent_id = parent_of.get(block_id)
+            while parent_id is not None:
+                if parent_id in tagged_ids:
+                    return True
+                parent_id = parent_of.get(parent_id)
+            return False
+
+        return [b for b in tagged if not has_tagged_ancestor(b.id)]
+
+    @classmethod
     def get_child_blocks(cls, parent_block: Block) -> QuerySet:
         """Get direct children of a block"""
         return cls.get_queryset().filter(parent=parent_block).order_by("order")

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -135,10 +135,19 @@ const BlockComponent = {
       type: Boolean,
       default: false,
     },
+    // Linked-references rendering mode. When true the block (and its
+    // subtree) starts collapsed regardless of the block's own collapsed
+    // flag, and expand/collapse toggles stay local instead of being
+    // persisted — these blocks live on another page and collapsing them
+    // in a references list shouldn't change how they render at home.
+    referenceMode: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
-      isCollapsed: this.block.collapsed === true,
+      isCollapsed: this.referenceMode ? true : this.block.collapsed === true,
       showContextMenu: false,
       contextMenuPosition: { x: 0, y: 0 },
       contextMenuFocusedIndex: -1,
@@ -778,6 +787,11 @@ const BlockComponent = {
       const next = !this.isCollapsed;
       const previous = this.isCollapsed;
       this.isCollapsed = next;
+      // In a linked-references list the block belongs to another page, so
+      // keep the toggle local and don't persist it back to the source.
+      if (this.referenceMode) {
+        return;
+      }
       this.block.collapsed = next;
       try {
         const result = await window.apiService.updateBlock(this.block.uuid, {
@@ -2020,6 +2034,7 @@ const BlockComponent = {
           :bulkDeleteSelected="bulkDeleteSelected"
           :bulkMoveSelectedToToday="bulkMoveSelectedToToday"
           :selectionMode="selectionMode"
+          :reference-mode="referenceMode"
         />
       </div>
     </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -4198,6 +4198,7 @@ const Page = {
               </div>
               <BlockComponent
                 :block="block"
+                :reference-mode="true"
                 :onBlockContentChange="onBlockContentChange"
                 :onBlockKeyDown="onBlockKeyDown"
                 :startEditing="startEditing"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -489,7 +489,9 @@ const Page = {
           this.directBlocks = this.setupParentReferences(
             result.data.direct_blocks || []
           );
-          this.referencedBlocks = result.data.referenced_blocks || [];
+          this.referencedBlocks = this.setupParentReferences(
+            result.data.referenced_blocks || []
+          );
           this.overdueBlocks = result.data.overdue_blocks || [];
           this.embeddedViews = result.data.embedded_views || [];
           this.$emit("page-loaded", this.page);

--- a/packages/django-app/app/knowledge/templates/knowledge/public_page.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/public_page.html
@@ -42,6 +42,11 @@
               {% endif %}
             </div>
             {% include 'knowledge/_public_block_content.html' with block=ref %}
+            {% if ref.children %}
+            <ul class="public-block-list">
+              {% include 'knowledge/_public_block_list.html' with blocks=ref.children %}
+            </ul>
+            {% endif %}
           </li>
           {% endfor %}
         </ul>

--- a/packages/django-app/app/knowledge/test/repositories/test_block_repository.py
+++ b/packages/django-app/app/knowledge/test/repositories/test_block_repository.py
@@ -1,0 +1,61 @@
+from django.test import TestCase
+
+from knowledge.repositories import BlockRepository
+
+from ..helpers import BlockFactory, PageFactory, UserFactory
+
+
+class TestGetReferencedBlocks(TestCase):
+    """get_referenced_blocks returns blocks on other pages tagged with the
+    given page, dropping descendants whose ancestor is also tagged (they
+    already render nested under that ancestor)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.tag_page = PageFactory(user=cls.user, title="Tag", slug="tag")
+        cls.source = PageFactory(user=cls.user, title="Source", slug="source")
+
+    def test_returns_tagged_block_from_other_page(self):
+        block = BlockFactory(user=self.user, page=self.source)
+        block.pages.add(self.tag_page)
+
+        result = BlockRepository.get_referenced_blocks(self.tag_page)
+        self.assertEqual([b.id for b in result], [block.id])
+
+    def test_excludes_blocks_belonging_to_the_tag_page_itself(self):
+        own = BlockFactory(user=self.user, page=self.tag_page)
+        own.pages.add(self.tag_page)
+
+        result = BlockRepository.get_referenced_blocks(self.tag_page)
+        self.assertEqual(result, [])
+
+    def test_dedupes_child_when_ancestor_is_also_tagged(self):
+        parent = BlockFactory(user=self.user, page=self.source)
+        parent.pages.add(self.tag_page)
+        child = BlockFactory(user=self.user, page=self.source, parent=parent)
+        child.pages.add(self.tag_page)
+
+        result = BlockRepository.get_referenced_blocks(self.tag_page)
+        self.assertEqual([b.id for b in result], [parent.id])
+
+    def test_dedupes_deeply_nested_descendant_through_untagged_ancestor(self):
+        parent = BlockFactory(user=self.user, page=self.source)
+        parent.pages.add(self.tag_page)
+        # Intermediate block is NOT tagged.
+        middle = BlockFactory(user=self.user, page=self.source, parent=parent)
+        grandchild = BlockFactory(user=self.user, page=self.source, parent=middle)
+        grandchild.pages.add(self.tag_page)
+
+        result = BlockRepository.get_referenced_blocks(self.tag_page)
+        self.assertEqual([b.id for b in result], [parent.id])
+
+    def test_keeps_tagged_child_when_ancestor_not_tagged(self):
+        # Parent isn't tagged, so the tagged child has no tagged ancestor and
+        # must surface as its own top-level reference.
+        parent = BlockFactory(user=self.user, page=self.source)
+        child = BlockFactory(user=self.user, page=self.source, parent=parent)
+        child.pages.add(self.tag_page)
+
+        result = BlockRepository.get_referenced_blocks(self.tag_page)
+        self.assertEqual([b.id for b in result], [child.id])

--- a/packages/django-app/app/knowledge/test/views/test_get_page_with_blocks_api.py
+++ b/packages/django-app/app/knowledge/test/views/test_get_page_with_blocks_api.py
@@ -1,0 +1,53 @@
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from knowledge.test.helpers import BlockFactory, PageFactory, UserFactory
+
+
+class GetPageWithBlocksReferencedChildrenTestCase(TestCase):
+    """Referenced (linked) blocks should carry their nested children so a
+    tag page can expand a tagged block and reveal its sub-blocks.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(email="owner@example.com")
+        # The tag page the user navigates to (e.g. "mental health").
+        cls.tag_page = PageFactory(
+            user=cls.user, title="Mental Health", slug="mental-health"
+        )
+        # A note on another page tagged with the tag page, with children.
+        cls.source_page = PageFactory(user=cls.user, title="Journal", slug="journal")
+        cls.parent = BlockFactory(
+            user=cls.user, page=cls.source_page, content="some note #mental-health"
+        )
+        cls.parent.pages.add(cls.tag_page)
+        cls.child = BlockFactory(
+            user=cls.user,
+            page=cls.source_page,
+            parent=cls.parent,
+            content="a child detail",
+            order=0,
+        )
+
+    def setUp(self):
+        self.client = APIClient()
+        token = Token.objects.create(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+
+    def test_referenced_block_includes_children(self):
+        response = self.client.get("/knowledge/api/page/?slug=mental-health")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["success"])
+
+        referenced = response.data["data"]["referenced_blocks"]
+        self.assertEqual(len(referenced), 1)
+
+        ref_block = referenced[0]
+        self.assertEqual(ref_block["uuid"], str(self.parent.uuid))
+        self.assertIsNotNone(ref_block["children"])
+        self.assertEqual(len(ref_block["children"]), 1)
+        self.assertEqual(ref_block["children"][0]["uuid"], str(self.child.uuid))
+        self.assertEqual(ref_block["children"][0]["content"], "a child detail")

--- a/packages/django-app/app/knowledge/test/views/test_get_page_with_blocks_api.py
+++ b/packages/django-app/app/knowledge/test/views/test_get_page_with_blocks_api.py
@@ -51,3 +51,39 @@ class GetPageWithBlocksReferencedChildrenTestCase(TestCase):
         self.assertEqual(len(ref_block["children"]), 1)
         self.assertEqual(ref_block["children"][0]["uuid"], str(self.child.uuid))
         self.assertEqual(ref_block["children"][0]["content"], "a child detail")
+
+    def test_child_tagged_alongside_ancestor_is_not_duplicated(self):
+        # The child is ALSO tagged with the same page. It already shows up
+        # nested under its tagged parent, so it must not appear again as its
+        # own top-level reference entry.
+        self.child.pages.add(self.tag_page)
+
+        response = self.client.get("/knowledge/api/page/?slug=mental-health")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        referenced = response.data["data"]["referenced_blocks"]
+        top_level_uuids = [b["uuid"] for b in referenced]
+        # Only the parent surfaces at top level; the child is deduped.
+        self.assertEqual(top_level_uuids, [str(self.parent.uuid)])
+        # ...but it's still reachable nested under the parent.
+        self.assertEqual(referenced[0]["children"][0]["uuid"], str(self.child.uuid))
+
+    def test_deeply_nested_tagged_descendant_is_deduped(self):
+        # parent (tagged) -> child (untagged) -> grandchild (tagged).
+        # The grandchild's ancestor is tagged, so it's deduped even though
+        # the intermediate child isn't tagged.
+        grandchild = BlockFactory(
+            user=self.user,
+            page=self.source_page,
+            parent=self.child,
+            content="a grandchild detail",
+            order=0,
+        )
+        grandchild.pages.add(self.tag_page)
+
+        response = self.client.get("/knowledge/api/page/?slug=mental-health")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        referenced = response.data["data"]["referenced_blocks"]
+        top_level_uuids = [b["uuid"] for b in referenced]
+        self.assertEqual(top_level_uuids, [str(self.parent.uuid)])

--- a/packages/django-app/app/knowledge/test/views/test_share_page_api.py
+++ b/packages/django-app/app/knowledge/test/views/test_share_page_api.py
@@ -178,6 +178,48 @@ class PublicPageViewTestCase(TestCase):
         self.assertIn("nested detail line", body)
         self.assertIn("deeper grandchild line", body)
 
+    def test_public_view_dedupes_child_tagged_alongside_ancestor(self):
+        # A child tagged with the same page as its parent must appear only
+        # once (nested under the parent), not also as a standalone reference.
+        from datetime import date
+
+        self.page.share_token = "tag-share-token-dedup"
+        self.page.share_mode = "link"
+        self.page.save()
+
+        daily = PageFactory(
+            user=self.user,
+            title="2026-05-02",
+            slug="2026-05-02",
+            page_type="daily",
+            date=date(2026, 5, 2),
+        )
+        parent = BlockFactory(
+            user=self.user, page=daily, content="parent note #food-log", order=0
+        )
+        parent.pages.add(self.page)
+        child = BlockFactory(
+            user=self.user,
+            page=daily,
+            parent=parent,
+            content="child note #food-log",
+            order=0,
+        )
+        child.pages.add(self.page)
+
+        client = Client()
+        response = client.get(f"/knowledge/share/{self.page.share_token}/")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode("utf-8")
+        # The public template renders each block's content twice (a data-md
+        # attribute plus the visible text), so compare the child against the
+        # parent: both should render the same number of times. If the child
+        # weren't deduped it would appear nested AND standalone — more times
+        # than the parent.
+        self.assertIn("child note", body)
+        self.assertEqual(body.count("child note"), body.count("parent note"))
+
     def test_public_view_excludes_blocks_tagged_with_other_pages(self):
         # A block tagged only with a different page must not leak just
         # because both pages belong to the same user.

--- a/packages/django-app/app/knowledge/test/views/test_share_page_api.py
+++ b/packages/django-app/app/knowledge/test/views/test_share_page_api.py
@@ -134,6 +134,50 @@ class PublicPageViewTestCase(TestCase):
         # Source-page label uses the daily's date, not its raw title.
         self.assertIn("2026-04-30", body)
 
+    def test_public_view_linked_reference_includes_nested_children(self):
+        # A tagged note with sub-blocks should expose those children in the
+        # shared page's linked references, not just the tagged parent.
+        from datetime import date
+
+        self.page.share_token = "tag-share-token-children"
+        self.page.share_mode = "link"
+        self.page.save()
+
+        daily = PageFactory(
+            user=self.user,
+            title="2026-05-01",
+            slug="2026-05-01",
+            page_type="daily",
+            date=date(2026, 5, 1),
+        )
+        parent = BlockFactory(
+            user=self.user, page=daily, content="some note #food-log", order=0
+        )
+        parent.pages.add(self.page)
+        child = BlockFactory(
+            user=self.user,
+            page=daily,
+            parent=parent,
+            content="nested detail line",
+            order=0,
+        )
+        BlockFactory(
+            user=self.user,
+            page=daily,
+            parent=child,
+            content="deeper grandchild line",
+            order=0,
+        )
+
+        client = Client()
+        response = client.get(f"/knowledge/share/{self.page.share_token}/")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode("utf-8")
+        self.assertIn("some note", body)
+        self.assertIn("nested detail line", body)
+        self.assertIn("deeper grandchild line", body)
+
     def test_public_view_excludes_blocks_tagged_with_other_pages(self):
         # A block tagged only with a different page must not leak just
         # because both pages belong to the same user.

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -552,7 +552,9 @@ def get_tag_content(request, tag_name):
 
         referenced_blocks_data = []
         for block in result["referenced_blocks"]:
-            referenced_blocks_data.append(block.to_dict(include_page_context=True))
+            referenced_blocks_data.append(
+                block.to_dict_with_children(include_page_context=True)
+            )
 
         pages_data = []
         for page in result["pages"]:
@@ -918,7 +920,7 @@ def get_page_with_blocks(request):
                     block.to_dict_with_children() for block in direct_blocks
                 ],
                 referenced_blocks=[
-                    block.to_dict(include_page_context=True)
+                    block.to_dict_with_children(include_page_context=True)
                     for block in referenced_blocks
                 ],
                 overdue_blocks=[

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -331,14 +331,14 @@ def _serialize_block_tree(block, share_token: str) -> dict:
 
 
 def _serialize_referenced_block(block, share_token: str) -> dict:
-    """Flat dict for a block that lives on another page but is tagged with
-    the shared page. Carries source-page context so the template can
-    label "from <daily date> / <page title>" without exposing a working
-    link to the source page.
+    """Dict for a block that lives on another page but is tagged with the
+    shared page. Carries source-page context so the template can label
+    "from <daily date> / <page title>" without exposing a working link to
+    the source page.
 
-    Renders flat (no children) to match how the editor surfaces linked
-    references — the recipient sees the same scope of content the owner
-    sees in their own "Linked References" section.
+    Includes the block's nested children (as block-tree dicts) so the
+    recipient can see the sub-blocks under a tagged note — matching the
+    editor's linked-references section, which now expands children too.
     """
     asset_uuid = str(block.asset.uuid) if block.asset_id else None
     asset_file_type = block.asset.file_type if block.asset_id else None
@@ -365,6 +365,9 @@ def _serialize_referenced_block(block, share_token: str) -> dict:
         "source_page_date": (
             source.date.isoformat() if source and source.date else None
         ),
+        "children": [
+            _serialize_block_tree(child, share_token) for child in block.get_children()
+        ],
     }
 
 

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -391,10 +391,10 @@ def public_page(request, share_token: str):
     # Linked references — blocks elsewhere that tag this page (e.g. daily
     # notes that mention #food-log). For a topic / tag-style page these
     # ARE the content, so the share view would be empty without them.
-    referenced_blocks = (
-        page.tagged_blocks.exclude(page=page)
-        .select_related("user", "page", "asset")
-        .order_by("-page__date", "-modified_at", "order")
+    # Descendants whose ancestor is also tagged are dropped (they already
+    # render nested under that ancestor) so the same block isn't shown twice.
+    referenced_blocks = BlockRepository.get_referenced_blocks(
+        page, order_by=("-page__date", "-modified_at", "order")
     )
     references = [
         _serialize_referenced_block(b, share_token) for b in referenced_blocks


### PR DESCRIPTION
When viewing a tag page, referenced blocks (blocks tagged with that tag from other pages) now include their nested children in the API response. This allows the UI to expand referenced blocks and reveal their sub-blocks without additional API calls.

**Key changes:**

- Updated `get_page_with_blocks` and `get_tag_content` views to use `to_dict_with_children()` instead of `to_dict()` when serializing referenced blocks, ensuring child blocks are included in the response
- Added `referenceMode` prop to `BlockComponent` to handle the unique behavior of referenced blocks:
  - Referenced blocks start collapsed regardless of their home-page state
  - Expand/collapse toggles remain local and are not persisted back to the source page (since these blocks belong to another page)
- Updated `Page.js` to pass `reference-mode="true"` when rendering referenced blocks
- Added test case `GetPageWithBlocksReferencedChildrenTestCase` to verify referenced blocks include their children in the API response

https://claude.ai/code/session_01GbtBBNj6mn9T1RucSHy86q