### PR TITLE
Add 15m and 30m snooze actions to reminders

### DIFF
--- a/packages/django-app/app/knowledge/commands/consume_reminder_action_command.py
+++ b/packages/django-app/app/knowledge/commands/consume_reminder_action_command.py
@@ -167,6 +167,8 @@ class ConsumeReminderActionCommand(AbstractBaseCommand):
 
 
 _SNOOZE_DELTAS = {
+    ReminderAction.ACTION_SNOOZE_15M: timedelta(minutes=15),
+    ReminderAction.ACTION_SNOOZE_30M: timedelta(minutes=30),
     ReminderAction.ACTION_SNOOZE_1H: timedelta(hours=1),
     ReminderAction.ACTION_SNOOZE_1D: timedelta(days=1),
 }
@@ -177,6 +179,10 @@ def _executed_detail(action: str) -> str:
         return "Marked the block as done."
     if action == ReminderAction.ACTION_MARK_DOING:
         return "Marked the block as doing."
+    if action == ReminderAction.ACTION_SNOOZE_15M:
+        return "Snoozed for 15 minutes."
+    if action == ReminderAction.ACTION_SNOOZE_30M:
+        return "Snoozed for 30 minutes."
     if action == ReminderAction.ACTION_SNOOZE_1H:
         return "Snoozed for 1 hour."
     if action == ReminderAction.ACTION_SNOOZE_1D:

--- a/packages/django-app/app/knowledge/commands/send_due_reminders_command.py
+++ b/packages/django-app/app/knowledge/commands/send_due_reminders_command.py
@@ -87,8 +87,13 @@ class SendDueRemindersCommand(AbstractBaseCommand):
                 # Mint the per-action tokens before posting so the
                 # links in the message resolve. Failing to mint tokens
                 # shouldn't block the reminder itself — fall back to a
-                # link-less embed so the user still gets pinged.
-                action_urls = _action_urls_for(reminder, settings.SITE_URL, now)
+                # link-less embed so the user still gets pinged. Which
+                # actions get offered depends on the block type — a plain
+                # bullet has no task state to advance, so it gets snooze
+                # links only (see `_actions_for_block`).
+                action_urls = _action_urls_for(
+                    reminder, settings.SITE_URL, now, _actions_for_block(block)
+                )
 
                 content, embeds = _build_payload(
                     reminder,
@@ -147,19 +152,53 @@ _COLOR_STAGING = 0xF59E0B  # amber
 _COLOR_DEFAULT = 0x6B7280  # gray (local / unknown)
 
 
-def _action_urls_for(reminder: Reminder, site_url: str, now) -> Dict[str, str]:
+# Status-change actions ("Mark done" / "Mark doing") only make sense for
+# task-like blocks — the same open-task set used across the app (see
+# OPEN_TODO_TYPES in get_completion_stats_command). A plain bullet,
+# heading, quote, code, or divider block can still carry a reminder, but
+# advancing a task state it doesn't have would be nonsensical, so those
+# blocks get the snooze actions only.
+_TASK_BLOCK_TYPES = {"todo", "doing", "later"}
+
+_SNOOZE_ACTIONS = [
+    ReminderAction.ACTION_SNOOZE_15M,
+    ReminderAction.ACTION_SNOOZE_30M,
+    ReminderAction.ACTION_SNOOZE_1H,
+    ReminderAction.ACTION_SNOOZE_1D,
+]
+
+
+def _actions_for_block(block) -> List[str]:
+    """Which reminder actions to surface for `block`, in display order.
+
+    Snooze is always offered. The status-change actions are added only
+    for task-like blocks so non-task blocks (bullet/heading/quote/...)
+    don't get a confusing "Mark done" link.
+    """
+    actions: List[str] = []
+    if block.block_type in _TASK_BLOCK_TYPES:
+        actions.append(ReminderAction.ACTION_COMPLETE)
+        actions.append(ReminderAction.ACTION_MARK_DOING)
+    actions.extend(_SNOOZE_ACTIONS)
+    return actions
+
+
+def _action_urls_for(
+    reminder: Reminder, site_url: str, now, actions: List[str]
+) -> Dict[str, str]:
     """Mint reminder-action tokens and return their absolute URLs.
 
-    Returns `{action: url}`. Skips when SITE_URL isn't a real http(s)
-    URL — without a working absolute base, the embed links would 404 so
-    the reminder is better off without them. Errors are swallowed so a
-    DB hiccup creating tokens doesn't block delivery; we log + carry
-    on. Worst case the user gets a notification with no quick-actions.
+    Returns `{action: url}` for the given `actions`. Skips when SITE_URL
+    isn't a real http(s) URL — without a working absolute base, the
+    embed links would 404 so the reminder is better off without them.
+    Errors are swallowed so a DB hiccup creating tokens doesn't block
+    delivery; we log + carry on. Worst case the user gets a notification
+    with no quick-actions.
     """
     if not site_url or not site_url.startswith(("http://", "https://")):
         return {}
     try:
-        rows = create_action_tokens(reminder, now=now)
+        rows = create_action_tokens(reminder, actions=actions, now=now)
     except Exception as e:
         logger.warning(
             "failed to mint reminder action tokens for %s: %s",
@@ -284,10 +323,12 @@ def _author_block(environment: str, pr_number: str, pr_url: str) -> dict:
 # Order matters: this is the order the links appear in the embed.
 # "Mark doing" sits between "Mark done" and the snoozes so the two
 # status-change actions cluster together on the left and the deferrals
-# cluster on the right.
+# cluster on the right (shortest snooze first).
 _ACTION_LABELS = [
     (ReminderAction.ACTION_COMPLETE, "Mark done"),
     (ReminderAction.ACTION_MARK_DOING, "Mark doing"),
+    (ReminderAction.ACTION_SNOOZE_15M, "Snooze 15m"),
+    (ReminderAction.ACTION_SNOOZE_30M, "Snooze 30m"),
     (ReminderAction.ACTION_SNOOZE_1H, "Snooze 1h"),
     (ReminderAction.ACTION_SNOOZE_1D, "Snooze 1d"),
 ]

--- a/packages/django-app/app/knowledge/migrations/0037_reminderaction_snooze_15m_30m.py
+++ b/packages/django-app/app/knowledge/migrations/0037_reminderaction_snooze_15m_30m.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("knowledge", "0036_savedview_dates_relative_to_daily"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="reminderaction",
+            name="action",
+            field=models.CharField(
+                choices=[
+                    ("complete", "Mark complete"),
+                    ("mark_doing", "Mark doing"),
+                    ("snooze_15m", "Snooze 15 minutes"),
+                    ("snooze_30m", "Snooze 30 minutes"),
+                    ("snooze_1h", "Snooze 1 hour"),
+                    ("snooze_1d", "Snooze 1 day"),
+                ],
+                max_length=32,
+            ),
+        ),
+    ]

--- a/packages/django-app/app/knowledge/models/reminder_action.py
+++ b/packages/django-app/app/knowledge/models/reminder_action.py
@@ -34,11 +34,15 @@ class ReminderAction(UUIDModelMixin, CRUDTimestampsMixin):
 
     ACTION_COMPLETE = "complete"
     ACTION_MARK_DOING = "mark_doing"
+    ACTION_SNOOZE_15M = "snooze_15m"
+    ACTION_SNOOZE_30M = "snooze_30m"
     ACTION_SNOOZE_1H = "snooze_1h"
     ACTION_SNOOZE_1D = "snooze_1d"
     ACTION_CHOICES = [
         (ACTION_COMPLETE, "Mark complete"),
         (ACTION_MARK_DOING, "Mark doing"),
+        (ACTION_SNOOZE_15M, "Snooze 15 minutes"),
+        (ACTION_SNOOZE_30M, "Snooze 30 minutes"),
         (ACTION_SNOOZE_1H, "Snooze 1 hour"),
         (ACTION_SNOOZE_1D, "Snooze 1 day"),
     ]

--- a/packages/django-app/app/knowledge/services/reminder_actions.py
+++ b/packages/django-app/app/knowledge/services/reminder_actions.py
@@ -18,14 +18,17 @@ def create_action_tokens(
     Returns a `{action: ReminderAction}` dict so callers can look up
     the per-action token without re-querying. `actions` defaults to
     the full set we surface in Discord (`complete`, `mark_doing`,
-    `snooze_1h`, `snooze_1d`) — pass a subset if you ever want to
-    hide an action.
+    `snooze_15m`, `snooze_30m`, `snooze_1h`, `snooze_1d`) — pass a
+    subset if you ever want to hide an action (e.g. the status-change
+    actions are dropped for non-task blocks).
     """
     moment = now or timezone.now()
     expires_at = moment + (ttl or ReminderAction.DEFAULT_TTL)
     chosen = actions or [
         ReminderAction.ACTION_COMPLETE,
         ReminderAction.ACTION_MARK_DOING,
+        ReminderAction.ACTION_SNOOZE_15M,
+        ReminderAction.ACTION_SNOOZE_30M,
         ReminderAction.ACTION_SNOOZE_1H,
         ReminderAction.ACTION_SNOOZE_1D,
     ]

--- a/packages/django-app/app/knowledge/test/commands/test_consume_reminder_action_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_consume_reminder_action_command.py
@@ -59,6 +59,38 @@ class ConsumeReminderActionCommandTests(TestCase):
         action.refresh_from_db()
         self.assertIsNotNone(action.used_at)
 
+    def test_snooze_15m_resets_pending_with_new_fire_at(self) -> None:
+        action = self._make_action(ReminderAction.ACTION_SNOOZE_15M)
+        pinned = timezone.now()
+
+        result = self._run(action.token, now=pinned)
+
+        self.assertEqual(result["status"], "executed")
+        self.assertEqual(result["detail"], "Snoozed for 15 minutes.")
+
+        self.reminder.refresh_from_db()
+        self.assertEqual(self.reminder.status, Reminder.STATUS_PENDING)
+        self.assertIsNone(self.reminder.sent_at)
+        self.assertEqual(
+            self.reminder.fire_at.replace(microsecond=0),
+            (pinned + timedelta(minutes=15)).replace(microsecond=0),
+        )
+
+    def test_snooze_30m_resets_pending_with_new_fire_at(self) -> None:
+        action = self._make_action(ReminderAction.ACTION_SNOOZE_30M)
+        pinned = timezone.now()
+
+        result = self._run(action.token, now=pinned)
+
+        self.assertEqual(result["status"], "executed")
+        self.assertEqual(result["detail"], "Snoozed for 30 minutes.")
+
+        self.reminder.refresh_from_db()
+        self.assertEqual(
+            self.reminder.fire_at.replace(microsecond=0),
+            (pinned + timedelta(minutes=30)).replace(microsecond=0),
+        )
+
     def test_snooze_1h_resets_pending_with_new_fire_at(self) -> None:
         action = self._make_action(ReminderAction.ACTION_SNOOZE_1H)
         pinned = timezone.now()

--- a/packages/django-app/app/knowledge/test/commands/test_reminder_actions_service.py
+++ b/packages/django-app/app/knowledge/test/commands/test_reminder_actions_service.py
@@ -30,13 +30,15 @@ class CreateActionTokensTests(TestCase):
             {
                 ReminderAction.ACTION_COMPLETE,
                 ReminderAction.ACTION_MARK_DOING,
+                ReminderAction.ACTION_SNOOZE_15M,
+                ReminderAction.ACTION_SNOOZE_30M,
                 ReminderAction.ACTION_SNOOZE_1H,
                 ReminderAction.ACTION_SNOOZE_1D,
             },
         )
         # Tokens are unique per row — collisions would break the
         # uniqueness constraint at write time, but assert here too.
-        self.assertEqual(len({r.token for r in rows.values()}), 4)
+        self.assertEqual(len({r.token for r in rows.values()}), 6)
 
     def test_tokens_default_expiry_uses_model_ttl(self) -> None:
         pinned = timezone.now()

--- a/packages/django-app/app/knowledge/test/commands/test_send_due_reminders_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_send_due_reminders_command.py
@@ -388,10 +388,12 @@ class TestSendDueRemindersCommand(TestCase):
     def test_embed_includes_action_links_when_site_url_is_real(self):
         # When a real SITE_URL is set, the dispatcher mints per-action
         # tokens and the embed description picks up a quick-action row
-        # ([Mark done](u) · [Snooze 1h](u) · [Snooze 1d](u)) underneath
-        # the existing "Open block" link.
+        # ([Mark done](u) · [Snooze 15m](u) · ...) underneath the
+        # existing "Open block" link. A task-type block gets the full set.
         page = PageFactory(user=self.user, title="Backlog", slug="backlog")
-        block = BlockFactory(user=self.user, page=page, content="TODO ship")
+        block = BlockFactory(
+            user=self.user, page=page, content="TODO ship", block_type="todo"
+        )
         reminder = Reminder.objects.create(
             block=block,
             fire_at=timezone.now() - timedelta(minutes=1),
@@ -406,18 +408,22 @@ class TestSendDueRemindersCommand(TestCase):
         self.assertIn("[Open block →]", description)
         self.assertIn("[Mark done]", description)
         self.assertIn("[Mark doing]", description)
+        self.assertIn("[Snooze 15m]", description)
+        self.assertIn("[Snooze 30m]", description)
         self.assertIn("[Snooze 1h]", description)
         self.assertIn("[Snooze 1d]", description)
 
-        # Four action rows minted, all linked to this reminder, none
+        # Six action rows minted, all linked to this reminder, none
         # consumed yet.
         actions = list(ReminderAction.objects.filter(reminder=reminder))
-        self.assertEqual(len(actions), 4)
+        self.assertEqual(len(actions), 6)
         self.assertEqual(
             {a.action for a in actions},
             {
                 ReminderAction.ACTION_COMPLETE,
                 ReminderAction.ACTION_MARK_DOING,
+                ReminderAction.ACTION_SNOOZE_15M,
+                ReminderAction.ACTION_SNOOZE_30M,
                 ReminderAction.ACTION_SNOOZE_1H,
                 ReminderAction.ACTION_SNOOZE_1D,
             },
@@ -427,6 +433,40 @@ class TestSendDueRemindersCommand(TestCase):
             self.assertIn(
                 f"https://app.example.com/knowledge/r/{a.token}/", description
             )
+
+    def test_non_task_block_gets_snooze_actions_only(self):
+        # A plain bullet block has no task state to advance, so the
+        # embed must not offer "Mark done" / "Mark doing" — just snooze.
+        page = PageFactory(user=self.user, title="Notes", slug="notes")
+        block = BlockFactory(
+            user=self.user, page=page, content="ping the vet", block_type="bullet"
+        )
+        reminder = Reminder.objects.create(
+            block=block,
+            fire_at=timezone.now() - timedelta(minutes=1),
+        )
+
+        captured, patcher = self._capture_payload()
+        with self.settings(SITE_URL="https://app.example.com"), patcher:
+            self._run()
+
+        description = captured["embeds"][0]["description"]
+        self.assertNotIn("[Mark done]", description)
+        self.assertNotIn("[Mark doing]", description)
+        self.assertIn("[Snooze 15m]", description)
+        self.assertIn("[Snooze 30m]", description)
+        self.assertIn("[Snooze 1h]", description)
+        self.assertIn("[Snooze 1d]", description)
+
+        self.assertEqual(
+            {a.action for a in ReminderAction.objects.filter(reminder=reminder)},
+            {
+                ReminderAction.ACTION_SNOOZE_15M,
+                ReminderAction.ACTION_SNOOZE_30M,
+                ReminderAction.ACTION_SNOOZE_1H,
+                ReminderAction.ACTION_SNOOZE_1D,
+            },
+        )
 
     def test_no_action_links_when_site_url_is_placeholder(self):
         # 0.0.0.0 doesn't form a real URL, so the embed renders without


### PR DESCRIPTION
Expands reminder snooze options from 1h/1d to include 15m and 30m intervals, and makes status-change actions conditional on block type.

**Key changes:**

- Added `ACTION_SNOOZE_15M` and `ACTION_SNOOZE_30M` to `ReminderAction` model with database migration
- Introduced `_actions_for_block()` to determine which actions surface for a given block type — task-like blocks (todo/doing/later) get status-change actions + snooze, while plain blocks (bullet/heading/quote/etc.) get snooze only
- Updated `_action_urls_for()` to accept an `actions` parameter so only relevant actions get tokens minted
- Updated `_SNOOZE_DELTAS` and `_executed_detail()` in consume command to handle the new snooze intervals
- Updated `create_action_tokens()` default action list to include the new snooze options
- Added comprehensive test coverage for both task and non-task block reminder behavior

The change prevents confusing "Mark done" / "Mark doing" links from appearing on non-task blocks while giving users finer-grained snooze control across all reminder types.

https://claude.ai/code/session_01EhgZdFxMLQJJeNj8eC5Pcb