### PR TITLE
Add count-only mode for collapsed saved-view embeds

### DIFF
--- a/packages/django-app/app/knowledge/commands/run_saved_view_command.py
+++ b/packages/django-app/app/knowledge/commands/run_saved_view_command.py
@@ -26,6 +26,7 @@ class RunSavedViewCommand(AbstractBaseCommand):
 
         user = self.form.cleaned_data["user"]
         limit = self.form.cleaned_data.get("limit") or 100
+        count_only = self.form.cleaned_data.get("count_only")
         view_uuid = self.form.cleaned_data.get("view_uuid")
         view_slug = self.form.cleaned_data.get("view_slug")
         context_date = self.form.cleaned_data.get("context_date")
@@ -55,6 +56,22 @@ class RunSavedViewCommand(AbstractBaseCommand):
             )
         except query_engine.QueryEngineError as exc:
             raise ValidationError(str(exc)) from exc
+
+        # Collapsed embeds only need the header count — count limit+1
+        # without serializing the rows so the count + truncation badge
+        # match the full path, but a daily page full of collapsed embeds
+        # stays cheap.
+        if count_only:
+            matched = BlockRepository.count_compiled_query(
+                user, compiled, limit=limit + 1
+            )
+            truncated = matched > limit
+            return {
+                "view": view.to_dict(),
+                "count": min(matched, limit),
+                "results": [],
+                "truncated": truncated,
+            }
 
         # Fetch limit+1 so we can flag when there are more results than fit.
         rows = list(BlockRepository.run_compiled_query(user, compiled, limit=limit + 1))

--- a/packages/django-app/app/knowledge/forms/run_saved_view_form.py
+++ b/packages/django-app/app/knowledge/forms/run_saved_view_form.py
@@ -13,6 +13,10 @@ class RunSavedViewForm(UserForm):
     # ``dates_relative_to_daily=True``; otherwise the command ignores it
     # so a stray context_date can't shift a "live today" view.
     context_date = forms.DateField(required=False)
+    # When true, return only the matched-block count (and truncation flag)
+    # without serializing the rows. Collapsed embeds use this for their
+    # header count — see RunSavedViewCommand.
+    count_only = forms.BooleanField(required=False)
 
     def clean(self):
         cleaned = super().clean()

--- a/packages/django-app/app/knowledge/repositories/block_repository.py
+++ b/packages/django-app/app/knowledge/repositories/block_repository.py
@@ -524,6 +524,19 @@ class BlockRepository(BaseRepository):
         )
 
     @classmethod
+    def _compiled_base_queryset(cls, user, compiled) -> QuerySet:
+        """Shared filter/exclude logic for a CompiledQuery, before ordering
+        and serialization hints. Used by both ``run_compiled_query`` (which
+        adds select_related/ordering) and ``count_compiled_query`` (which
+        only needs the row count). Keeping the template-page exclusion in
+        one place so the two paths can never drift.
+        """
+        qs = cls.get_queryset().filter(user=user).filter(compiled.filter_q)
+        if not compiled.includes_page_type:
+            qs = qs.exclude(page__page_type="template")
+        return qs
+
+    @classmethod
     def run_compiled_query(
         cls,
         user,
@@ -545,14 +558,10 @@ class BlockRepository(BaseRepository):
         and the exclusion is skipped, putting the spec back in control.
         """
         qs = (
-            cls.get_queryset()
-            .filter(user=user)
-            .filter(compiled.filter_q)
+            cls._compiled_base_queryset(user, compiled)
             .select_related("page", "user")
             .prefetch_related("reminders")
         )
-        if not compiled.includes_page_type:
-            qs = qs.exclude(page__page_type="template")
         if compiled.order_by:
             qs = qs.order_by(*compiled.order_by)
         else:
@@ -560,6 +569,28 @@ class BlockRepository(BaseRepository):
         if limit is not None:
             qs = qs[:limit]
         return qs
+
+    @classmethod
+    def count_compiled_query(
+        cls,
+        user,
+        compiled,
+        limit: Optional[int] = None,
+    ) -> int:
+        """Count the blocks a CompiledQuery matches, without fetching or
+        serializing the rows. Used by collapsed saved-view embeds, which
+        only need the header count — running the full ``run_compiled_query``
+        + ``to_dict`` for a header number is wasteful when a daily page can
+        carry many collapsed embeds.
+
+        ``limit`` caps the count (via a sliced subquery) so callers can
+        cheaply distinguish "exactly N" from "at least N" for truncation
+        badges; pass ``limit + 1`` and compare against ``limit``.
+        """
+        qs = cls._compiled_base_queryset(user, compiled)
+        if limit is not None:
+            qs = qs[:limit]
+        return qs.count()
 
     @classmethod
     def clone_block_tree_to_page(

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -8081,6 +8081,13 @@ a.hashtag-mention:hover,
   font-size: 0.95rem;
   cursor: pointer;
 }
+.result-content.completed {
+  text-decoration: line-through;
+  text-decoration-color: var(--text-primary);
+  text-decoration-thickness: 2px;
+  opacity: 0.6;
+  color: var(--completed-text);
+}
 .result-meta {
   font-size: 0.8rem;
   color: var(--text-secondary);

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4810,6 +4810,11 @@ a.sidebar-item:visited {
 
 .page-sort-btn.is-active {
   background: var(--tag-bg);
+  /* Pair --tag-bg with --tag-text: in several themes --tag-bg is the
+     same hue as --text-primary (e.g. #00ff00 on the default theme), so
+     leaving the inherited text color would make the active sort label
+     invisible against its own background. */
+  color: var(--tag-text);
   border-color: var(--border-primary);
 }
 

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -8094,6 +8094,20 @@ a.hashtag-mention:hover,
   font-family: var(--font-mono, monospace);
   text-decoration: none;
 }
+/* Due date pulled out to the right of the row so it reads as its own
+   field, well clear of the page name in the meta line — two dates side
+   by side in the meta line were hard to parse. */
+.result-due {
+  flex: 0 0 auto;
+  align-self: flex-start;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  font-family: var(--font-mono, monospace);
+  white-space: nowrap;
+  border: 1px solid var(--border-primary);
+  border-radius: 3px;
+  padding: 0 5px;
+}
 .result-block-type {
   display: inline-block;
   border: 1px solid var(--border-primary);

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -8079,11 +8079,13 @@ a.hashtag-mention:hover,
 }
 .result-content {
   font-size: 0.95rem;
+  cursor: pointer;
 }
 .result-meta {
   font-size: 0.8rem;
   color: var(--text-secondary);
   font-family: var(--font-mono, monospace);
+  text-decoration: none;
 }
 .result-block-type {
   display: inline-block;

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -6608,9 +6608,18 @@ kbd {
 }
 
 .overdue-due-date {
+  /* Pushed to the right of the meta row (page name sits on the left) so
+     the due date reads as its own field — matches the embed rows'
+     right-aligned due chip, keeping the overdue red emphasis. */
+  margin-left: auto;
+  flex: 0 0 auto;
   font-size: 0.8rem;
   color: var(--error-color, #c0392b);
-  margin-right: 0.5rem;
+  font-family: var(--font-mono, monospace);
+  white-space: nowrap;
+  border: 1px solid var(--error-color, #c0392b);
+  border-radius: 3px;
+  padding: 0 5px;
   opacity: 0.85;
 }
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
@@ -341,11 +341,11 @@ window.EmbedResultRow = {
           <span class="result-content" :class="{ completed: isCompleted(block) }" @click="openBlock" v-html="renderContent(block)"></span>
           <a :href="blockHref(block)" class="result-meta">
             <span v-if="block.block_type" class="result-block-type">{{ block.block_type }}</span>
-            <span v-if="block.scheduled_for"> · due {{ block.scheduled_for }}</span>
             <span v-if="block.completed_at"> · done {{ block.completed_at.split('T')[0] }}</span>
             <span v-if="block.page_title && !isDailyOnDueDate(block)"> · {{ block.page_title }}</span>
           </a>
         </div>
+        <span v-if="block.scheduled_for" class="result-due">due {{ block.scheduled_for }}</span>
         <button
           type="button"
           class="block-menu result-row-menu-btn"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
@@ -67,18 +67,6 @@ window.EmbedResultRow = {
     isCompleted(b) {
       return ["done", "wontdo"].includes(b && b.block_type);
     },
-    isDailyOnDueDate(b) {
-      // A block on a daily page whose date equals its due date: the page
-      // name (the daily's date) duplicates the "due <date>" token, so the
-      // caller suppresses the page label. Daily slugs are the ISO date,
-      // same format as scheduled_for.
-      return !!(
-        b &&
-        b.page_type === "daily" &&
-        b.scheduled_for &&
-        b.page_slug === b.scheduled_for
-      );
-    },
     renderContent(b) {
       // Escape first, then linkify #hashtags into the same clickable
       // anchors the page block tree uses (.inline-tag .clickable-tag →
@@ -342,7 +330,7 @@ window.EmbedResultRow = {
           <a :href="blockHref(block)" class="result-meta">
             <span v-if="block.block_type" class="result-block-type">{{ block.block_type }}</span>
             <span v-if="block.completed_at"> · done {{ block.completed_at.split('T')[0] }}</span>
-            <span v-if="block.page_title && !isDailyOnDueDate(block)"> · {{ block.page_title }}</span>
+            <span v-if="block.page_title"> · {{ block.page_title }}</span>
           </a>
         </div>
         <span v-if="block.scheduled_for" class="result-due">due {{ block.scheduled_for }}</span>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
@@ -64,6 +64,9 @@ window.EmbedResultRow = {
       if (!c) return "(empty block)";
       return c.length > 200 ? c.slice(0, 200) + "…" : c;
     },
+    isCompleted(b) {
+      return ["done", "wontdo"].includes(b && b.block_type);
+    },
     renderContent(b) {
       // Escape first, then linkify #hashtags into the same clickable
       // anchors the page block tree uses (.inline-tag .clickable-tag →
@@ -71,7 +74,13 @@ window.EmbedResultRow = {
       // what keeps block content from injecting markup. This is the
       // reason the content sits in its own <span> rather than inside the
       // block link — anchors can't nest.
-      const text = this.blockLabel(b);
+      let text = this.blockLabel(b);
+      // The bullet already conveys todo state, so strip a leading
+      // TODO/DOING/DONE/LATER/WONTDO marker from the text — same as the
+      // page block tree's formatContentWithTags.
+      if (this.isTodoType(b)) {
+        text = text.replace(/^(WONTDO|LATER|DOING|DONE|TODO)\s*:?\s*/i, "");
+      }
       const escaped = text
         .replace(/&/g, "&amp;")
         .replace(/</g, "&lt;")
@@ -317,7 +326,7 @@ window.EmbedResultRow = {
           :aria-label="isTodoType(block) ? 'Cycle todo state' : null"
         >{{ bulletSymbol(block) }}</div>
         <div class="result-row-link">
-          <span class="result-content" @click="openBlock" v-html="renderContent(block)"></span>
+          <span class="result-content" :class="{ completed: isCompleted(block) }" @click="openBlock" v-html="renderContent(block)"></span>
           <a :href="blockHref(block)" class="result-meta">
             <span v-if="block.block_type" class="result-block-type">{{ block.block_type }}</span>
             <span v-if="block.scheduled_for"> · due {{ block.scheduled_for }}</span>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
@@ -64,6 +64,38 @@ window.EmbedResultRow = {
       if (!c) return "(empty block)";
       return c.length > 200 ? c.slice(0, 200) + "…" : c;
     },
+    renderContent(b) {
+      // Escape first, then linkify #hashtags into the same clickable
+      // anchors the page block tree uses (.inline-tag .clickable-tag →
+      // /knowledge/page/<tag>/). Rendered via v-html, so escaping is
+      // what keeps block content from injecting markup. This is the
+      // reason the content sits in its own <span> rather than inside the
+      // block link — anchors can't nest.
+      const text = this.blockLabel(b);
+      const escaped = text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+      return escaped.replace(
+        /#([a-zA-Z0-9_-]+)/g,
+        '<a class="inline-tag clickable-tag" href="/knowledge/page/$1/" data-tag="$1">#$1</a>'
+      );
+    },
+    openBlock(event) {
+      // Clicking a hashtag inside the content navigates to that tag via
+      // its own anchor — let it through. Any other click on the content
+      // opens the source block, preserving the old whole-row-is-a-link
+      // behavior (the meta line is also a real link for keyboard / open
+      // in new tab).
+      if (event.target.closest("a")) return;
+      const href = this.blockHref(this.block);
+      if (!href || href === "#") return;
+      if (event.metaKey || event.ctrlKey) {
+        window.open(href, "_blank", "noopener");
+        return;
+      }
+      window.location.href = href;
+    },
     isTodoType(b) {
       return ["todo", "doing", "done", "later", "wontdo"].includes(
         b && b.block_type
@@ -284,15 +316,15 @@ window.EmbedResultRow = {
           :role="isTodoType(block) ? 'button' : null"
           :aria-label="isTodoType(block) ? 'Cycle todo state' : null"
         >{{ bulletSymbol(block) }}</div>
-        <a :href="blockHref(block)" class="result-row-link">
-          <span class="result-content">{{ blockLabel(block) }}</span>
-          <span class="result-meta">
+        <div class="result-row-link">
+          <span class="result-content" @click="openBlock" v-html="renderContent(block)"></span>
+          <a :href="blockHref(block)" class="result-meta">
             <span v-if="block.block_type" class="result-block-type">{{ block.block_type }}</span>
             <span v-if="block.scheduled_for"> · due {{ block.scheduled_for }}</span>
             <span v-if="block.completed_at"> · done {{ block.completed_at.split('T')[0] }}</span>
             <span v-if="block.page_title"> · {{ block.page_title }}</span>
-          </span>
-        </a>
+          </a>
+        </div>
         <button
           type="button"
           class="block-menu result-row-menu-btn"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/EmbedResultRow.js
@@ -67,6 +67,18 @@ window.EmbedResultRow = {
     isCompleted(b) {
       return ["done", "wontdo"].includes(b && b.block_type);
     },
+    isDailyOnDueDate(b) {
+      // A block on a daily page whose date equals its due date: the page
+      // name (the daily's date) duplicates the "due <date>" token, so the
+      // caller suppresses the page label. Daily slugs are the ISO date,
+      // same format as scheduled_for.
+      return !!(
+        b &&
+        b.page_type === "daily" &&
+        b.scheduled_for &&
+        b.page_slug === b.scheduled_for
+      );
+    },
     renderContent(b) {
       // Escape first, then linkify #hashtags into the same clickable
       // anchors the page block tree uses (.inline-tag .clickable-tag →
@@ -331,7 +343,7 @@ window.EmbedResultRow = {
             <span v-if="block.block_type" class="result-block-type">{{ block.block_type }}</span>
             <span v-if="block.scheduled_for"> · due {{ block.scheduled_for }}</span>
             <span v-if="block.completed_at"> · done {{ block.completed_at.split('T')[0] }}</span>
-            <span v-if="block.page_title"> · {{ block.page_title }}</span>
+            <span v-if="block.page_title && !isDailyOnDueDate(block)"> · {{ block.page_title }}</span>
           </a>
         </div>
         <button

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -388,6 +388,19 @@ const Page = {
       return blockUuid ? `${base}#block-${blockUuid}` : base;
     },
 
+    isDailyOnDueDate(block) {
+      // A block on a daily page whose date equals its due date: the page
+      // name (the daily's date) just duplicates the "due <date>" token, so
+      // callers suppress the page label to avoid showing the date twice.
+      // Daily slugs are the ISO date, same format as scheduled_for.
+      return !!(
+        block &&
+        block.page_type === "daily" &&
+        block.scheduled_for &&
+        block.page_slug === block.scheduled_for
+      );
+    },
+
     // Copy an absolute deep link to the block to the user's
     // clipboard. Uses `block.page_slug` when present (referenced /
     // overdue blocks set it via `include_page_context=True`) and
@@ -4225,7 +4238,7 @@ const Page = {
             <div v-for="block in overdueBlocks" :key="block.uuid" class="referenced-block-wrapper overdue-block-wrapper" :class="{ 'in-context': isBlockInContext(block.uuid) }" :data-block-uuid="block.uuid">
               <div class="block-meta">
                 <span v-if="block.scheduled_for" class="overdue-due-date">due {{ formatDate(block.scheduled_for) }}</span>
-                <a class="page-title clickable" :href="pageBlockHref(block.page_slug, block.uuid)">{{ block.page_type === 'daily' ? formatDate(block.page_title) : block.page_title }}</a>
+                <a v-if="!isDailyOnDueDate(block)" class="page-title clickable" :href="pageBlockHref(block.page_slug, block.uuid)">{{ block.page_type === 'daily' ? formatDate(block.page_title) : block.page_title }}</a>
               </div>
               <BlockComponent
                 :block="block"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -301,6 +301,14 @@ const Page = {
       "brainspread:request-archive",
       this.handleRequestArchive
     );
+    // An embed (or any other surface) toggled / scheduled / deleted a
+    // block we might also be rendering in the page tree. Refresh so the
+    // page copy reflects the change — embeds already sync via this same
+    // event, but the page itself wasn't listening.
+    document.addEventListener(
+      "brainspread:block-changed",
+      this.handleBlockChanged
+    );
     // When a same-page deep link fires (e.g. spotlight block result on
     // the current page), the URL hash changes without a reload. Listen
     // so we still scroll the matching block into view.
@@ -342,6 +350,14 @@ const Page = {
       "brainspread:request-archive",
       this.handleRequestArchive
     );
+    document.removeEventListener(
+      "brainspread:block-changed",
+      this.handleBlockChanged
+    );
+    if (this._blockChangedTimer) {
+      clearTimeout(this._blockChangedTimer);
+      this._blockChangedTimer = null;
+    }
   },
 
   methods: {
@@ -453,6 +469,61 @@ const Page = {
         // the reload — clobbering an in-progress edit would be worse than
         // showing stale state. They'll see the AI's changes the next time
         // they finish editing (which saves and reloads).
+        const active = document.activeElement;
+        if (
+          active &&
+          active.tagName === "TEXTAREA" &&
+          this.$el &&
+          this.$el.contains(active)
+        ) {
+          return;
+        }
+        this.loadPage({ silent: true });
+      }, 300);
+    },
+
+    broadcastBlockChanged(uuid) {
+      // Single entry point for the page's own block-changed broadcasts.
+      // Tagging the event with `source: this` lets handleBlockChanged
+      // ignore our own notifications — the page already updated its tree
+      // in place, so reloading from the same event would just churn.
+      if (!uuid) return;
+      document.dispatchEvent(
+        new CustomEvent("brainspread:block-changed", {
+          detail: { uuid, source: this },
+        })
+      );
+    },
+
+    pageHasBlock(uuid) {
+      // True when `uuid` is rendered anywhere on this page — the direct
+      // tree, the referenced-block tree, or the overdue list. Used to
+      // skip reloads for changes to blocks we aren't showing.
+      const inTree = (blocks) =>
+        this.flattenBlockTree(blocks).some((b) => b.uuid === uuid);
+      return (
+        inTree(this.directBlocks) ||
+        inTree(this.referencedBlocks) ||
+        inTree(this.overdueBlocks)
+      );
+    },
+
+    handleBlockChanged(event) {
+      // Another surface (typically a saved-view embed on this page)
+      // changed a block we also render. Reload silently so the page copy
+      // picks up the new state — e.g. a TODO toggled to DONE in an embed
+      // should also flip on the bullet list.
+      const uuid = event?.detail?.uuid;
+      if (!uuid) return;
+      // Our own broadcast — the mutating method already patched the tree.
+      if (event.detail.source === this) return;
+      if (!this.page || !this.pageHasBlock(uuid)) return;
+      // Debounce + active-edit guard, mirroring handleNotesModified: skip
+      // the reload while the user is typing in a block on this page so we
+      // don't clobber an in-progress edit.
+      if (this._blockChangedTimer) clearTimeout(this._blockChangedTimer);
+      this._blockChangedTimer = setTimeout(() => {
+        this._blockChangedTimer = null;
         const active = document.activeElement;
         if (
           active &&
@@ -823,11 +894,7 @@ const Page = {
         if (result.success) {
           // Notify embeds that may still be displaying this block —
           // their saved view re-run will drop the now-gone row.
-          document.dispatchEvent(
-            new CustomEvent("brainspread:block-changed", {
-              detail: { uuid: block.uuid },
-            })
-          );
+          this.broadcastBlockChanged(block.uuid);
           await this.loadPage();
         }
       } catch (error) {
@@ -895,11 +962,7 @@ const Page = {
           // Embeds may be showing this block — let them re-run so the
           // bullet / DONE strikethrough reflects the new state without
           // a manual collapse-expand.
-          document.dispatchEvent(
-            new CustomEvent("brainspread:block-changed", {
-              detail: { uuid: block.uuid },
-            })
-          );
+          this.broadcastBlockChanged(block.uuid);
         } else {
           this.error =
             result.errors?.non_field_errors?.[0] || "Failed to toggle todo";
@@ -1071,11 +1134,7 @@ const Page = {
         // Let any QueryEmbedBlock on this page re-run its saved view —
         // the moved block's page_slug just changed and embeds keep
         // their own copy of the block until they refetch.
-        document.dispatchEvent(
-          new CustomEvent("brainspread:block-changed", {
-            detail: { uuid: block.uuid },
-          })
-        );
+        this.broadcastBlockChanged(block.uuid);
         await this.loadPage({ silent: true });
       } catch (error) {
         console.error("failed to move block to today:", error);
@@ -1110,11 +1169,7 @@ const Page = {
             completed_at: result.data?.completed_at || iso,
           };
           this.$parent?.addToast?.("completion time updated", "success");
-          document.dispatchEvent(
-            new CustomEvent("brainspread:block-changed", {
-              detail: { uuid: block.uuid },
-            })
-          );
+          this.broadcastBlockChanged(block.uuid);
           await this.loadPage({ silent: true });
         } else {
           this.$parent?.addToast?.("failed to update completion time", "error");
@@ -1171,11 +1226,7 @@ const Page = {
         // See moveBlockToToday for rationale — embeds keep their own
         // copy of the block until they refetch, and the move just
         // updated page_slug on the server.
-        document.dispatchEvent(
-          new CustomEvent("brainspread:block-changed", {
-            detail: { uuid: block.uuid },
-          })
-        );
+        this.broadcastBlockChanged(block.uuid);
         await this.loadPage({ silent: true });
       } catch (error) {
         console.error("failed to move block to page:", error);
@@ -2626,11 +2677,7 @@ const Page = {
           // they re-run their saved view — keeps the displayed
           // scheduled_for / due meta in sync without a manual
           // collapse-expand.
-          document.dispatchEvent(
-            new CustomEvent("brainspread:block-changed", {
-              detail: { uuid: block.uuid },
-            })
-          );
+          this.broadcastBlockChanged(block.uuid);
           await this.loadPage({ silent: true });
         } else {
           this.$parent?.addToast?.("failed to schedule block", "error");
@@ -3890,13 +3937,7 @@ const Page = {
         this.$parent?.addToast?.(msg, "success");
         // Keep any embeds that surface these blocks in sync, same as the
         // single-block schedule path.
-        uuids.forEach((uuid) =>
-          document.dispatchEvent(
-            new CustomEvent("brainspread:block-changed", {
-              detail: { uuid },
-            })
-          )
-        );
+        uuids.forEach((uuid) => this.broadcastBlockChanged(uuid));
         this.clearBlockSelection();
         await this.loadPage({ silent: true });
       } catch (error) {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -388,19 +388,6 @@ const Page = {
       return blockUuid ? `${base}#block-${blockUuid}` : base;
     },
 
-    isDailyOnDueDate(block) {
-      // A block on a daily page whose date equals its due date: the page
-      // name (the daily's date) just duplicates the "due <date>" token, so
-      // callers suppress the page label to avoid showing the date twice.
-      // Daily slugs are the ISO date, same format as scheduled_for.
-      return !!(
-        block &&
-        block.page_type === "daily" &&
-        block.scheduled_for &&
-        block.page_slug === block.scheduled_for
-      );
-    },
-
     // Copy an absolute deep link to the block to the user's
     // clipboard. Uses `block.page_slug` when present (referenced /
     // overdue blocks set it via `include_page_context=True`) and
@@ -4237,8 +4224,8 @@ const Page = {
           <div class="overdue-blocks-container">
             <div v-for="block in overdueBlocks" :key="block.uuid" class="referenced-block-wrapper overdue-block-wrapper" :class="{ 'in-context': isBlockInContext(block.uuid) }" :data-block-uuid="block.uuid">
               <div class="block-meta">
+                <a class="page-title clickable" :href="pageBlockHref(block.page_slug, block.uuid)">{{ block.page_type === 'daily' ? formatDate(block.page_title) : block.page_title }}</a>
                 <span v-if="block.scheduled_for" class="overdue-due-date">due {{ formatDate(block.scheduled_for) }}</span>
-                <a v-if="!isDailyOnDueDate(block)" class="page-title clickable" :href="pageBlockHref(block.page_slug, block.uuid)">{{ block.page_type === 'daily' ? formatDate(block.page_title) : block.page_title }}</a>
               </div>
               <BlockComponent
                 :block="block"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
@@ -128,10 +128,19 @@ window.QueryEmbedBlock = {
     this._onBlocksChanged = (ev) => {
       const uuid = ev?.detail?.uuid;
       if (!uuid || ev?.detail?.source === this) return;
-      if (this.collapsed || !this.result?.results) return;
-      if (this.result.results.some((b) => b.uuid === uuid)) {
+      // Only expanded embeds render rows; collapsed ones just carry a
+      // count, which we leave until expand/nav.
+      if (this.collapsed || !this.detailLoaded) return;
+      // Re-run on any block change, not just blocks already in our
+      // results: a change can move a block INTO the view (e.g. a todo
+      // marked done on the page now matching a "done" view), which a
+      // results-membership check would miss. Debounced so a bulk action
+      // (which fires one event per block) coalesces into a single re-run.
+      if (this._refetchTimer) clearTimeout(this._refetchTimer);
+      this._refetchTimer = setTimeout(() => {
+        this._refetchTimer = null;
         this.fetch();
-      }
+      }, 150);
     };
     document.addEventListener(
       "brainspread:block-changed",
@@ -145,6 +154,10 @@ window.QueryEmbedBlock = {
         "brainspread:block-changed",
         this._onBlocksChanged
       );
+    }
+    if (this._refetchTimer) {
+      clearTimeout(this._refetchTimer);
+      this._refetchTimer = null;
     }
   },
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
@@ -53,6 +53,10 @@ window.QueryEmbedBlock = {
       loading: true,
       error: null,
       result: null, // {view, count, results, truncated}
+      // True once a full (row-serializing) fetch has landed. Collapsed
+      // embeds fetch count-only, so this stays false until they expand —
+      // it's how the expand watcher knows it still needs the rows.
+      detailLoaded: false,
     };
   },
 
@@ -112,7 +116,10 @@ window.QueryEmbedBlock = {
   },
 
   mounted() {
-    if (!this.collapsed) this.fetch();
+    // Always fetch on mount: expanded embeds load their rows, collapsed
+    // embeds load a count-only payload so the header still shows how many
+    // blocks the view matches. fetch() picks the mode from `collapsed`.
+    this.fetch();
     // Re-run the saved view when any block we might be displaying
     // mutates elsewhere on the page (a different embed's row, the
     // home-page editor, etc.). Our own row actions also broadcast
@@ -143,20 +150,21 @@ window.QueryEmbedBlock = {
 
   watch: {
     collapsed(now, prev) {
-      // Lazy-load when the user expands a previously-collapsed embed,
-      // so collapsed embeds don't all hammer /api/views/run/ on page
-      // load.
-      if (prev && !now && !this.result) this.fetch();
+      // Expanding a collapsed embed: it only has a count-only payload so
+      // far, so fetch the rows. Collapsed embeds still fetch their count
+      // on mount, so they don't hammer the full /api/views/run/ path on
+      // page load — just the cheap count.
+      if (prev && !now && !this.detailLoaded) this.fetch();
     },
     contextDate(now, prev) {
       // ``scope="daily"`` embeds are the same DB row across every daily,
       // so navigating between dailies can reuse this component instance
-      // rather than remount it. Refetch so the results rebase to the
-      // new daily — but only when the view actually cares about
-      // context_date. Without the dates_relative_to_daily check we'd
-      // re-run every "live today" embed on every daily nav for no
-      // visible reason.
-      if (now !== prev && !this.collapsed && this._viewRebases()) {
+      // rather than remount it. Refetch so the results (or collapsed
+      // count) rebase to the new daily — but only when the view actually
+      // cares about context_date. Without the dates_relative_to_daily
+      // check we'd re-run every "live today" embed on every daily nav for
+      // no visible reason.
+      if (now !== prev && this._viewRebases()) {
         this.fetch();
       }
     },
@@ -180,15 +188,21 @@ window.QueryEmbedBlock = {
         this.error = "This embed doesn't reference a saved view.";
         return;
       }
+      // Collapsed embeds only need the header count, so skip serializing
+      // the matched rows. Expanding later triggers a full fetch (see the
+      // collapsed watcher).
+      const countOnly = this.collapsed;
       this.loading = true;
       try {
         const r = await window.apiService.runSavedView({
           uuid: this.savedView.uuid,
           limit: 25,
           contextDate: this.contextDate || null,
+          countOnly,
         });
         if (r && r.success) {
           this.result = r.data;
+          this.detailLoaded = !countOnly;
           this.error = null;
         } else {
           const errs = (r && r.errors) || {};
@@ -269,7 +283,7 @@ window.QueryEmbedBlock = {
           ><path fill="currentColor" d="M8 1.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3ZM7.25 5.92V7.5H5.5a.5.5 0 0 0 0 1h1.75v4.97c-1.49-.18-2.62-1.07-3.13-1.91l.72-.43a.4.4 0 0 0-.15-.74L2.5 9.85a.4.4 0 0 0-.5.4v2.34a.4.4 0 0 0 .65.31l.7-.55C4.05 13.55 5.83 14.5 8 14.5s3.95-.95 4.65-2.15l.7.55a.4.4 0 0 0 .65-.31v-2.34a.4.4 0 0 0-.5-.4l-2.19.54a.4.4 0 0 0-.15.74l.72.43c-.51.84-1.64 1.73-3.13 1.91V8.5h1.75a.5.5 0 0 0 0-1H8.75V5.92a2.5 2.5 0 1 0-1.5 0Z"/></svg>
           <span class="block-query-embed-anchor-label">{{ dateAnchor.label }}</span>
         </span>
-        <span v-if="result && !collapsed" class="block-query-embed-meta">
+        <span v-if="result" class="block-query-embed-meta">
           {{ result.count }}<span v-if="result.truncated">+ truncated</span>
         </span>
         <span class="block-query-embed-actions">

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -906,6 +906,7 @@ class ApiService {
     slug = null,
     limit = 100,
     contextDate = null,
+    countOnly = false,
   } = {}) {
     const params = new URLSearchParams();
     if (uuid) params.set("view_uuid", uuid);
@@ -916,6 +917,10 @@ class ApiService {
     // view's ``dates_relative_to_daily`` flag is on; otherwise it's a
     // no-op. Pass null for non-daily surfaces.
     if (contextDate) params.set("context_date", contextDate);
+    // countOnly returns just the matched-block count (+ truncation flag)
+    // without serializing the rows — used by collapsed embeds for their
+    // header count.
+    if (countOnly) params.set("count_only", "true");
     return await this.request(`/knowledge/api/views/run/?${params.toString()}`);
   }
 

--- a/packages/django-app/app/knowledge/test/commands/test_saved_view_commands.py
+++ b/packages/django-app/app/knowledge/test/commands/test_saved_view_commands.py
@@ -280,6 +280,53 @@ class RunSavedViewTests(_SavedViewTestBase):
         self.assertEqual(result["count"], 2)
         self.assertTrue(result["truncated"])
 
+    def test_count_only_returns_count_without_serializing_rows(self):
+        # Collapsed embeds ask for count_only — the header count comes
+        # back but the rows are not serialized.
+        for _ in range(2):
+            BlockFactory(
+                user=self.user,
+                page=self.page,
+                block_type="todo",
+                scheduled_for=date(2026, 4, 23),
+            )
+        form = RunSavedViewForm(
+            {
+                "user": self.user.id,
+                "view_slug": SYSTEM_VIEW_OVERDUE,
+                "count_only": "true",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        result = RunSavedViewCommand(form).execute()
+        self.assertEqual(result["count"], 2)
+        self.assertEqual(result["results"], [])
+        self.assertFalse(result["truncated"])
+
+    def test_count_only_truncates_and_flags(self):
+        for _ in range(3):
+            BlockFactory(
+                user=self.user,
+                page=self.page,
+                block_type="todo",
+                scheduled_for=date(2026, 4, 23),
+            )
+        form = RunSavedViewForm(
+            {
+                "user": self.user.id,
+                "view_slug": SYSTEM_VIEW_OVERDUE,
+                "limit": 2,
+                "count_only": "true",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        result = RunSavedViewCommand(form).execute()
+        # Count is capped at the limit and truncation is flagged, matching
+        # the full (row-serializing) path.
+        self.assertEqual(result["count"], 2)
+        self.assertTrue(result["truncated"])
+        self.assertEqual(result["results"], [])
+
     def test_run_unknown_view_404(self):
         form = RunSavedViewForm({"user": self.user.id, "view_slug": "does-not-exist"})
         self.assertTrue(form.is_valid())


### PR DESCRIPTION
Collapsed saved-view embeds now fetch only the matched-block count on mount, deferring the expensive row serialization until the user expands them. This reduces page-load overhead when a daily page carries many collapsed embeds.

**Key changes:**

- **Backend**: Added `count_compiled_query()` method to `BlockRepository` to count matched blocks without fetching or serializing rows. Extracted shared filter/exclude logic into `_compiled_base_queryset()` so both paths stay in sync.
- **Command**: `RunSavedViewCommand` now accepts a `count_only` parameter. When true, it returns the count and truncation flag with an empty results array, bypassing row serialization.
- **Form**: Added `count_only` boolean field to `RunSavedViewForm`.
- **API**: `runSavedView()` in `api.js` now accepts a `countOnly` parameter and passes it to the backend.
- **Frontend**: `QueryEmbedBlock` component now:
  - Always fetches on mount (collapsed embeds get count-only, expanded get full rows)
  - Tracks `detailLoaded` to distinguish "has count" from "has rows"
  - Lazy-loads rows when expanding a collapsed embed (via the `collapsed` watcher)
  - Shows the count in the header for both collapsed and expanded states
  - Refetches on context-date changes regardless of collapsed state (since count-only is cheap)
- **Tests**: Added two test cases verifying count-only behavior matches the full path for both normal and truncated results.

The implementation keeps the two code paths (`run_compiled_query` and `count_compiled_query`) aligned by sharing the base queryset logic, ensuring count and truncation badges are always accurate.

https://claude.ai/code/session_01AVfKD5FaakCpdnh9wKeaWF