### PR TITLE
Default scheduled date to future daily page date

### DIFF
--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -2522,11 +2522,29 @@ const Page = {
       }
 
       this.schedulePopoverBlock = block;
-      this.schedulePopoverInitialDate = block.scheduled_for || "";
+      this.schedulePopoverInitialDate =
+        block.scheduled_for || this._defaultScheduleDate();
       this.schedulePopoverInitialReminderDate =
         block.pending_reminder_date || "";
       this.schedulePopoverInitialTime = block.pending_reminder_time || "";
       this.schedulePopoverOpen = true;
+    },
+
+    // Default due date for an unscheduled block. On a future daily page we
+    // seed the page's own date — the user navigated to that day on purpose,
+    // so a TODO they're scheduling almost certainly belongs on it, not
+    // today. Today's/past daily pages and non-daily pages return "" so the
+    // popover falls back to its own "today" default.
+    _defaultScheduleDate() {
+      if (!this.isDaily) return "";
+      const pageDate = this.page?.date;
+      if (!pageDate) return "";
+      const now = new Date();
+      const tzOffsetMs = now.getTimezoneOffset() * 60_000;
+      const todayIso = new Date(now.getTime() - tzOffsetMs)
+        .toISOString()
+        .slice(0, 10);
+      return pageDate > todayIso ? pageDate : "";
     },
 
     onSchedulePopoverSave({ scheduledFor, reminderDate, reminderTime }) {


### PR DESCRIPTION
When scheduling an unscheduled block on a future daily page, pre-populate the schedule popover's date field with that page's date instead of today. This aligns with user intent — if they navigated to a specific day to add a TODO, it almost certainly belongs on that day rather than today.

**Key changes:**
- Added `_defaultScheduleDate()` method that returns the page's date if it's a future daily page, otherwise returns empty string (falling back to the popover's own "today" default)
- Updated `openSchedulePopover()` to use `_defaultScheduleDate()` instead of always defaulting to empty string

The logic preserves existing behavior for today's/past daily pages and non-daily pages, which continue to default to today.

https://claude.ai/code/session_01Ga8HbUPgG96Fz9PtinofNp