### PR TITLE
Restrict URL paste embeds to empty blocks only

### DIFF
--- a/packages/django-app/app/ai_chat/admin.py
+++ b/packages/django-app/app/ai_chat/admin.py
@@ -234,7 +234,7 @@ class ChatMessageAdmin(admin.ModelAdmin):
                         '<a href="{}" target="_blank" rel="noopener" '
                         'style="margin-right: 0.4rem; display: inline-block;">'
                         '<img src="{}" style="max-width: 160px; max-height: 160px; '
-                        'border: 1px solid #ccc; border-radius: 3px;" alt="{}" />'
+                        'border: 1px solid #ccc; border-radius: 0;" alt="{}" />'
                         "</a>",
                         url,
                         url,

--- a/packages/django-app/app/assets/admin.py
+++ b/packages/django-app/app/assets/admin.py
@@ -112,7 +112,7 @@ class AssetAdmin(admin.ModelAdmin):
             return format_html(
                 '<a href="{}" target="_blank" rel="noopener">'
                 '<img src="{}" style="max-width: 480px; max-height: 360px; '
-                'border: 1px solid #ccc; border-radius: 3px;" alt="{}" />'
+                'border: 1px solid #ccc; border-radius: 0;" alt="{}" />'
                 "</a>",
                 url,
                 url,
@@ -125,7 +125,7 @@ class AssetAdmin(admin.ModelAdmin):
         ):
             return format_html(
                 '<iframe src="{}" style="width: 100%; max-width: 720px; '
-                'height: 360px; border: 1px solid #ccc; border-radius: 3px;"></iframe>'
+                'height: 360px; border: 1px solid #ccc; border-radius: 0;"></iframe>'
                 '<div style="margin-top: 0.4rem;">'
                 '<a href="{}" target="_blank" rel="noopener">open in new tab</a>'
                 "</div>",

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -5791,7 +5791,7 @@ kbd {
   font-size: 0.875em;
   background-color: var(--bg-secondary, rgba(0, 0, 0, 0.08));
   border: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.1em 0.35em;
 }
 
@@ -5830,7 +5830,7 @@ kbd {
   font-size: 0.85em;
   background-color: var(--bg-secondary, rgba(0, 0, 0, 0.08));
   border: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
-  border-radius: 4px;
+  border-radius: 0;
   padding: 0.5em 0.75em;
   margin: 0;
   overflow-x: auto;
@@ -5868,7 +5868,7 @@ kbd {
   right: 0.4em;
   background: var(--bg-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.15rem 0.4rem;
   font-family: inherit;
   font-size: 0.65rem;
@@ -5915,7 +5915,7 @@ kbd {
 .block-mermaid {
   background-color: var(--bg-secondary, rgba(0, 0, 0, 0.08));
   border: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
-  border-radius: 4px;
+  border-radius: 0;
   padding: 0.75em;
   overflow-x: auto;
   text-align: center;
@@ -5946,7 +5946,7 @@ kbd {
 .block-csv-scroll {
   overflow-x: auto;
   border: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
-  border-radius: 4px;
+  border-radius: 0;
   background-color: var(--bg-secondary, rgba(0, 0, 0, 0.04));
 }
 
@@ -6378,7 +6378,7 @@ kbd {
   gap: 0.6rem;
   padding: 0.5rem 0.6rem;
   border: 1px solid var(--border-secondary);
-  border-radius: 4px;
+  border-radius: 0;
   background: var(--hover-bg-light);
   cursor: pointer;
   color: var(--text-primary);
@@ -6415,7 +6415,7 @@ kbd {
   cursor: text;
   padding: 0.1rem 0.2rem;
   margin: -0.1rem -0.2rem;
-  border-radius: 2px;
+  border-radius: 0;
 }
 
 .block-embed-title-clickable:hover,
@@ -6431,7 +6431,7 @@ kbd {
   color: var(--text-primary);
   background: var(--bg-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 2px;
+  border-radius: 0;
   padding: 0.1rem 0.3rem;
   width: 100%;
   resize: none;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -5856,6 +5856,53 @@ kbd {
   opacity: 0.8;
   user-select: none;
   pointer-events: none;
+  transition: opacity 0.15s ease-in-out;
+}
+
+/* Hover-revealed "copy" button on plain code blocks. Mirrors the chat
+   .copy-button affordance but scoped to .block-code-wrapper. The lang
+   badge fades out on hover so the button can take the top-right corner. */
+.block-code-copy {
+  position: absolute;
+  top: 0.25em;
+  right: 0.4em;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-secondary);
+  border-radius: 3px;
+  padding: 0.15rem 0.4rem;
+  font-family: inherit;
+  font-size: 0.65rem;
+  line-height: 1;
+  color: var(--text-secondary);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 0.15s ease-in-out,
+    background-color 0.15s ease-in-out;
+  z-index: 2;
+}
+
+.block-code-wrapper:hover .block-code-copy,
+.block-code-copy:focus-visible {
+  opacity: 1;
+}
+
+.block-code-wrapper:hover .block-code-lang {
+  opacity: 0;
+}
+
+.block-code-copy:hover {
+  background: var(--hover-bg);
+  color: var(--text-primary);
+}
+
+.block-code-copy:active {
+  transform: translateY(1px);
+}
+
+.block-code-copy.copied {
+  color: var(--text-primary);
+  border-color: var(--text-primary);
 }
 
 .block-mermaid-wrapper {

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -565,7 +565,7 @@ body {
   height: 28px;
   object-fit: cover;
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
 }
 
 .context-picker-text {
@@ -836,7 +836,7 @@ body {
   color: var(--text-primary);
   background: var(--bg-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.1rem 0.4rem;
   cursor: pointer;
 }
@@ -850,7 +850,7 @@ body {
   padding: 0.5rem 0.6rem;
   background: var(--bg-secondary, var(--bg-primary));
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.75rem;
   color: var(--text-primary);
@@ -873,7 +873,7 @@ body {
   color: var(--text-primary);
   background: var(--bg-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.1rem 0.3rem;
 }
 
@@ -890,7 +890,7 @@ body {
   max-height: 18rem;
   overflow-y: auto;
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   background: var(--bg-primary);
 }
 
@@ -939,7 +939,7 @@ body {
   color: var(--text-muted);
   background: var(--tag-bg);
   padding: 1px 6px;
-  border-radius: 3px;
+  border-radius: 0;
   letter-spacing: 0.04em;
 }
 
@@ -1935,7 +1935,7 @@ kbd {
 .block-collapse-toggle {
   background: var(--bg-primary);
   border: none;
-  border-radius: 3px;
+  border-radius: 0;
   color: var(--text-secondary);
   cursor: pointer;
   font-size: 0.8rem;
@@ -1973,7 +1973,7 @@ kbd {
 .block-collapsed-indicator {
   background: color-mix(in srgb, var(--text-primary) 10%, transparent);
   border: 1px solid color-mix(in srgb, var(--text-primary) 25%, transparent);
-  border-radius: 10px;
+  border-radius: 0;
   color: var(--text-secondary);
   cursor: pointer;
   font-size: 0.7rem;
@@ -2033,7 +2033,7 @@ kbd {
 .block-menu:focus {
   color: var(--text-primary);
   background: var(--bg-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   outline: 2px solid var(--border-primary);
   outline-offset: 1px;
 }
@@ -2845,7 +2845,7 @@ kbd {
   margin-right: 0.2rem;
   color: var(--text-muted);
   text-decoration: none;
-  border-radius: 3px;
+  border-radius: 0;
   font-size: 0.85rem;
   opacity: 0;
   transition: opacity 80ms linear;
@@ -3718,7 +3718,7 @@ a.sidebar-item:visited {
   color: var(--text-primary);
   border: 1px solid var(--border-secondary);
   padding: 0.5rem 0.75rem;
-  border-radius: 6px;
+  border-radius: 0;
   cursor: pointer;
   font-size: 0.85rem;
 }
@@ -3734,7 +3734,7 @@ a.sidebar-item:visited {
   right: 0;
   background: var(--sidebar-bg);
   border: 1px solid var(--border-primary);
-  border-radius: 0 0 8px 8px;
+  border-radius: 0;
   border-top: none;
   max-height: 400px;
   overflow: hidden;
@@ -3786,7 +3786,7 @@ a.sidebar-item:visited {
 .close-btn:hover {
   color: var(--text-primary);
   background: var(--hover-bg);
-  border-radius: 4px;
+  border-radius: 0;
 }
 
 .history-search {
@@ -3926,7 +3926,7 @@ a.sidebar-item:visited {
   background: transparent;
   color: var(--text-secondary);
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.25rem 0.6rem;
   font-family: inherit;
   font-size: 0.75rem;
@@ -3976,7 +3976,7 @@ a.sidebar-item:visited {
   background: transparent;
   color: var(--text-muted);
   border: none;
-  border-radius: 3px;
+  border-radius: 0;
   width: 22px;
   height: 22px;
   padding: 0;
@@ -4017,7 +4017,7 @@ a.sidebar-item:visited {
   background: var(--bg-primary);
   color: var(--text-primary);
   border: 1px solid var(--text-primary);
-  border-radius: 3px;
+  border-radius: 0;
   font-family: inherit;
   font-size: 0.85rem;
 }
@@ -4486,7 +4486,7 @@ a.sidebar-item:visited {
   align-items: center;
   background: var(--accent-bg);
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.4rem;
   font-size: 0.7rem;
 }
@@ -4505,7 +4505,7 @@ a.sidebar-item:visited {
   width: 36px;
   height: 36px;
   object-fit: cover;
-  border-radius: 3px;
+  border-radius: 0;
   border: 1px solid var(--border-secondary);
   margin-right: 0.4rem;
   flex-shrink: 0;
@@ -4597,7 +4597,7 @@ a.sidebar-item:visited {
   margin: 0 0 0.5rem;
   background: var(--accent-bg);
   border: 1px solid var(--border-primary);
-  border-radius: 4px;
+  border-radius: 0;
   box-shadow: 2px 2px 0 var(--border-primary);
 }
 
@@ -4641,7 +4641,7 @@ a.sidebar-item:visited {
 .block-wrapper.in-selection-mode > .block {
   outline: 1px dashed color-mix(in srgb, var(--text-primary) 25%, transparent);
   outline-offset: -1px;
-  border-radius: 3px;
+  border-radius: 0;
   cursor: pointer;
 }
 
@@ -5029,7 +5029,7 @@ a.sidebar-item:visited {
 /* Slow background blink on the row whose tool call is in flight, so
    the eye lands on it among any already-completed calls above it. */
 .tool-call.tool-call-running {
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.05rem 0.25rem;
   margin: 0 -0.25rem;
   animation: tool-call-blink 1.8s ease-in-out infinite;
@@ -5685,7 +5685,7 @@ a.sidebar-item:visited {
   background: var(--tag-bg);
   color: var(--tag-text);
   padding: 0.125rem 0.25rem;
-  border-radius: 2px;
+  border-radius: 0;
   font-weight: 600;
 }
 
@@ -5734,7 +5734,7 @@ a.sidebar-item:visited {
 kbd {
   background: var(--bg-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.125rem 0.375rem;
   font-size: 0.75rem;
   font-family: monospace;
@@ -5806,7 +5806,7 @@ kbd {
 .markdown-highlight {
   background-color: var(--highlight-bg, #ffe066);
   color: var(--highlight-text, #333);
-  border-radius: 2px;
+  border-radius: 0;
   padding: 0.05em 0.2em;
 }
 
@@ -6135,13 +6135,13 @@ kbd {
   font-size: 0.85em;
   background-color: var(--bg-secondary, rgba(0, 0, 0, 0.08));
   padding: 0.1em 0.3em;
-  border-radius: 3px;
+  border-radius: 0;
 }
 
 .block-markdown pre {
   background-color: var(--bg-secondary, rgba(0, 0, 0, 0.08));
   border: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
-  border-radius: 4px;
+  border-radius: 0;
   padding: 0.5em 0.75em;
   overflow-x: auto;
 }
@@ -6198,7 +6198,7 @@ kbd {
   text-transform: uppercase;
   color: var(--text-secondary, #888);
   border: 1px solid var(--border-color, rgba(0, 0, 0, 0.2));
-  border-radius: 10px;
+  border-radius: 0;
   padding: 0.05em 0.5em;
 }
 
@@ -6245,7 +6245,7 @@ kbd {
   color: var(--text-secondary, #888);
   background: var(--bg-primary, rgba(255, 255, 255, 0.85));
   padding: 0.15em 0.5em;
-  border-radius: 3px;
+  border-radius: 0;
   pointer-events: none;
 }
 
@@ -6507,7 +6507,7 @@ kbd {
   align-items: center;
   gap: 0.15rem;
   padding: 0.1rem 0.4rem;
-  border-radius: 3px;
+  border-radius: 0;
   background-color: var(--tag-bg);
   color: var(--tag-text);
   border: 1px solid var(--tag-bg);
@@ -6542,7 +6542,7 @@ kbd {
 .block-embed-tag-add {
   background: transparent;
   border: 1px dashed var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.1rem 0.5rem;
   font-size: 0.75rem;
   color: var(--text-muted);
@@ -6567,7 +6567,7 @@ kbd {
   color: var(--text-primary);
   background: var(--bg-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.1rem 0.5rem;
   min-width: 6rem;
   max-width: 12rem;
@@ -6592,7 +6592,7 @@ kbd {
   padding: 0.75rem 1rem;
   border-left: 3px solid var(--error-color, #c0392b);
   background: color-mix(in srgb, var(--error-color, #c0392b) 6%, transparent);
-  border-radius: 4px;
+  border-radius: 0;
 }
 
 .overdue-title {
@@ -6724,7 +6724,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   background: var(--bg-primary);
   border: 1px solid var(--border-primary);
   padding: 1.25rem 1.5rem;
-  border-radius: 6px;
+  border-radius: 0;
   min-width: 18rem;
   display: flex;
   flex-direction: column;
@@ -6761,7 +6761,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   color: var(--text-primary);
   background: var(--bg-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.25rem 0.5rem;
   flex: 1;
 }
@@ -6801,7 +6801,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   background: var(--bg-primary);
   color: var(--text-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.2rem 0.55rem;
   font-family: inherit;
   font-size: 0.78rem;
@@ -6899,7 +6899,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   max-width: 100%;
   max-height: 480px;
   height: auto;
-  border-radius: 3px;
+  border-radius: 0;
   border: 1px solid var(--border-secondary);
   margin-top: 0.25rem;
   margin-bottom: 0.25rem;
@@ -6913,7 +6913,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
    * metrics (1rem / 1.5 line-height) so chip + textarea share the
    * same line box and align cleanly on the flex row. */
   padding: 0.125rem 0.5rem;
-  border-radius: 3px;
+  border-radius: 0;
   background-color: var(--accent-bg);
   border: 1px solid var(--border-secondary);
   color: var(--text-primary);
@@ -6964,7 +6964,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   width: 56px;
   height: 56px;
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   overflow: hidden;
   background-color: var(--accent-bg);
 }
@@ -6983,7 +6983,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   background: rgba(0, 0, 0, 0.6);
   color: #fff;
   border: none;
-  border-radius: 0 0 0 3px;
+  border-radius: 0;
   width: 18px;
   height: 18px;
   font-size: 0.75rem;
@@ -7006,7 +7006,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
 .chat-attach-btn {
   background: transparent;
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   color: var(--text-primary);
   cursor: pointer;
   padding: 0.4rem 0.6rem;
@@ -7039,7 +7039,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
 .message-attachment-image {
   max-width: 280px;
   max-height: 280px;
-  border-radius: 3px;
+  border-radius: 0;
   border: 1px solid var(--border-secondary);
   display: block;
 }
@@ -7050,7 +7050,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   gap: 0.3rem;
   padding: 0.2rem 0.5rem;
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   background-color: var(--accent-bg);
   font-size: 0.85rem;
   color: var(--text-primary);
@@ -7066,7 +7066,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   line-height: 1.2;
   background: var(--accent-primary, #0969da);
   color: #fff;
-  border-radius: 3px;
+  border-radius: 0;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -7086,7 +7086,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   background: var(--bg-primary, #fff);
   color: var(--text-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   width: 100%;
   max-width: 480px;
   max-height: calc(100vh - 2rem);
@@ -7116,7 +7116,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   color: var(--text-secondary, #6b7280);
   cursor: pointer;
   padding: 4px 8px;
-  border-radius: 3px;
+  border-radius: 0;
 }
 
 .share-modal-close:hover {
@@ -7147,7 +7147,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   gap: 10px;
   padding: 10px 12px;
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   cursor: pointer;
   transition:
     background 0.1s,
@@ -7195,7 +7195,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   flex: 1;
   padding: 6px 10px;
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   background: var(--bg-primary);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.8rem;
@@ -7248,7 +7248,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
 .block-chat-popover {
   background: var(--bg-primary);
   border: 1px solid var(--border-primary);
-  border-radius: 6px;
+  border-radius: 0;
   width: min(640px, 100%);
   max-height: min(80vh, 720px);
   display: flex;
@@ -7278,7 +7278,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   line-height: 1;
   cursor: pointer;
   padding: 0.125rem 0.375rem;
-  border-radius: 3px;
+  border-radius: 0;
 }
 
 .block-chat-popover-close:hover {
@@ -7288,7 +7288,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
 
 .block-chat-popover-source {
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.5rem 0.75rem;
   background: var(--bg-secondary);
 }
@@ -7312,7 +7312,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   width: auto;
   height: auto;
   object-fit: cover;
-  border-radius: 3px;
+  border-radius: 0;
   flex-shrink: 0;
 }
 
@@ -7347,7 +7347,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
 
 .block-chat-popover-msg.user .block-chat-popover-content {
   background: var(--bg-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.4rem 0.6rem;
   align-self: flex-end;
   max-width: 85%;
@@ -7369,7 +7369,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
 
 .block-chat-popover-tools {
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.4rem 0.5rem;
   background: var(--bg-secondary);
   font-size: 0.75rem;
@@ -7440,7 +7440,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
 
 .block-chat-popover-approval {
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.5rem 0.75rem;
   background: var(--bg-secondary);
   display: flex;
@@ -7455,7 +7455,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
 
 .block-chat-popover-approval-row {
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.4rem 0.5rem;
   background: var(--bg-primary);
   display: flex;
@@ -7485,7 +7485,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   font-family: var(--font-monospace, monospace);
   background: var(--bg-secondary);
   padding: 0.4rem 0.5rem;
-  border-radius: 3px;
+  border-radius: 0;
   overflow-x: auto;
   margin: 0;
   white-space: pre-wrap;
@@ -7525,7 +7525,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   background: var(--bg-secondary);
   color: var(--text-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.3rem 0.6rem;
   font-size: 0.8rem;
   cursor: pointer;
@@ -7559,7 +7559,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   left: 0;
   background: var(--bg-primary);
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   z-index: 1110;
   min-width: 14rem;
   max-height: 14rem;
@@ -7593,7 +7593,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   left: 0;
   background: var(--bg-primary);
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   z-index: 1110;
   min-width: 18rem;
   padding: 0.5rem;
@@ -7640,7 +7640,7 @@ input[type="time"]::-webkit-calendar-picker-indicator:hover {
   background: var(--bg-primary);
   color: var(--text-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.5rem 0.6rem;
   font-family: inherit;
   font-size: 0.9rem;
@@ -7697,7 +7697,7 @@ a.hashtag-mention:hover,
   overflow-y: auto;
   background: var(--bg-primary);
   border: 1px solid var(--border-primary);
-  border-radius: 4px;
+  border-radius: 0;
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.18);
   padding: 0.25rem 0;
 }
@@ -7782,7 +7782,7 @@ a.hashtag-mention:hover,
   color: var(--text-secondary);
   background: var(--tag-bg, var(--bg-secondary));
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 1px 5px;
 }
 
@@ -7802,7 +7802,7 @@ a.hashtag-mention:hover,
   padding: 0;
   margin: 0;
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   background: var(--bg-secondary);
 }
 
@@ -7836,7 +7836,7 @@ a.hashtag-mention:hover,
 
 .saved-view-editor {
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 1rem;
   background: var(--bg-secondary);
   margin: 1rem 0;
@@ -7866,7 +7866,7 @@ a.hashtag-mention:hover,
   background: var(--bg-primary);
   color: var(--text-primary);
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.4rem 0.5rem;
   font-size: 0.9rem;
 }
@@ -7918,7 +7918,7 @@ a.hashtag-mention:hover,
   margin-bottom: 0.75rem;
   background: var(--bg-primary);
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   color: var(--text-primary);
   font-size: 0.85rem;
 }
@@ -7939,7 +7939,7 @@ a.hashtag-mention:hover,
   background: var(--bg-primary);
   padding: 0.6rem;
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   font-size: 0.8rem;
   overflow-x: auto;
 }
@@ -7964,7 +7964,7 @@ a.hashtag-mention:hover,
 .saved-view-cheatsheet code {
   background: var(--bg-primary);
   padding: 1px 4px;
-  border-radius: 3px;
+  border-radius: 0;
   border: 1px solid var(--border-primary);
   font-size: 0.78rem;
 }
@@ -7991,7 +7991,7 @@ a.hashtag-mention:hover,
 
 .saved-view-spec details {
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.4rem 0.6rem;
   margin: 0.5rem 0 1rem;
   background: var(--bg-secondary);
@@ -8006,7 +8006,7 @@ a.hashtag-mention:hover,
   background: var(--bg-primary);
   padding: 0.5rem;
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   margin-top: 0.5rem;
   font-size: 0.85rem;
   overflow-x: auto;
@@ -8031,7 +8031,7 @@ a.hashtag-mention:hover,
   padding: 0;
   margin: 0;
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   background: var(--bg-secondary);
 }
 .result-list li {
@@ -8083,7 +8083,7 @@ a.hashtag-mention:hover,
 .result-block-type {
   display: inline-block;
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0 4px;
   margin-right: 0.25rem;
 }
@@ -8103,7 +8103,7 @@ a.hashtag-mention:hover,
 }
 .block-query-embed {
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.6rem 0.8rem;
   background: var(--bg-secondary);
 }
@@ -8155,7 +8155,7 @@ a.hashtag-mention:hover,
   color: var(--tag-text);
   background: var(--tag-bg, var(--bg-primary));
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   padding: 0.05rem 0.35rem;
   cursor: help;
 }
@@ -8178,7 +8178,7 @@ a.hashtag-mention:hover,
 .block-query-embed-iconbtn {
   background: transparent;
   border: 1px solid var(--border-primary);
-  border-radius: 3px;
+  border-radius: 0;
   color: var(--text-secondary);
   cursor: pointer;
   font: inherit;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -1608,9 +1608,9 @@ kbd {
   background-color: currentColor;
   color: var(--text-primary);
   opacity: 0.7;
-  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='black' stroke-width='1.5' stroke-linejoin='round' stroke-linecap='round'><rect x='2' y='3' width='12' height='11' rx='1'/><line x1='2' y1='6.5' x2='14' y2='6.5'/><line x1='5.5' y1='1.5' x2='5.5' y2='4.5'/><line x1='10.5' y1='1.5' x2='10.5' y2='4.5'/></svg>")
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='black' stroke-width='1.5' stroke-linejoin='round' stroke-linecap='round'><rect x='2' y='3' width='12' height='11' rx='0'/><line x1='2' y1='6.5' x2='14' y2='6.5'/><line x1='5.5' y1='1.5' x2='5.5' y2='4.5'/><line x1='10.5' y1='1.5' x2='10.5' y2='4.5'/></svg>")
     center / contain no-repeat;
-  mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='black' stroke-width='1.5' stroke-linejoin='round' stroke-linecap='round'><rect x='2' y='3' width='12' height='11' rx='1'/><line x1='2' y1='6.5' x2='14' y2='6.5'/><line x1='5.5' y1='1.5' x2='5.5' y2='4.5'/><line x1='10.5' y1='1.5' x2='10.5' y2='4.5'/></svg>")
+  mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='black' stroke-width='1.5' stroke-linejoin='round' stroke-linecap='round'><rect x='2' y='3' width='12' height='11' rx='0'/><line x1='2' y1='6.5' x2='14' y2='6.5'/><line x1='5.5' y1='1.5' x2='5.5' y2='4.5'/><line x1='10.5' y1='1.5' x2='10.5' y2='4.5'/></svg>")
     center / contain no-repeat;
 }
 
@@ -6656,9 +6656,9 @@ input[type="time"]::-webkit-calendar-picker-indicator {
 }
 
 input[type="date"]::-webkit-calendar-picker-indicator {
-  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='black' stroke-width='1.5' stroke-linejoin='round' stroke-linecap='round'><rect x='2' y='3' width='12' height='11' rx='1'/><line x1='2' y1='6.5' x2='14' y2='6.5'/><line x1='5.5' y1='1.5' x2='5.5' y2='4.5'/><line x1='10.5' y1='1.5' x2='10.5' y2='4.5'/></svg>")
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='black' stroke-width='1.5' stroke-linejoin='round' stroke-linecap='round'><rect x='2' y='3' width='12' height='11' rx='0'/><line x1='2' y1='6.5' x2='14' y2='6.5'/><line x1='5.5' y1='1.5' x2='5.5' y2='4.5'/><line x1='10.5' y1='1.5' x2='10.5' y2='4.5'/></svg>")
     center / contain no-repeat;
-  mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='black' stroke-width='1.5' stroke-linejoin='round' stroke-linecap='round'><rect x='2' y='3' width='12' height='11' rx='1'/><line x1='2' y1='6.5' x2='14' y2='6.5'/><line x1='5.5' y1='1.5' x2='5.5' y2='4.5'/><line x1='10.5' y1='1.5' x2='10.5' y2='4.5'/></svg>")
+  mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='black' stroke-width='1.5' stroke-linejoin='round' stroke-linecap='round'><rect x='2' y='3' width='12' height='11' rx='0'/><line x1='2' y1='6.5' x2='14' y2='6.5'/><line x1='5.5' y1='1.5' x2='5.5' y2='4.5'/><line x1='10.5' y1='1.5' x2='10.5' y2='4.5'/></svg>")
     center / contain no-repeat;
 }
 

--- a/packages/django-app/app/knowledge/static/knowledge/css/public_page.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/public_page.css
@@ -155,7 +155,7 @@ body {
 .public-block-content code {
   background: #eef0f2;
   padding: 2px 5px;
-  border-radius: 3px;
+  border-radius: 0;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.9em;
 }
@@ -164,7 +164,7 @@ body {
   background: #1f2328;
   color: #eef0f2;
   padding: 12px 14px;
-  border-radius: 3px;
+  border-radius: 0;
   overflow-x: auto;
 }
 
@@ -197,7 +197,7 @@ body {
   max-width: 100%;
   height: auto;
   margin: 8px 0;
-  border-radius: 3px;
+  border-radius: 0;
 }
 
 .public-block-empty {
@@ -212,7 +212,7 @@ body {
   vertical-align: top;
   width: calc(100% - 12px);
   border: 1px solid #e1e4e8;
-  border-radius: 3px;
+  border-radius: 0;
   padding: 8px 12px;
   background: #ffffff;
 }
@@ -249,7 +249,7 @@ body {
   color: #6b7280;
   background: #eef0f2;
   padding: 1px 6px;
-  border-radius: 3px;
+  border-radius: 0;
 }
 
 .public-references {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -548,6 +548,7 @@ const BlockComponent = {
       // its targets aren't present.
       this.renderMermaidIfPresent();
       this.highlightCodeIfPresent();
+      this.addCodeCopyButtonsIfPresent();
       this.applyResizableHandles();
     },
 
@@ -648,6 +649,68 @@ const BlockComponent = {
           // un-highlighted code is still legible.
         }
       });
+    },
+
+    addCodeCopyButtonsIfPresent() {
+      // Inject a hover-revealed "copy" button into each plain code block.
+      // Mermaid / CSV blocks render no <pre class="block-code"> so they're
+      // skipped. The code HTML comes from formatContentWithTags via v-html,
+      // so the button has to be wired here after mount/update rather than in
+      // the template.
+      if (!this.$el || this.$el.nodeType !== 1 || !this.$el.querySelector)
+        return;
+      const wrappers = this.$el.querySelectorAll(".block-code-wrapper");
+      wrappers.forEach((wrapper) => {
+        if (wrapper.querySelector(".block-code-copy")) return;
+        const pre = wrapper.querySelector("pre.block-code");
+        if (!pre) return;
+        const codeEl = pre.querySelector("code") || pre;
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "block-code-copy";
+        btn.textContent = "copy";
+        btn.setAttribute("aria-label", "Copy code to clipboard");
+        btn.addEventListener("click", (event) => {
+          // Don't let the click fall through to the content-display handler,
+          // which would drop the block into edit (or toggle selection).
+          event.preventDefault();
+          event.stopPropagation();
+          this.copyCodeToClipboard(codeEl.textContent, btn);
+        });
+        wrapper.appendChild(btn);
+      });
+    },
+
+    async copyCodeToClipboard(text, button) {
+      const flashCopied = () => {
+        button.textContent = "copied";
+        button.classList.add("copied");
+        setTimeout(() => {
+          button.textContent = "copy";
+          button.classList.remove("copied");
+        }, 2000);
+      };
+      try {
+        await navigator.clipboard.writeText(text);
+        flashCopied();
+      } catch (_) {
+        // Fallback for contexts without the async clipboard API (e.g.
+        // non-secure origins).
+        const textArea = document.createElement("textarea");
+        textArea.value = text;
+        textArea.style.position = "fixed";
+        textArea.style.opacity = "0";
+        document.body.appendChild(textArea);
+        textArea.select();
+        try {
+          document.execCommand("copy");
+          flashCopied();
+        } catch (err) {
+          console.error("copy failed:", err);
+        } finally {
+          document.body.removeChild(textArea);
+        }
+      }
     },
 
     async loadWebArchive() {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -1481,13 +1481,35 @@ const BlockComponent = {
       this.onBlockSelectClick(this.block, event);
     },
 
+    // While in selection mode, the whole block row is a hit target, not just
+    // the radio toggle. The bullet / content / toggle handlers stop
+    // propagation when they handle a click, so this only fires for the
+    // "dead" space (margins, gaps left of the content). Dedicated controls
+    // — collapse toggle, menu button, links, embeds, form fields — keep
+    // their own behavior and must not double-fire a selection toggle.
+    handleRowClick(event) {
+      if (!this.selectionMode) return;
+      if (
+        event.target.closest(
+          "button, a, input, textarea, .block-asset, .block-embed-card"
+        )
+      ) {
+        return;
+      }
+      const handled = this.onBlockSelectClick(this.block, event);
+      if (handled) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    },
+
     showBulkSelectionActions() {
       return this.blockSelected && this.selectedBlockCount >= 2;
     },
   },
   template: `
     <div class="block-wrapper" :class="{ 'child-block': block.parent, 'in-context': blockInContext, 'selected': blockSelected, 'in-selection-mode': selectionMode }" :data-block-uuid="block.uuid" @dragover="handleBlockDragOver" @drop="handleBlockDrop">
-      <div class="block" :class="{ 'has-children': hasChildren, 'is-collapsed': hasChildren && isCollapsed }">
+      <div class="block" :class="{ 'has-children': hasChildren, 'is-collapsed': hasChildren && isCollapsed }" @click="handleRowClick($event)">
         <button
           v-if="selectionMode"
           type="button"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -1956,7 +1956,7 @@ const BlockComponent = {
           :class="{ 'overdue': isOverdue }"
           @click.stop="scheduleBlock(block)"
           :title="'Scheduled ' + block.scheduled_for + (reminderTimeLabel ? ' · reminder at ' + reminderTimeLabel : '') + (isOverdue ? ' (overdue)' : '') + ' — click to change'"
-        ><svg class="block-due-icon" viewBox="0 0 16 16" width="11" height="11" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"><rect x="2" y="3" width="12" height="11" rx="1"/><line x1="2" y1="6.5" x2="14" y2="6.5"/><line x1="5.5" y1="1.5" x2="5.5" y2="4.5"/><line x1="10.5" y1="1.5" x2="10.5" y2="4.5"/></g></svg> {{ scheduledForLabel }}<span v-if="reminderTimeLabel"> · <svg class="block-due-icon" viewBox="0 0 16 16" width="11" height="11" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"><circle cx="8" cy="8" r="6.25"/><polyline points="8,4.5 8,8 11,9.5"/></g></svg> {{ reminderInlineLabel }}</span></button>
+        ><svg class="block-due-icon" viewBox="0 0 16 16" width="11" height="11" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"><rect x="2" y="3" width="12" height="11" rx="0"/><line x1="2" y1="6.5" x2="14" y2="6.5"/><line x1="5.5" y1="1.5" x2="5.5" y2="4.5"/><line x1="10.5" y1="1.5" x2="10.5" y2="4.5"/></g></svg> {{ scheduledForLabel }}<span v-if="reminderTimeLabel"> · <svg class="block-due-icon" viewBox="0 0 16 16" width="11" height="11" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"><circle cx="8" cy="8" r="6.25"/><polyline points="8,4.5 8,8 11,9.5"/></g></svg> {{ reminderInlineLabel }}</span></button>
         <button
           v-else
           type="button"
@@ -1964,7 +1964,7 @@ const BlockComponent = {
           @click.stop="scheduleBlock(block)"
           title="Schedule this block"
           aria-label="Schedule this block"
-        ><svg class="block-due-icon" viewBox="0 0 16 16" width="11" height="11" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"><rect x="2" y="3" width="12" height="11" rx="1"/><line x1="2" y1="6.5" x2="14" y2="6.5"/><line x1="5.5" y1="1.5" x2="5.5" y2="4.5"/><line x1="10.5" y1="1.5" x2="10.5" y2="4.5"/></g></svg></button>
+        ><svg class="block-due-icon" viewBox="0 0 16 16" width="11" height="11" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"><rect x="2" y="3" width="12" height="11" rx="0"/><line x1="2" y1="6.5" x2="14" y2="6.5"/><line x1="5.5" y1="1.5" x2="5.5" y2="4.5"/><line x1="10.5" y1="1.5" x2="10.5" y2="4.5"/></g></svg></button>
         <button
           @click="showContextMenuAt($event)"
           @contextmenu="showContextMenuAt($event)"
@@ -2040,7 +2040,7 @@ const BlockComponent = {
         </template>
         <div class="context-menu-separator"></div>
         <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('schedule')">
-          <span class="context-menu-icon"><svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"><rect x="2" y="3" width="12" height="11" rx="1"/><line x1="2" y1="6.5" x2="14" y2="6.5"/><line x1="5.5" y1="1.5" x2="5.5" y2="4.5"/><line x1="10.5" y1="1.5" x2="10.5" y2="4.5"/></g></svg></span>
+          <span class="context-menu-icon"><svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"><rect x="2" y="3" width="12" height="11" rx="0"/><line x1="2" y1="6.5" x2="14" y2="6.5"/><line x1="5.5" y1="1.5" x2="5.5" y2="4.5"/><line x1="10.5" y1="1.5" x2="10.5" y2="4.5"/></g></svg></span>
           <span>{{ block.scheduled_for ? 'reschedule...' : 'schedule...' }}</span>
         </button>
         <button class="context-menu-item" role="menuitem" tabindex="-1" v-if="block.scheduled_for" @click="handleContextMenuAction('unschedule')">

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/LeftNav.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/LeftNav.js
@@ -899,7 +899,7 @@ window.LeftNav = {
             stroke-linejoin="round"
             aria-hidden="true"
           >
-            <rect x="2" y="3.5" width="12" height="10.5" rx="0.5"/>
+            <rect x="2" y="3.5" width="12" height="10.5" rx="0"/>
             <line x1="2" y1="7" x2="14" y2="7"/>
             <line x1="5" y1="2" x2="5" y2="5"/>
             <line x1="11" y1="2" x2="11" y2="5"/>
@@ -1017,7 +1017,7 @@ window.LeftNav = {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                 >
-                  <rect x="2" y="3.5" width="12" height="10.5" rx="0.5"/>
+                  <rect x="2" y="3.5" width="12" height="10.5" rx="0"/>
                   <line x1="2" y1="7" x2="14" y2="7"/>
                   <line x1="5" y1="2" x2="5" y2="5"/>
                   <line x1="11" y1="2" x2="11" y2="5"/>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -3087,24 +3087,29 @@ const Page = {
           media_url: url,
         });
         if (!result.success) throw new Error("update block failed");
+        block.content = url;
         block.content_type = "embed";
         block.media_url = url;
-        // Open the label field empty (with its "label this link…"
-        // placeholder) instead of full of the raw URL. BlockComponent's
-        // isEditing watcher normally does this, but only on a false->true
-        // transition; here the block was already being edited, so mirror
-        // it explicitly. (The URL persists via media_url; on blur the empty
-        // label falls back to the hostname, same as any unlabeled embed.)
-        block.content = "";
-        // Keep the user in the block: promoting to an embed swaps the
-        // textarea they were typing in for the embed's label textarea.
-        // Removing the old textarea fires its blur -> stopEditing, which
-        // would set isEditing=false and clobber the focus we're about to
-        // take. Setting isNavigating makes that blur-driven stopEditing
-        // bail (same guard block-to-block navigation uses), so re-entering
-        // edit mode here sticks and focus lands in the label field.
+        // Keep the user in the block, focused in the embed's label field.
+        // The block was being edited as plain text, so flipping straight
+        // to an editing embed swaps one focused textarea for another and
+        // the old one's blur tears down edit mode mid-flight. Instead drop
+        // out of edit mode first (rendering the embed's static label, fully
+        // removing the plain textarea), then re-enter on the next tick. That
+        // clean false->true isEditing transition focuses the label field and
+        // lets BlockComponent's watcher swap the raw URL for the empty
+        // "label this link…" placeholder — the same path as clicking an
+        // embed's label to rename it.
+        //
+        // isNavigating makes the plain textarea's teardown blur bail out of
+        // stopEditing (same guard block-to-block navigation uses); otherwise
+        // its async save would race the watcher and repopulate the label
+        // with the raw URL just after we cleared it.
         this.isNavigating = true;
-        this.startEditing(block);
+        block.isEditing = false;
+        this.$nextTick(() => {
+          this.startEditing(block);
+        });
         // Archiving is opt-in - user clicks "archive" on the embed card.
       } catch (error) {
         console.error("url paste failed:", error);

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -3090,6 +3090,11 @@ const Page = {
         block.content = url;
         block.content_type = "embed";
         block.media_url = url;
+        // Keep the user in the block: promoting to an embed swaps the
+        // textarea they were typing in for the embed card, which would
+        // otherwise drop focus. Re-enter edit mode so focus lands in the
+        // embed's label field and they can rename the link in place.
+        this.startEditing(block);
         // Archiving is opt-in - user clicks "archive" on the embed card.
       } catch (error) {
         console.error("url paste failed:", error);

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -3087,13 +3087,23 @@ const Page = {
           media_url: url,
         });
         if (!result.success) throw new Error("update block failed");
-        block.content = url;
         block.content_type = "embed";
         block.media_url = url;
+        // Open the label field empty (with its "label this link…"
+        // placeholder) instead of full of the raw URL. BlockComponent's
+        // isEditing watcher normally does this, but only on a false->true
+        // transition; here the block was already being edited, so mirror
+        // it explicitly. (The URL persists via media_url; on blur the empty
+        // label falls back to the hostname, same as any unlabeled embed.)
+        block.content = "";
         // Keep the user in the block: promoting to an embed swaps the
-        // textarea they were typing in for the embed card, which would
-        // otherwise drop focus. Re-enter edit mode so focus lands in the
-        // embed's label field and they can rename the link in place.
+        // textarea they were typing in for the embed's label textarea.
+        // Removing the old textarea fires its blur -> stopEditing, which
+        // would set isEditing=false and clobber the focus we're about to
+        // take. Setting isNavigating makes that blur-driven stopEditing
+        // bail (same guard block-to-block navigation uses), so re-entering
+        // edit mode here sticks and focus lands in the label field.
+        this.isNavigating = true;
         this.startEditing(block);
         // Archiving is opt-in - user clicks "archive" on the embed card.
       } catch (error) {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -3058,55 +3058,20 @@ const Page = {
     },
 
     async handleUrlPaste(block, url) {
-      // Empty block: promote it to an embed in place. Otherwise append a
-      // sibling embed block after the current one (matches paste-as-list
-      // behaviour for consistency).
-      const blockIsEmpty = !block.content || block.content.trim() === "";
-      let targetBlock = block;
-
+      // Only called for an empty block: promote it to an embed in place.
+      // (Pasting a URL into a non-empty block is handled as a plain text
+      // paste by onBlockPaste and never reaches here.)
       try {
-        if (blockIsEmpty) {
-          const result = await window.apiService.updateBlock(block.uuid, {
-            content: url,
-            content_type: "embed",
-            media_url: url,
-          });
-          if (!result.success) throw new Error("update block failed");
-          block.content = url;
-          block.content_type = "embed";
-          block.media_url = url;
-        } else {
-          const parentUuid = block.parent ? block.parent.uuid : null;
-          const newOrder = block.order + 1;
-          const siblings = block.parent
-            ? block.parent.children
-            : this.directBlocks;
-          const blocksToShift = siblings.filter(
-            (b) => b.uuid !== block.uuid && b.order >= newOrder
-          );
-          if (blocksToShift.length > 0) {
-            const reorderPayload = blocksToShift.map((b) => ({
-              uuid: b.uuid,
-              order: b.order + 1,
-            }));
-            const reorderResult =
-              await window.apiService.reorderBlocks(reorderPayload);
-            if (!reorderResult.success) throw new Error("reorder failed");
-          }
-          const createResult = await window.apiService.createBlock({
-            page: this.page.uuid,
-            parent: parentUuid,
-            content: url,
-            content_type: "embed",
-            block_type: "bullet",
-            media_url: url,
-            order: newOrder,
-          });
-          if (!createResult.success) throw new Error("create block failed");
-          targetBlock = { uuid: createResult.data.uuid };
-        }
+        const result = await window.apiService.updateBlock(block.uuid, {
+          content: url,
+          content_type: "embed",
+          media_url: url,
+        });
+        if (!result.success) throw new Error("update block failed");
+        block.content = url;
+        block.content_type = "embed";
+        block.media_url = url;
         // Archiving is opt-in - user clicks "archive" on the embed card.
-        void targetBlock;
       } catch (error) {
         console.error("url paste failed:", error);
         this.emitToast("could not save URL", "error");
@@ -3274,10 +3239,14 @@ const Page = {
       const text = clipboardData.getData("text/plain");
       if (!text) return;
 
-      // URL paste gets first shot. If the clipboard is a bare URL, create an
-      // embed block and kick off an archive capture in the background.
+      // URL paste gets first shot, but only into an empty block: there we
+      // promote the block to an embed in place. Pasting a URL into a block
+      // that already has content should behave like an ordinary paste -
+      // drop the URL text in at the cursor, don't hijack it into an embed
+      // (or a stray sibling block).
       const trimmed = text.trim();
-      if (this.isBareUrl(trimmed)) {
+      const blockIsEmptyForUrl = !block.content || block.content.trim() === "";
+      if (this.isBareUrl(trimmed) && blockIsEmptyForUrl) {
         event.preventDefault();
         await this.handleUrlPaste(block, trimmed);
         return;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -71,6 +71,10 @@ const Page = {
       schedulePopoverInitialDate: "",
       schedulePopoverInitialReminderDate: "",
       schedulePopoverInitialTime: "",
+      // When the schedule popover is opened for a multi-select, these hold
+      // the bulk context so onSchedulePopoverSave routes to the bulk path.
+      schedulePopoverBulk: false,
+      schedulePopoverBulkUuids: [],
       blockChatPopoverOpen: false,
       blockChatPopoverBlock: null,
       blockInfoModalOpen: false,
@@ -2526,9 +2530,22 @@ const Page = {
     },
 
     onSchedulePopoverSave({ scheduledFor, reminderDate, reminderTime }) {
+      const bulk = this.schedulePopoverBulk;
+      const bulkUuids = this.schedulePopoverBulkUuids;
       const block = this.schedulePopoverBlock;
       this.schedulePopoverOpen = false;
       this.schedulePopoverBlock = null;
+      this.schedulePopoverBulk = false;
+      this.schedulePopoverBulkUuids = [];
+      if (bulk) {
+        this._submitBulkSchedule(
+          bulkUuids,
+          scheduledFor,
+          reminderDate,
+          reminderTime
+        );
+        return;
+      }
       if (!block) return;
       this._submitSchedule(block, scheduledFor, reminderDate, reminderTime);
     },
@@ -2536,6 +2553,8 @@ const Page = {
     onSchedulePopoverCancel() {
       this.schedulePopoverOpen = false;
       this.schedulePopoverBlock = null;
+      this.schedulePopoverBulk = false;
+      this.schedulePopoverBulkUuids = [];
     },
 
     openBlockChatPopover(block) {
@@ -3782,6 +3801,75 @@ const Page = {
         );
       }
     },
+
+    bulkScheduleSelected() {
+      // Reuse the single-block schedule popover for the whole selection.
+      // We snapshot the selected uuids now; the popover's save handler
+      // routes back through _submitBulkSchedule once the user picks a date.
+      const uuids = [...this.selectedBlockUuids];
+      if (uuids.length === 0) {
+        this.$parent?.addToast?.("no blocks selected", "info");
+        return;
+      }
+      this.schedulePopoverBulk = true;
+      this.schedulePopoverBulkUuids = uuids;
+      this.schedulePopoverBlock = null;
+      // No shared starting point across N blocks — let the popover default
+      // to today rather than seeding from one block's existing schedule.
+      this.schedulePopoverInitialDate = "";
+      this.schedulePopoverInitialReminderDate = "";
+      this.schedulePopoverInitialTime = "";
+      this.schedulePopoverOpen = true;
+    },
+
+    async _submitBulkSchedule(uuids, scheduledFor, reminderDate, reminderTime) {
+      if (!uuids || uuids.length === 0) return;
+      if (!scheduledFor) {
+        this.$parent?.addToast?.("pick a date to schedule", "info");
+        return;
+      }
+      try {
+        const result = await window.apiService.bulkScheduleBlocks(
+          uuids,
+          scheduledFor,
+          reminderDate,
+          reminderTime
+        );
+        if (!result || !result.success) {
+          throw new Error(
+            result?.errors?.non_field_errors?.[0] || "bulk schedule failed"
+          );
+        }
+        const count = result.data?.updated_count ?? 0;
+        let msg = `scheduled ${count} block${
+          count === 1 ? "" : "s"
+        } for ${scheduledFor}`;
+        if (result.data?.reminder_set && reminderTime) {
+          const formatted =
+            window.formatTimeForUser?.(reminderTime) || reminderTime;
+          msg += ` · remind at ${formatted}`;
+        }
+        this.$parent?.addToast?.(msg, "success");
+        // Keep any embeds that surface these blocks in sync, same as the
+        // single-block schedule path.
+        uuids.forEach((uuid) =>
+          document.dispatchEvent(
+            new CustomEvent("brainspread:block-changed", {
+              detail: { uuid },
+            })
+          )
+        );
+        this.clearBlockSelection();
+        await this.loadPage({ silent: true });
+      } catch (error) {
+        console.error("failed to bulk-schedule blocks:", error);
+        this.error = "failed to schedule selected blocks";
+        this.$parent?.addToast?.(
+          `failed to schedule selected blocks: ${error.message || error}`,
+          "error"
+        );
+      }
+    },
   },
 
   template: `
@@ -4026,6 +4114,13 @@ const Page = {
               @click="bulkMoveSelectedToPage"
               title="Move selected blocks to any page…"
             >move to page…</button>
+            <button
+              type="button"
+              class="btn btn-outline selection-toolbar-action"
+              :disabled="selectedBlockCount === 0"
+              @click="bulkScheduleSelected"
+              title="Schedule selected blocks (set a due date / reminder)"
+            >schedule…</button>
             <button
               type="button"
               class="btn btn-outline selection-toolbar-action selection-toolbar-danger"

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -384,6 +384,26 @@ class ApiService {
     });
   }
 
+  async bulkScheduleBlocks(
+    blockUuids,
+    scheduledFor,
+    reminderDate = "",
+    reminderTime = ""
+  ) {
+    return await this.request("/knowledge/api/blocks/bulk-schedule/", {
+      method: "POST",
+      body: JSON.stringify({
+        block_uuids: blockUuids,
+        new_date: scheduledFor || "",
+        reminder_date: reminderDate || "",
+        reminder_time: reminderTime || "",
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
   async getHistoricalData(daysBack = 30, limit = 50) {
     return await this.request(
       `/knowledge/api/historical/?days_back=${daysBack}&limit=${limit}`

--- a/packages/django-app/app/knowledge/test/commands/test_bulk_schedule_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_bulk_schedule_command.py
@@ -1,0 +1,97 @@
+from datetime import date, time, timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from knowledge.commands import BulkScheduleCommand
+from knowledge.forms import BulkScheduleForm
+from knowledge.models import Reminder
+
+from ..helpers import BlockFactory, PageFactory, UserFactory
+
+
+class TestBulkScheduleCommand(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(timezone="America/New_York")
+        cls.page = PageFactory(user=cls.user)
+
+    def _run(self, **kwargs):
+        form = BulkScheduleForm({"user": self.user.id, **kwargs})
+        self.assertTrue(form.is_valid(), form.errors)
+        return BulkScheduleCommand(form).execute()
+
+    def test_date_only_sets_scheduled_for_on_all_blocks(self):
+        b1 = BlockFactory(user=self.user, page=self.page)
+        b2 = BlockFactory(user=self.user, page=self.page)
+        new_date = date(2026, 4, 30)
+
+        result = self._run(block_uuids=[str(b1.uuid), str(b2.uuid)], new_date=new_date)
+
+        self.assertEqual(result["updated_count"], 2)
+        self.assertFalse(result["reminder_set"])
+        self.assertEqual(result["missing"], [])
+        b1.refresh_from_db()
+        b2.refresh_from_db()
+        self.assertEqual(b1.scheduled_for, new_date)
+        self.assertEqual(b2.scheduled_for, new_date)
+        # No reminder times supplied -> no reminders created.
+        self.assertEqual(Reminder.objects.filter(block__in=[b1, b2]).count(), 0)
+
+    def test_date_only_shifts_existing_pending_reminder_by_delta(self):
+        old_date = date(2026, 4, 10)
+        block = BlockFactory(user=self.user, page=self.page, scheduled_for=old_date)
+        fire_at = timezone.now() + timedelta(hours=2)
+        reminder = Reminder.objects.create(block=block, fire_at=fire_at)
+
+        new_date = date(2026, 4, 15)  # +5 days
+        result = self._run(block_uuids=[str(block.uuid)], new_date=new_date)
+
+        self.assertEqual(result["updated_count"], 1)
+        block.refresh_from_db()
+        self.assertEqual(block.scheduled_for, new_date)
+        # Time-of-day preserved: the pending reminder shifts by the same delta.
+        reminder.refresh_from_db()
+        self.assertEqual(reminder.fire_at, fire_at + timedelta(days=5))
+
+    def test_reminder_mode_creates_a_pending_reminder_on_each_block(self):
+        b1 = BlockFactory(user=self.user, page=self.page)
+        b2 = BlockFactory(user=self.user, page=self.page)
+        new_date = date(2026, 4, 30)
+
+        result = self._run(
+            block_uuids=[str(b1.uuid), str(b2.uuid)],
+            new_date=new_date,
+            reminder_time=time(hour=9),
+        )
+
+        self.assertEqual(result["updated_count"], 2)
+        self.assertTrue(result["reminder_set"])
+        for block in (b1, b2):
+            self.assertEqual(
+                Reminder.objects.filter(block=block, sent_at__isnull=True).count(),
+                1,
+            )
+
+    def test_skips_blocks_owned_by_another_user(self):
+        mine = BlockFactory(user=self.user, page=self.page)
+        other = UserFactory()
+        other_page = PageFactory(user=other, slug="other-bulk-schedule")
+        theirs = BlockFactory(user=other, page=other_page)
+        new_date = date(2026, 4, 30)
+
+        result = self._run(
+            block_uuids=[str(mine.uuid), str(theirs.uuid)], new_date=new_date
+        )
+
+        self.assertEqual(result["updated_count"], 1)
+        self.assertEqual(result["missing"], [str(theirs.uuid)])
+        theirs.refresh_from_db()
+        self.assertIsNone(theirs.scheduled_for)
+
+    def test_rejects_empty_block_uuids(self):
+        form = BulkScheduleForm(
+            {"user": self.user.id, "block_uuids": [], "new_date": date(2026, 4, 30)}
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("block_uuids", form.errors)

--- a/packages/django-app/app/knowledge/urls.py
+++ b/packages/django-app/app/knowledge/urls.py
@@ -75,6 +75,11 @@ urlpatterns = [
         views.bulk_move_blocks_to_page,
         name="bulk_move_blocks_to_page",
     ),
+    path(
+        "api/blocks/bulk-schedule/",
+        views.bulk_schedule_blocks,
+        name="bulk_schedule_blocks",
+    ),
     # Page-centric API endpoints
     path("api/pages/", views.create_page, name="create_page"),
     path("api/pages/update/", views.update_page, name="update_page"),

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -16,6 +16,7 @@ from knowledge.commands import (
     BulkDeleteBlocksCommand,
     BulkMoveBlocksCommand,
     BulkMoveBlocksToPageCommand,
+    BulkScheduleCommand,
     ConsumeReminderActionCommand,
     CreateBlockCommand,
     CreatePageCommand,
@@ -76,6 +77,7 @@ from knowledge.forms import (
     BulkDeleteBlocksForm,
     BulkMoveBlocksForm,
     BulkMoveBlocksToPageForm,
+    BulkScheduleForm,
     ConsumeReminderActionForm,
     CreateBlockForm,
     CreatePageEmbeddedViewForm,
@@ -1796,6 +1798,43 @@ def bulk_move_blocks_to_page(request):
             "errors": {"non_field_errors": [str(e)]},
         }
         return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def bulk_schedule_blocks(request):
+    """Set the same scheduled_for (and optional reminder) on a list of blocks.
+
+    Mirrors single-block schedule_block, batched: when reminder_time is
+    supplied each block gets a replacement pending reminder; otherwise the
+    date moves and any existing pending reminder shifts to preserve its
+    time-of-day. Blocks owned by another user are silently skipped.
+    """
+    try:
+        data = request.data.copy()
+        data["user"] = request.user.id
+
+        form = BulkScheduleForm(data)
+        if not form.is_valid():
+            return Response(
+                {"success": False, "data": None, "errors": form.errors},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        result = BulkScheduleCommand(form).execute()
+        return Response({"success": True, "data": result, "errors": None})
+
+    except ValidationError as e:
+        return Response(
+            {"success": False, "data": None, "errors": {"non_field_errors": [str(e)]}},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    except Exception as e:
+        return Response(
+            {"success": False, "data": None, "errors": {"non_field_errors": [str(e)]}},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Paste / embeds

Paste a URL into a block that already has content → drops in as plain text instead of hijacking it into an embed/sibling block
Paste a URL into an empty block → still becomes an embed, and focus now lands in the embed's empty label field (took 3 tries to nail the focus race)
Selection mode

Whole block row is now a click target for selecting (not just the tiny radio), while collapse toggle / menu / links keep their own behavior
Code blocks

Hover "copy" button on code snippets (copies raw code, flashes "copied"); mermaid/CSV excluded
Bulk scheduling

"schedule…" action in the multi-select toolbar → sets a due date / reminder on all selected blocks (new bulk-schedule endpoint wiring up the existing BulkScheduleCommand, plus command tests)
Squaring everything (no rounded corners)

Code-snippet & embed borders → border-radius: 0
App-wide sweep: 80 CSS radii zeroed (modals, popovers, menus, chips, images, etc.), leaving only the genuine 50% circles (spinner/dots)
Django admin image/iframe preview borders
SVG rx rounded corners on the calendar/date-picker icons