### PR TITLE
Add all-pages browser and daily navigation (issue #133)

### DIFF
--- a/packages/django-app/app/knowledge/commands/bulk_move_blocks_to_page_command.py
+++ b/packages/django-app/app/knowledge/commands/bulk_move_blocks_to_page_command.py
@@ -1,5 +1,6 @@
 from typing import List, TypedDict
 
+from django.core.exceptions import ValidationError
 from django.db import transaction
 
 from common.commands.abstract_base_command import AbstractBaseCommand
@@ -23,6 +24,11 @@ class BulkMoveBlocksToPageCommand(AbstractBaseCommand):
     parent is not in the selection) are moved individually in
     document order so their relative order on the target page
     matches the source.
+
+    With ``target_parent`` set, each top block nests under that block
+    instead of the page root. A top block that contains the target
+    parent in its own subtree is skipped (the per-block circular
+    guard rejects it) rather than failing the whole batch.
     """
 
     def __init__(self, form: BulkMoveBlocksToPageForm) -> None:
@@ -34,6 +40,7 @@ class BulkMoveBlocksToPageCommand(AbstractBaseCommand):
         user = self.form.cleaned_data["user"]
         uuids: List[str] = self.form.cleaned_data["blocks"]
         target_page = self.form.cleaned_data["target_page"]
+        target_parent = self.form.cleaned_data.get("target_parent")
 
         blocks_qs = BlockRepository.get_queryset().filter(user=user, uuid__in=uuids)
         blocks_by_uuid = {str(b.uuid): b for b in blocks_qs}
@@ -56,17 +63,24 @@ class BulkMoveBlocksToPageCommand(AbstractBaseCommand):
         skipped = len(uuids) - len(selected_uuids)
         with transaction.atomic():
             for block in top_blocks:
-                inner = MoveBlockToPageForm(
-                    {
-                        "user": user.id,
-                        "block": str(block.uuid),
-                        "target_page": str(target_page.uuid),
-                    }
-                )
+                inner_data = {
+                    "user": user.id,
+                    "block": str(block.uuid),
+                    "target_page": str(target_page.uuid),
+                }
+                if target_parent:
+                    inner_data["target_parent"] = str(target_parent.uuid)
+                inner = MoveBlockToPageForm(inner_data)
                 if not inner.is_valid():
                     skipped += 1
                     continue
-                result = MoveBlockToPageCommand(inner).execute()
+                try:
+                    result = MoveBlockToPageCommand(inner).execute()
+                except ValidationError:
+                    # e.g. the target parent lives inside this block's own
+                    # subtree — skip the offender, keep moving the rest.
+                    skipped += 1
+                    continue
                 if result.get("moved"):
                     moved += 1
 

--- a/packages/django-app/app/knowledge/commands/get_user_pages_command.py
+++ b/packages/django-app/app/knowledge/commands/get_user_pages_command.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 from common.commands.abstract_base_command import AbstractBaseCommand
 
 from ..forms.get_user_pages_form import GetUserPagesForm
-from ..models import Page
+from ..repositories.page_repository import PageRepository
 
 
 class GetUserPagesCommand(AbstractBaseCommand):
@@ -21,24 +21,16 @@ class GetUserPagesCommand(AbstractBaseCommand):
         limit = self.form.cleaned_data.get("limit", 10)
         offset = self.form.cleaned_data.get("offset", 0)
         page_type = self.form.cleaned_data.get("page_type") or None
+        # "modified" default keeps the page picker's empty-query landing
+        # state surfacing what the user has been touching lately; the
+        # All Pages surface passes "title" / "date" explicitly.
+        order_by = self.form.cleaned_data.get("order_by") or "modified"
 
-        # Order by most-recently-modified first so the page picker's
-        # empty-query landing state surfaces what the user has been
-        # touching lately. Title is a stable tiebreaker for pages
-        # modified at the same instant (e.g. bulk imports). This is the
-        # only caller today; if a future caller wants alphabetical it
-        # should pass an explicit order_by once that's plumbed through.
-        queryset = Page.objects.filter(user=user).order_by("-modified_at", "title")
-        if published_only:
-            queryset = queryset.filter(is_published=True)
-        if page_type:
-            queryset = queryset.filter(page_type=page_type)
-
-        pages = queryset[offset : offset + limit]
-        total_count = queryset.count()
-
-        return {
-            "pages": list(pages),
-            "total_count": total_count,
-            "has_more": (offset + limit) < total_count,
-        }
+        return PageRepository.get_user_pages(
+            user=user,
+            published_only=published_only,
+            limit=limit,
+            offset=offset,
+            page_type=page_type,
+            order_by=order_by,
+        )

--- a/packages/django-app/app/knowledge/commands/move_block_to_page_command.py
+++ b/packages/django-app/app/knowledge/commands/move_block_to_page_command.py
@@ -1,5 +1,6 @@
 from typing import TypedDict
 
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Max
 
@@ -19,6 +20,11 @@ class MoveBlockToPageCommand(AbstractBaseCommand):
     target, land at the bottom of the existing order, carry descendants
     along, touch both pages so they bubble to the top of Recent — but
     accepts an arbitrary target page rather than resolving by date.
+
+    With ``target_parent`` set the block nests under that block instead
+    of landing at the page root — the "move under…" flow. The order is
+    then scoped to the parent's children (last child) rather than the
+    page-wide max.
     """
 
     def __init__(self, form: MoveBlockToPageForm) -> None:
@@ -30,17 +36,26 @@ class MoveBlockToPageCommand(AbstractBaseCommand):
         user = self.form.cleaned_data["user"]
         block = self.form.cleaned_data["block"]
         target_page = self.form.cleaned_data["target_page"]
+        target_parent = self.form.cleaned_data.get("target_parent")
 
-        already_root_on_target = (
-            block.page_id == target_page.pk and block.parent_id is None
+        target_parent_id = target_parent.pk if target_parent else None
+        already_in_place = (
+            block.page_id == target_page.pk and block.parent_id == target_parent_id
         )
-        if already_root_on_target:
+        if already_in_place:
             return {
                 "moved": False,
                 "block": block.to_dict(),
                 "target_page": target_page.to_dict(),
-                "message": "Block is already on the target page",
+                "message": "Block is already in the target position",
             }
+
+        if target_parent and self._would_create_circular_reference(
+            block, target_parent
+        ):
+            raise ValidationError(
+                "Cannot move a block under itself or one of its descendants"
+            )
 
         descendants = BlockRepository.get_block_descendants(block)
         # Capture before reassignment so we can touch the source page after
@@ -48,15 +63,14 @@ class MoveBlockToPageCommand(AbstractBaseCommand):
         source_page = block.page
 
         with transaction.atomic():
-            max_order = (
-                BlockRepository.get_queryset()
-                .filter(page=target_page)
-                .aggregate(max_order=Max("order"))["max_order"]
-            )
+            order_scope = BlockRepository.get_queryset().filter(page=target_page)
+            if target_parent:
+                order_scope = order_scope.filter(parent=target_parent)
+            max_order = order_scope.aggregate(max_order=Max("order"))["max_order"]
             max_order = max_order if max_order is not None else 0
 
             block.page = target_page
-            block.parent = None
+            block.parent = target_parent
             block.order = max_order + 1
             block.save(update_fields=["page", "parent", "order"])
 
@@ -75,6 +89,17 @@ class MoveBlockToPageCommand(AbstractBaseCommand):
             "target_page": target_page.to_dict(),
             "message": f"Moved block to {target_page.title}",
         }
+
+    def _would_create_circular_reference(self, block, proposed_parent) -> bool:
+        """True when proposed_parent is the block itself or lives inside
+        the block's subtree — nesting there would detach the subtree
+        from the page tree entirely."""
+        current = proposed_parent
+        while current is not None:
+            if current.pk == block.pk:
+                return True
+            current = current.parent
+        return False
 
 
 class MoveBlockToPageData(TypedDict):

--- a/packages/django-app/app/knowledge/commands/update_block_command.py
+++ b/packages/django-app/app/knowledge/commands/update_block_command.py
@@ -24,7 +24,11 @@ class UpdateBlockCommand(AbstractBaseCommand):
         user = self.form.cleaned_data["user"]
         block = self.form.cleaned_data["block"]
 
-        # Update fields
+        # Update fields. Parent only changes when the caller submitted
+        # the key: an explicit null re-roots the block (outdent), while
+        # omitting it leaves nesting alone. The old "omitted → clear"
+        # behavior silently re-rooted nested blocks on partial updates
+        # like the resize handle's properties-only save.
         content_updated = False
         if "parent" in self.form.cleaned_data:
             parent = self.form.cleaned_data["parent"]
@@ -35,9 +39,6 @@ class UpdateBlockCommand(AbstractBaseCommand):
                 )
 
             block.parent = parent
-        else:
-            # If no parent is provided, ensure parent is set to None
-            block.parent = None
 
         # Update other fields
         for field in [

--- a/packages/django-app/app/knowledge/forms/bulk_move_blocks_to_page_form.py
+++ b/packages/django-app/app/knowledge/forms/bulk_move_blocks_to_page_form.py
@@ -1,5 +1,5 @@
 import uuid as uuid_lib
-from typing import List
+from typing import Any, Dict, List, Optional
 
 from django import forms
 from django.core.exceptions import ValidationError
@@ -8,7 +8,8 @@ from common.forms import BaseForm, UUIDModelChoiceField
 from core.models import User
 from core.repositories import UserRepository
 
-from ..models import Page
+from ..models import Block, Page
+from ..repositories import BlockRepository
 from ..repositories.page_repository import PageRepository
 
 
@@ -19,12 +20,20 @@ class BulkMoveBlocksToPageForm(BaseForm):
     but the target is an explicit Page UUID instead of a date. We
     never auto-create pages on this path; the caller picks an
     existing one via the page-picker modal.
+
+    ``target_parent`` (optional) nests the moved blocks under an
+    existing block instead of the target page's root — the bulk
+    "move under…" flow. When only ``target_parent`` is given the
+    target page is derived from it.
     """
 
     user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
     blocks = forms.JSONField()
     target_page = UUIDModelChoiceField(
-        queryset=PageRepository.get_queryset(), required=True
+        queryset=PageRepository.get_queryset(), required=False
+    )
+    target_parent = UUIDModelChoiceField(
+        queryset=BlockRepository.get_queryset(), required=False
     )
 
     def clean_user(self) -> User:
@@ -58,9 +67,31 @@ class BulkMoveBlocksToPageForm(BaseForm):
 
         return normalized
 
-    def clean_target_page(self) -> Page:
+    def clean_target_page(self) -> Optional[Page]:
         page = self.cleaned_data.get("target_page")
         user = self.cleaned_data.get("user")
         if page and user and page.user != user:
             raise ValidationError("Target page not found")
         return page
+
+    def clean_target_parent(self) -> Optional[Block]:
+        parent = self.cleaned_data.get("target_parent")
+        user = self.cleaned_data.get("user")
+        if parent and user and parent.user != user:
+            raise ValidationError("Target parent not found")
+        return parent
+
+    def clean(self) -> Dict[str, Any]:
+        cleaned_data = super().clean()
+        target_page = cleaned_data.get("target_page")
+        target_parent = cleaned_data.get("target_parent")
+
+        if not target_page and not target_parent:
+            raise ValidationError("target_page or target_parent is required")
+
+        if target_parent:
+            if target_page and target_parent.page_id != target_page.pk:
+                raise ValidationError("target_parent does not belong to target_page")
+            cleaned_data["target_page"] = target_parent.page
+
+        return cleaned_data

--- a/packages/django-app/app/knowledge/forms/get_user_pages_form.py
+++ b/packages/django-app/app/knowledge/forms/get_user_pages_form.py
@@ -20,6 +20,17 @@ class GetUserPagesForm(BaseForm):
         choices=Page._meta.get_field("page_type").choices,
         required=False,
     )
+    # Optional ordering — vocabulary lives in
+    # PageRepository.get_user_pages. Defaults to "modified" when
+    # omitted so existing picker callers keep their behavior.
+    order_by = forms.ChoiceField(
+        choices=[
+            ("modified", "Recently modified"),
+            ("title", "Title"),
+            ("date", "Date"),
+        ],
+        required=False,
+    )
 
     def clean_user(self) -> User:
         user = self.cleaned_data.get("user")

--- a/packages/django-app/app/knowledge/forms/move_block_to_page_form.py
+++ b/packages/django-app/app/knowledge/forms/move_block_to_page_form.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, Optional
+
 from django import forms
 from django.core.exceptions import ValidationError
 
@@ -16,12 +18,21 @@ class MoveBlockToPageForm(BaseForm):
     Distinct from MoveBlockToDailyForm — that one resolves the target by
     date and may auto-create a daily note. Here the caller passes an
     explicit target page UUID and we never create pages on their behalf.
+
+    ``target_parent`` (optional) nests the moved block under an existing
+    block instead of promoting it to the target page's root — the
+    "move under…" flow. When only ``target_parent`` is given the target
+    page is derived from it, so pickers that select a block don't need
+    to know its page.
     """
 
     user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
     block = UUIDModelChoiceField(queryset=BlockRepository.get_queryset(), required=True)
     target_page = UUIDModelChoiceField(
-        queryset=PageRepository.get_queryset(), required=True
+        queryset=PageRepository.get_queryset(), required=False
+    )
+    target_parent = UUIDModelChoiceField(
+        queryset=BlockRepository.get_queryset(), required=False
     )
 
     def clean_user(self) -> User:
@@ -37,9 +48,31 @@ class MoveBlockToPageForm(BaseForm):
             raise ValidationError("Block not found")
         return block
 
-    def clean_target_page(self) -> Page:
+    def clean_target_page(self) -> Optional[Page]:
         page = self.cleaned_data.get("target_page")
         user = self.cleaned_data.get("user")
         if page and user and page.user != user:
             raise ValidationError("Target page not found")
         return page
+
+    def clean_target_parent(self) -> Optional[Block]:
+        parent = self.cleaned_data.get("target_parent")
+        user = self.cleaned_data.get("user")
+        if parent and user and parent.user != user:
+            raise ValidationError("Target parent not found")
+        return parent
+
+    def clean(self) -> Dict[str, Any]:
+        cleaned_data = super().clean()
+        target_page = cleaned_data.get("target_page")
+        target_parent = cleaned_data.get("target_parent")
+
+        if not target_page and not target_parent:
+            raise ValidationError("target_page or target_parent is required")
+
+        if target_parent:
+            if target_page and target_parent.page_id != target_page.pk:
+                raise ValidationError("target_parent does not belong to target_page")
+            cleaned_data["target_page"] = target_parent.page
+
+        return cleaned_data

--- a/packages/django-app/app/knowledge/repositories/page_repository.py
+++ b/packages/django-app/app/knowledge/repositories/page_repository.py
@@ -1,7 +1,7 @@
 from datetime import date
 from typing import Any, Dict, Optional
 
-from django.db.models import Count, Q, QuerySet
+from django.db.models import Count, F, Q, QuerySet
 
 from common.repositories.base_repository import BaseRepository
 
@@ -37,13 +37,38 @@ class PageRepository(BaseRepository):
 
     @classmethod
     def get_user_pages(
-        cls, user, published_only: bool = True, limit: int = 10, offset: int = 0
+        cls,
+        user,
+        published_only: bool = True,
+        limit: int = 10,
+        offset: int = 0,
+        page_type: Optional[str] = None,
+        order_by: str = "modified",
     ) -> Dict[str, Any]:
-        """Get paginated user pages with filtering"""
+        """Get paginated user pages with filtering and ordering.
+
+        ``order_by`` vocabulary:
+        - "modified" — most-recently-modified first (title tiebreak);
+          surfaces the user's working set. The default.
+        - "title" — alphabetical.
+        - "date" — newest daily date first; undated pages sort last so
+          the option stays usable on mixed-type lists.
+        """
         queryset = cls.get_queryset().filter(user=user)
 
         if published_only:
             queryset = queryset.filter(is_published=True)
+        if page_type:
+            queryset = queryset.filter(page_type=page_type)
+
+        if order_by == "title":
+            queryset = queryset.order_by("title")
+        elif order_by == "date":
+            queryset = queryset.order_by(
+                F("date").desc(nulls_last=True), "-modified_at"
+            )
+        else:
+            queryset = queryset.order_by("-modified_at", "title")
 
         total_count = queryset.count()
         pages = list(queryset[offset : offset + limit])

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -5533,14 +5533,16 @@ a.sidebar-item:visited {
   align-items: center;
   justify-content: center;
   align-self: stretch;
-  min-width: 2.1rem;
-  padding: 0 0.5rem;
-  border: 2px solid var(--border-secondary);
+  /* Bare glyphs — no border/background so the arrows don't compete
+     with the date input. min-width keeps a finger-sized hit area. */
+  min-width: 1.9rem;
+  padding: 0 0.35rem;
+  border: none;
   border-radius: 0;
-  background: var(--bg-primary);
-  color: var(--text-primary);
+  background: transparent;
+  color: var(--text-secondary);
   font-family: inherit;
-  font-size: 1.1rem;
+  font-size: 1.4rem;
   line-height: 1;
   text-decoration: none;
   cursor: pointer;
@@ -5548,8 +5550,6 @@ a.sidebar-item:visited {
 }
 
 .daily-nav-btn:hover {
-  background: var(--hover-bg);
-  border-color: var(--border-primary);
   color: var(--text-primary);
 }
 
@@ -5558,9 +5558,20 @@ a.sidebar-item:visited {
   outline-offset: 2px;
 }
 
+/* "today" is a text label, not a glyph — keep it as a bordered chip
+   matching the date input so it still reads as a button. */
 .daily-nav-today {
+  border: 2px solid var(--border-secondary);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  padding: 0 0.5rem;
   font-size: 0.85rem;
   letter-spacing: 0.02em;
+}
+
+.daily-nav-today:hover {
+  background: var(--hover-bg);
+  border-color: var(--border-primary);
 }
 
 /* Spotlight Search Styles */

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -5519,9 +5519,8 @@ a.sidebar-item:visited {
 }
 
 /* Prev/next daily navigation (issue #133). The arrows flank the date
-   picker inside .daily-nav; "today" only renders when viewing another
-   day. align-self: stretch keys the buttons' height off the date
-   input so the row reads as one control group. */
+   picker inside .daily-nav; align-self: stretch keys them off the
+   date input's height so the row reads as one control group. */
 .daily-nav {
   display: flex;
   align-items: center;
@@ -5556,22 +5555,6 @@ a.sidebar-item:visited {
 .daily-nav-btn:focus-visible {
   outline: 2px solid var(--border-primary);
   outline-offset: 2px;
-}
-
-/* "today" is a text label, not a glyph — keep it as a bordered chip
-   matching the date input so it still reads as a button. */
-.daily-nav-today {
-  border: 2px solid var(--border-secondary);
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  padding: 0 0.5rem;
-  font-size: 0.85rem;
-  letter-spacing: 0.02em;
-}
-
-.daily-nav-today:hover {
-  background: var(--hover-bg);
-  border-color: var(--border-primary);
 }
 
 /* Spotlight Search Styles */

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -5327,6 +5327,7 @@ a.sidebar-item:visited {
    visual vocabulary. */
 .page-header-flex-left:hover .page-favorite-toggle,
 .title-left:hover .page-favorite-toggle,
+.daily-nav:hover .page-favorite-toggle,
 .saved-view-title-row:hover .page-favorite-toggle,
 .page-favorite-toggle:focus-visible,
 .page-favorite-toggle.is-favorited {
@@ -8537,5 +8538,47 @@ a.hashtag-mention:hover,
 
   .pages-list-modified {
     display: none;
+  }
+}
+
+/* ── Touch-device tap hardening (issue #133 follow-up) ──────────────
+   Two-tap fixes for phones/tablets:
+   - Controls that desktop reveals on :hover don't exist for a touch
+     user until a first tap applies the emulated hover — so the first
+     tap reads as dead. Keep them visible (dimmed) on touch instead.
+   - touch-action: manipulation removes the browser's double-tap-to-
+     zoom wait on the app's interactive controls, so single taps fire
+     immediately. */
+@media (hover: none) and (pointer: coarse) {
+  .block-collapse-toggle,
+  .block-code-copy,
+  .leftnav-template-edit {
+    opacity: 1;
+  }
+
+  .block-due-add {
+    opacity: 0.45;
+  }
+
+  .block-mermaid-open {
+    opacity: 0.7;
+  }
+
+  /* The copy button occupies the same top-right corner the language
+     badge does; desktop swaps them on hover. With copy pinned visible
+     on touch, hide the badge so they don't overlap. */
+  .block-code-wrapper .block-code-lang {
+    opacity: 0;
+  }
+
+  button,
+  select,
+  [role="button"],
+  .leftnav-item,
+  .leftnav-rail-btn,
+  .daily-nav-btn,
+  .block-content-display,
+  .date-picker {
+    touch-action: manipulation;
   }
 }

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -8576,3 +8576,46 @@ a.hashtag-mention:hover,
     touch-action: manipulation;
   }
 }
+
+/* ── Block drag-and-drop indicators (issue #133 follow-up) ─────────
+   Dragging a block by its bullet: the hovered row shows an insertion
+   line (top 30% → before, bottom 30% → after as sibling) or a nest
+   highlight (middle → becomes the row's last child). Desktop-only —
+   HTML5 drag events don't fire on touch. */
+.block.block-drop-before,
+.block.block-drop-after {
+  position: relative;
+}
+
+.block.block-drop-before::before,
+.block.block-drop-after::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--border-primary);
+  pointer-events: none;
+  z-index: 2;
+}
+
+.block.block-drop-before::before {
+  top: -1px;
+}
+
+.block.block-drop-after::after {
+  bottom: -1px;
+}
+
+.block.block-drop-child {
+  background: var(--hover-bg);
+  box-shadow: inset 0 0 0 2px var(--border-primary);
+}
+
+/* Grab affordance on non-todo bullets; todo bullets keep their
+   pointer cursor since click-to-toggle is their primary action. */
+.block-bullet[draggable="true"]:not(.todo):not(.doing):not(.done):not(
+    .later
+  ):not(.wontdo) {
+  cursor: grab;
+}

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -2168,24 +2168,19 @@ kbd {
     align-items: center;
   }
 
-  /* On the daily page, sit the date picker and context menu side by
-     side, centered as a pair. Anchoring the menu to the far right
-     would put it under the AI chat-toggle in the top-right corner. */
+  /* On the daily page, sit the date navigation and context menu side
+     by side, centered as a pair, wrapping the menu to a second row on
+     narrow screens. Anchoring the menu to the far right would put it
+     under the AI chat-toggle in the top-right corner. */
   .daily-note-title.page-header-flex {
     justify-content: center;
     gap: 0.5rem;
+    flex-wrap: wrap;
   }
 
-  /* Pull the favorite star out of flow on mobile so it doesn't shift
-     the date input off-center inside the centered pair. The star sits
-     just to the left of the date input, .title-left's width equals the
-     date input alone, and the pair stays visually centered. */
-  .daily-note-title .title-left .page-favorite-toggle {
-    position: absolute;
-    right: 100%;
-    top: 50%;
-    transform: translateY(-50%);
-    margin-right: 0.25rem;
+  .daily-nav {
+    flex-wrap: wrap;
+    justify-content: center;
   }
 
   .child-block {
@@ -5522,6 +5517,51 @@ a.sidebar-item:visited {
   border-color: var(--border-primary);
 }
 
+/* Prev/next daily navigation (issue #133). The arrows flank the date
+   picker inside .daily-nav; "today" only renders when viewing another
+   day. align-self: stretch keys the buttons' height off the date
+   input so the row reads as one control group. */
+.daily-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.daily-nav-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: stretch;
+  min-width: 2.1rem;
+  padding: 0 0.5rem;
+  border: 2px solid var(--border-secondary);
+  border-radius: 0;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 1.1rem;
+  line-height: 1;
+  text-decoration: none;
+  cursor: pointer;
+  user-select: none;
+}
+
+.daily-nav-btn:hover {
+  background: var(--hover-bg);
+  border-color: var(--border-primary);
+  color: var(--text-primary);
+}
+
+.daily-nav-btn:focus-visible {
+  outline: 2px solid var(--border-primary);
+  outline-offset: 2px;
+}
+
+.daily-nav-today {
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+}
+
 /* Spotlight Search Styles */
 .spotlight-overlay {
   position: fixed;
@@ -8269,4 +8309,233 @@ a.hashtag-mention:hover,
   color: var(--text-secondary);
   font-size: 0.9rem;
   padding: 0.5rem 0;
+}
+
+/* ── All Pages browser (issue #133) ─────────────────────────────── */
+
+.pages-list-page {
+  padding: 1.25rem 1.75rem 4rem;
+  max-width: 950px;
+  margin: 0 auto;
+  width: 100%;
+  color: var(--text-primary);
+}
+
+.pages-list-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.pages-list-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.pages-list-count {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.pages-list-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.pages-list-search {
+  position: relative;
+  flex: 1 1 220px;
+  min-width: 180px;
+  max-width: 340px;
+}
+
+.pages-list-search-input {
+  width: 100%;
+  padding: 0.4rem 1.75rem 0.4rem 0.6rem;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 2px solid var(--border-secondary);
+  border-radius: 0;
+  font-family: inherit;
+  font-size: 0.9rem;
+}
+
+.pages-list-search-input:focus {
+  outline: none;
+  border-color: var(--border-primary);
+}
+
+.pages-list-search-clear {
+  position: absolute;
+  right: 0.35rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0.1rem 0.25rem;
+  cursor: pointer;
+}
+
+.pages-list-search-clear:hover {
+  color: var(--text-primary);
+}
+
+.pages-list-type-filters {
+  display: inline-flex;
+  flex-wrap: wrap;
+}
+
+.pages-list-type-btn {
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  border: 2px solid var(--border-secondary);
+  border-radius: 0;
+  font-family: inherit;
+  font-size: 0.85rem;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+  /* Collapse shared edges so the group reads as one segmented control. */
+  margin-right: -2px;
+}
+
+.pages-list-type-btn:last-child {
+  margin-right: 0;
+}
+
+.pages-list-type-btn:hover {
+  background: var(--hover-bg);
+  color: var(--text-primary);
+}
+
+.pages-list-type-btn.is-active {
+  background: var(--tag-bg, var(--bg-secondary));
+  /* Pair --tag-bg with --tag-text: in several themes --tag-bg matches
+     --text-primary's hue, which would render the active label
+     invisible against its own background. */
+  color: var(--tag-text, var(--text-primary));
+  border-color: var(--border-primary);
+  /* Keep the active segment's border on top of its neighbors'. */
+  position: relative;
+  z-index: 1;
+}
+
+.pages-list-order {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.pages-list-order select {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 2px solid var(--border-secondary);
+  border-radius: 0;
+  font-family: inherit;
+  font-size: 0.85rem;
+  padding: 0.3rem 0.4rem;
+  cursor: pointer;
+}
+
+.pages-list-order select:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.pages-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border: 1px solid var(--border-primary);
+  border-radius: 0;
+  background: var(--bg-secondary);
+}
+
+.pages-list li {
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.pages-list li:last-child {
+  border-bottom: none;
+}
+
+.pages-list-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.55rem 0.9rem;
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.pages-list-row:hover {
+  background: var(--hover-bg);
+}
+
+.pages-list-title {
+  font-weight: 500;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pages-list-star {
+  color: var(--text-secondary);
+  margin-right: 0.15rem;
+}
+
+.pages-list-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex: none;
+}
+
+.pages-list-page .page-type-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 0;
+  padding: 0.05em 0.5em;
+}
+
+.pages-list-modified {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.pages-list-more {
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+@media (max-width: 768px) {
+  .pages-list-page {
+    padding: 1rem 1rem 3rem;
+    /* Clear the fixed 45×45 leftnav-rail-toggle pinned to the top-left
+       corner on mobile, same as the page-title-container rule above. */
+    padding-top: calc(45px + 0.75rem);
+  }
+
+  .pages-list-modified {
+    display: none;
+  }
 }

--- a/packages/django-app/app/knowledge/static/knowledge/js/app.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/app.js
@@ -21,6 +21,7 @@ const KnowledgeApp = createApp({
     const cachedUser = window.apiService.getCurrentUser();
 
     const isGraphRoute = window.location.pathname === "/knowledge/graph/";
+    const isPagesRoute = window.location.pathname === "/knowledge/pages/";
     const viewsMatch = window.location.pathname.match(
       /^\/knowledge\/views(?:\/([^\/]+))?\/?$/
     );
@@ -31,9 +32,11 @@ const KnowledgeApp = createApp({
     const initialView = isAuth
       ? isGraphRoute
         ? "graph"
-        : isViewsRoute
-          ? "views"
-          : "journal"
+        : isPagesRoute
+          ? "pages"
+          : isViewsRoute
+            ? "views"
+            : "journal"
       : "login";
 
     return {
@@ -79,6 +82,7 @@ const KnowledgeApp = createApp({
     SpotlightSearch: window.SpotlightSearch,
     GraphView: window.GraphView,
     SavedViewsPage: window.SavedViewsPage,
+    PagesListPage: window.PagesListPage,
   },
 
   computed: {
@@ -100,10 +104,11 @@ const KnowledgeApp = createApp({
     },
 
     showChatPanel() {
-      // Whiteboards, graph view, and saved-views surface use the full
-      // column width; chat is noise there.
+      // Whiteboards, graph view, and the saved-views / all-pages
+      // surfaces use the full column width; chat is noise there.
       if (this.currentView === "graph") return false;
       if (this.currentView === "views") return false;
+      if (this.currentView === "pages") return false;
       return this.currentPagePageType !== "whiteboard";
     },
   },
@@ -152,6 +157,13 @@ const KnowledgeApp = createApp({
       /^\/knowledge\/views(?:\/[^\/]+)?\/?$/.test(window.location.pathname)
     ) {
       this.currentView = "views";
+    }
+
+    if (
+      this.isAuthenticated &&
+      window.location.pathname === "/knowledge/pages/"
+    ) {
+      this.currentView = "pages";
     }
 
     // Reapply theme after auth check in case user data was updated
@@ -531,6 +543,10 @@ const KnowledgeApp = createApp({
       window.location.href = "/knowledge/views/";
     },
 
+    navigateToPages() {
+      window.location.href = "/knowledge/pages/";
+    },
+
     // Fired by child components (CustomEvent 'brainspread:toast', detail = {message, type, duration}).
     // Bridges DOM events into the toast state without coupling the children to this component.
     handleToastEvent(event) {
@@ -736,6 +752,12 @@ const KnowledgeApp = createApp({
           label: "graph",
           description: "view the knowledge graph",
           icon: "◉",
+        },
+        {
+          id: "all-pages",
+          label: "all pages",
+          description: "browse the full list of pages",
+          icon: "☰",
         },
         {
           id: "toggle-sidebar",
@@ -985,6 +1007,9 @@ const KnowledgeApp = createApp({
         case "graph":
           this.navigateToGraph();
           break;
+        case "all-pages":
+          this.navigateToPages();
+          break;
         case "toggle-sidebar":
           this.toggleLeftNav();
           break;
@@ -1081,6 +1106,7 @@ const KnowledgeApp = createApp({
                             @navigate-today="redirectToToday"
                             @navigate-graph="navigateToGraph"
                             @navigate-views="navigateToViews"
+                            @navigate-pages="navigateToPages"
                             @open-search="openSpotlight"
                             @create-page="createNewPage"
                             @create-whiteboard="createNewWhiteboard"
@@ -1098,6 +1124,7 @@ const KnowledgeApp = createApp({
                             @navigate-today="redirectToToday"
                             @navigate-graph="navigateToGraph"
                             @navigate-views="navigateToViews"
+                            @navigate-pages="navigateToPages"
                             @open-search="openSpotlight"
                             @create-page="createNewPage"
                             @create-whiteboard="createNewWhiteboard"
@@ -1109,6 +1136,26 @@ const KnowledgeApp = createApp({
                             <SavedViewsPage :initial-slug="viewsSlug" />
                         </div>
                     </div>
+                    <div v-else-if="currentView === 'pages'" class="views-layout">
+                        <LeftNav
+                            ref="leftNav"
+                            :user="user"
+                            @navigate-to-slug="onNavigateToSlug"
+                            @navigate-today="redirectToToday"
+                            @navigate-graph="navigateToGraph"
+                            @navigate-views="navigateToViews"
+                            @navigate-pages="navigateToPages"
+                            @open-search="openSpotlight"
+                            @create-page="createNewPage"
+                            @create-whiteboard="createNewWhiteboard"
+                            @use-template="useTemplate"
+                            @open-settings="openSettings"
+                            @open-help="openHelp"
+                            @logout="requestLogout" />
+                        <div class="main-content-area">
+                            <PagesListPage />
+                        </div>
+                    </div>
                     <div v-else class="content-layout">
                         <LeftNav
                             ref="leftNav"
@@ -1117,6 +1164,7 @@ const KnowledgeApp = createApp({
                             @navigate-today="redirectToToday"
                             @navigate-graph="navigateToGraph"
                             @navigate-views="navigateToViews"
+                            @navigate-pages="navigateToPages"
                             @open-search="openSpotlight"
                             @create-page="createNewPage"
                             @create-whiteboard="createNewWhiteboard"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/AppModals.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/AppModals.js
@@ -70,14 +70,19 @@ window.AppModals = {
           const ok = this.$refs.alertOk;
           if (ok) ok.focus();
         });
-      } else if (next && next.kind === "pickPage") {
+      } else if (
+        next &&
+        (next.kind === "pickPage" || next.kind === "pickBlock")
+      ) {
         this._resetPicker();
         this.$nextTick(() => {
           const input = this.$refs.pickerInput;
           if (input) input.focus();
         });
         // Kick off an initial search so the user sees their most-
-        // recently-edited pages without typing. Empty query → recent.
+        // recently-edited pages without typing. Empty query → recent
+        // for pages; block search needs a query, so pickBlock just
+        // shows its type-to-search hint.
         this._runPickerSearch("");
       }
       if (!next && prev) {
@@ -93,6 +98,7 @@ window.AppModals = {
       prompt: this.prompt.bind(this),
       alert: this.alert.bind(this),
       pickPage: this.pickPage.bind(this),
+      pickBlock: this.pickBlock.bind(this),
     };
   },
 
@@ -187,6 +193,30 @@ window.AppModals = {
       });
     },
 
+    pickBlock(opts) {
+      // Typeahead block picker — same scaffolding as pickPage but
+      // searching block content via /api/blocks/search/. Resolves with
+      // {uuid, content, page_title, page_slug, block_type} or null on
+      // dismiss. Callers pass ``excludeUuids`` to hide blocks that
+      // can't be valid targets (e.g. the block being moved).
+      const normalized = opts || {};
+      return new Promise((resolve) => {
+        this.queue.push({
+          id: ++this._idCounter,
+          kind: "pickBlock",
+          opts: {
+            title: normalized.title || "pick a block",
+            message: normalized.message || "",
+            placeholder: normalized.placeholder || "search blocks…",
+            confirmLabel: normalized.confirmLabel || "select",
+            cancelLabel: normalized.cancelLabel || "cancel",
+            excludeUuids: normalized.excludeUuids || [],
+          },
+          resolve,
+        });
+      });
+    },
+
     _resetPicker() {
       this.pickerQuery = "";
       this.pickerResults = [];
@@ -211,6 +241,9 @@ window.AppModals = {
     },
 
     async _runPickerSearch(query) {
+      if (this.active?.kind === "pickBlock") {
+        return this._runBlockPickerSearch(query);
+      }
       const requestId = ++this._pickerRequestId;
       this.pickerLoading = true;
       const pageType = this.active?.opts?.pageType || null;
@@ -266,6 +299,49 @@ window.AppModals = {
       }
     },
 
+    async _runBlockPickerSearch(query) {
+      // Block search has no "recent" fallback — the endpoint requires a
+      // query — so the empty state is a type-to-search hint (see the
+      // template's pickBlock empty branch).
+      const requestId = ++this._pickerRequestId;
+      const trimmed = query.trim();
+      if (trimmed === "") {
+        this.pickerResults = [];
+        this.pickerSelectedIndex = -1;
+        this.pickerLoading = false;
+        return;
+      }
+      this.pickerLoading = true;
+      const exclude = new Set(this.active?.opts?.excludeUuids || []);
+      try {
+        const result = await window.apiService.searchBlocks(trimmed, 15);
+        if (requestId !== this._pickerRequestId) return; // stale
+        const rows = (result && result.data && result.data.results) || [];
+        // Normalize to the picker's row shape — the search endpoint
+        // calls the id ``block_uuid`` but every consumer (and the
+        // v-for :key) expects ``uuid``.
+        this.pickerResults = rows
+          .filter((b) => !exclude.has(b.block_uuid))
+          .map((b) => ({
+            uuid: b.block_uuid,
+            content: b.content,
+            block_type: b.block_type,
+            page_title: b.page_title,
+            page_slug: b.page_slug,
+          }));
+        this.pickerSelectedIndex = this.pickerResults.length ? 0 : -1;
+      } catch (err) {
+        if (requestId !== this._pickerRequestId) return;
+        console.error("pickBlock search failed:", err);
+        this.pickerResults = [];
+        this.pickerSelectedIndex = -1;
+      } finally {
+        if (requestId === this._pickerRequestId) {
+          this.pickerLoading = false;
+        }
+      }
+    },
+
     async _fetchTodayDailyPage() {
       // Locate the user's daily note for today's date so the picker can
       // pin it to the top of the empty-query list. Goes through the
@@ -291,7 +367,7 @@ window.AppModals = {
 
     onPickerKeydown(event) {
       const top = this.active;
-      if (!top || top.kind !== "pickPage") return;
+      if (!top || (top.kind !== "pickPage" && top.kind !== "pickBlock")) return;
       if (event.key === "ArrowDown") {
         event.preventDefault();
         if (this.pickerResults.length === 0) return;
@@ -368,16 +444,17 @@ window.AppModals = {
       if (top.kind === "confirm") this.onCancel();
       else if (top.kind === "prompt") this.onPromptCancel();
       else if (top.kind === "alert") this.onAlertOk();
-      else if (top.kind === "pickPage") this.onPickerCancel();
+      else if (top.kind === "pickPage" || top.kind === "pickBlock")
+        this.onPickerCancel();
     },
 
     onKeydown(event) {
       const top = this.active;
       if (!top) return;
-      // pickPage drives its own keyboard surface (arrows + Enter +
+      // The pickers drive their own keyboard surface (arrows + Enter +
       // Esc) via @keydown on the input — the global Enter-on-button
       // handlers below would otherwise fight Enter-to-pick.
-      if (top.kind === "pickPage") return;
+      if (top.kind === "pickPage" || top.kind === "pickBlock") return;
       if (event.key === "Escape") {
         event.preventDefault();
         if (top.kind === "confirm") this.onCancel();
@@ -493,7 +570,7 @@ window.AppModals = {
         </div>
 
         <div
-          v-else-if="active.kind === 'pickPage'"
+          v-else-if="active.kind === 'pickPage' || active.kind === 'pickBlock'"
           class="app-modal app-modal-picker"
           role="dialog"
           aria-modal="true"
@@ -520,30 +597,53 @@ window.AppModals = {
               searching…
             </div>
             <div
+              v-else-if="active.kind === 'pickBlock' && !pickerQuery.trim()"
+              class="app-modal-picker-empty"
+            >
+              type to search block content
+            </div>
+            <div
               v-else-if="!pickerResults.length"
               class="app-modal-picker-empty"
             >
-              no pages match
+              {{ active.kind === 'pickBlock' ? 'no blocks match' : 'no pages match' }}
             </div>
-            <button
-              v-else
-              v-for="(page, index) in pickerResults"
-              :key="page.uuid"
-              type="button"
-              class="app-modal-picker-result"
-              :class="{ 'is-selected': index === pickerSelectedIndex }"
-              @click="onPickerResultClick(index)"
-              @mouseenter="pickerSelectedIndex = index"
-              role="option"
-              :aria-selected="index === pickerSelectedIndex"
-            >
-              <span class="app-modal-picker-result-title">{{ page.title }}</span>
-              <span
-                v-if="page.page_type && page.page_type !== 'page'"
-                class="app-modal-picker-result-type"
-              >{{ page.page_type }}</span>
-              <span class="app-modal-picker-result-slug">{{ page.slug }}</span>
-            </button>
+            <template v-else-if="active.kind === 'pickBlock'">
+              <button
+                v-for="(blockRow, index) in pickerResults"
+                :key="blockRow.uuid"
+                type="button"
+                class="app-modal-picker-result"
+                :class="{ 'is-selected': index === pickerSelectedIndex }"
+                @click="onPickerResultClick(index)"
+                @mouseenter="pickerSelectedIndex = index"
+                role="option"
+                :aria-selected="index === pickerSelectedIndex"
+              >
+                <span class="app-modal-picker-result-title">{{ blockRow.content }}</span>
+                <span class="app-modal-picker-result-slug">{{ blockRow.page_title || blockRow.page_slug }}</span>
+              </button>
+            </template>
+            <template v-else>
+              <button
+                v-for="(page, index) in pickerResults"
+                :key="page.uuid"
+                type="button"
+                class="app-modal-picker-result"
+                :class="{ 'is-selected': index === pickerSelectedIndex }"
+                @click="onPickerResultClick(index)"
+                @mouseenter="pickerSelectedIndex = index"
+                role="option"
+                :aria-selected="index === pickerSelectedIndex"
+              >
+                <span class="app-modal-picker-result-title">{{ page.title }}</span>
+                <span
+                  v-if="page.page_type && page.page_type !== 'page'"
+                  class="app-modal-picker-result-type"
+                >{{ page.page_type }}</span>
+                <span class="app-modal-picker-result-slug">{{ page.slug }}</span>
+              </button>
+            </template>
           </div>
           <div class="app-modal-actions">
             <button

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -87,6 +87,37 @@ const BlockComponent = {
       type: Function,
       default: () => () => {},
     },
+    openMoveUnderPicker: {
+      type: Function,
+      default: () => () => {},
+    },
+    // Block drag-and-drop (issue #133 follow-up). Only the main page
+    // tree passes real handlers + moveDraggable; linked-reference and
+    // overdue lists render without drag affordances.
+    moveDraggable: {
+      type: Boolean,
+      default: false,
+    },
+    moveDropTarget: {
+      type: Object,
+      default: null,
+    },
+    onMoveDragStart: {
+      type: Function,
+      default: () => () => {},
+    },
+    onMoveDragOver: {
+      type: Function,
+      default: () => () => {},
+    },
+    onMoveDrop: {
+      type: Function,
+      default: () => () => {},
+    },
+    onMoveDragEnd: {
+      type: Function,
+      default: () => () => {},
+    },
     openBlockInfoModal: {
       type: Function,
       default: () => () => {},
@@ -124,6 +155,10 @@ const BlockComponent = {
       default: 0,
     },
     bulkDeleteSelected: {
+      type: Function,
+      default: () => () => {},
+    },
+    bulkMoveSelectedUnder: {
       type: Function,
       default: () => () => {},
     },
@@ -276,6 +311,13 @@ const BlockComponent = {
     },
     hasChildren() {
       return this.block.children?.length > 0;
+    },
+    moveDropZone() {
+      // 'before' | 'after' | 'child' when a live block drag hovers
+      // this row; null otherwise. Drives the drop-indicator classes.
+      return this.moveDropTarget && this.moveDropTarget.uuid === this.block.uuid
+        ? this.moveDropTarget.zone
+        : null;
     },
     childrenCount() {
       return this.block.children?.length || 0;
@@ -1429,6 +1471,9 @@ const BlockComponent = {
         case "moveToPage":
           this.openMovePagePicker(this.block);
           break;
+        case "moveUnder":
+          this.openMoveUnderPicker(this.block);
+          break;
         case "blockInfo":
           this.openBlockInfoModal(this.block);
           break;
@@ -1443,6 +1488,9 @@ const BlockComponent = {
           break;
         case "bulkMoveToToday":
           this.bulkMoveSelectedToToday();
+          break;
+        case "bulkMoveUnder":
+          this.bulkMoveSelectedUnder();
           break;
         case "schedule":
           this.scheduleBlock(this.block);
@@ -1593,7 +1641,7 @@ const BlockComponent = {
   },
   template: `
     <div class="block-wrapper" :class="{ 'child-block': block.parent, 'in-context': blockInContext, 'selected': blockSelected, 'in-selection-mode': selectionMode }" :data-block-uuid="block.uuid" @dragover="handleBlockDragOver" @drop="handleBlockDrop">
-      <div class="block" :class="{ 'has-children': hasChildren, 'is-collapsed': hasChildren && isCollapsed }" @click="handleRowClick($event)">
+      <div class="block" :class="{ 'has-children': hasChildren, 'is-collapsed': hasChildren && isCollapsed, 'block-drop-before': moveDropZone === 'before', 'block-drop-after': moveDropZone === 'after', 'block-drop-child': moveDropZone === 'child' }" @click="handleRowClick($event)" @dragover="moveDraggable ? onMoveDragOver(block, $event) : null" @drop="moveDraggable ? onMoveDrop(block, $event) : null">
         <button
           v-if="selectionMode"
           type="button"
@@ -1621,6 +1669,9 @@ const BlockComponent = {
             'later': block.block_type === 'later',
             'wontdo': block.block_type === 'wontdo'
           }"
+          :draggable="moveDraggable"
+          @dragstart="moveDraggable ? onMoveDragStart(block, $event) : null"
+          @dragend="moveDraggable ? onMoveDragEnd() : null"
           @click="selectionMode ? handleSelectToggleClick($event) : (['todo', 'doing', 'done', 'later', 'wontdo'].includes(block.block_type) ? toggleBlockTodo(block) : null)"
           @touchstart="handleTouchStart"
           @touchend="selectionMode ? null : handleTodoTouchEnd($event)"
@@ -2039,6 +2090,10 @@ const BlockComponent = {
           <span class="context-menu-icon">→</span>
           <span>move to page…</span>
         </button>
+        <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('moveUnder')">
+          <span class="context-menu-icon">⤷</span>
+          <span>move under block…</span>
+        </button>
         <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('copyLink')">
           <span class="context-menu-icon">↗</span>
           <span>copy link to block</span>
@@ -2096,6 +2151,10 @@ const BlockComponent = {
             <span class="context-menu-icon">⇨</span>
             <span>move {{ selectedBlockCount }} selected to today</span>
           </button>
+          <button class="context-menu-item" role="menuitem" tabindex="-1" @click="handleContextMenuAction('bulkMoveUnder')">
+            <span class="context-menu-icon">⤷</span>
+            <span>move {{ selectedBlockCount }} selected under…</span>
+          </button>
           <button class="context-menu-item context-menu-danger" role="menuitem" tabindex="-1" @click="handleContextMenuAction('bulkDelete')">
             <span class="context-menu-icon">×</span>
             <span>delete {{ selectedBlockCount }} selected</span>
@@ -2129,6 +2188,13 @@ const BlockComponent = {
           :moveBlockDown="moveBlockDown"
           :moveBlockToToday="moveBlockToToday"
           :openMovePagePicker="openMovePagePicker"
+          :openMoveUnderPicker="openMoveUnderPicker"
+          :moveDraggable="moveDraggable"
+          :moveDropTarget="moveDropTarget"
+          :onMoveDragStart="onMoveDragStart"
+          :onMoveDragOver="onMoveDragOver"
+          :onMoveDrop="onMoveDrop"
+          :onMoveDragEnd="onMoveDragEnd"
           :openBlockInfoModal="openBlockInfoModal"
           :onBlockPaste="onBlockPaste"
           :onBlockDrop="onBlockDrop"
@@ -2140,6 +2206,7 @@ const BlockComponent = {
           :selectedBlockCount="selectedBlockCount"
           :bulkDeleteSelected="bulkDeleteSelected"
           :bulkMoveSelectedToToday="bulkMoveSelectedToToday"
+          :bulkMoveSelectedUnder="bulkMoveSelectedUnder"
           :selectionMode="selectionMode"
           :reference-mode="referenceMode"
         />

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -564,10 +564,23 @@ const BlockComponent = {
       this.applyResizableHandles();
     },
 
+    ownResizableEls(selector) {
+      // Scope subtree queries to THIS block's own resizable elements.
+      // $el is the block's `[data-block-uuid]` root and contains the
+      // children's DOM too, so an unscoped querySelectorAll would let
+      // an ancestor block (usually with no saved size) stomp the width
+      // a nested block just applied — nested image resizes looked
+      // saved until the next render/reload, then snapped back.
+      if (!this.$el || this.$el.nodeType !== 1) return [];
+      return [...this.$el.querySelectorAll(selector)].filter(
+        (el) => el.closest("[data-block-uuid]") === this.$el
+      );
+    },
+
     applyResizableHandles() {
       // Apply the persisted block-level width to every resizable
-      // wrapper inside this block, and wire up corner-handle drag.
-      // A block has a single properties.size today, so multiple
+      // wrapper belonging to this block, and wire up corner-handle
+      // drag. A block has a single properties.size today, so multiple
       // resizables in one block share the same width — fine for the
       // current shapes (one mermaid wrapper per block; an asset block
       // has either an image or a renderable text-shaped asset, never
@@ -578,8 +591,7 @@ const BlockComponent = {
       if (this.$el.querySelector(".block-resize-handle.is-resizing")) return;
       const savedWidth = this.block.properties?.size?.width || null;
       const target = savedWidth ? String(savedWidth) : "";
-      const wrappers = this.$el.querySelectorAll(".block-resizable");
-      wrappers.forEach((el) => {
+      this.ownResizableEls(".block-resizable").forEach((el) => {
         if (el.dataset.savedSizeApplied === target) return;
         if (savedWidth) {
           el.style.width = `${savedWidth}px`;
@@ -590,10 +602,9 @@ const BlockComponent = {
         }
         el.dataset.savedSizeApplied = target;
       });
-      const handles = this.$el.querySelectorAll(
+      this.ownResizableEls(
         ".block-resize-handle:not([data-resize-bound])"
-      );
-      handles.forEach((handle) => {
+      ).forEach((handle) => {
         handle.dataset.resizeBound = "true";
         handle.addEventListener("mousedown", (event) =>
           this.startResize(event, handle)
@@ -1467,13 +1478,11 @@ const BlockComponent = {
       // wrappers fall back to their natural defaults (image at
       // intrinsic size, mermaid at column width).
       this.setBlockProperties(this.block, { size: null });
-      if (this.$el) {
-        this.$el.querySelectorAll(".block-resizable").forEach((el) => {
-          el.style.width = "";
-          el.classList.remove("has-saved-size");
-          el.dataset.savedSizeApplied = "";
-        });
-      }
+      this.ownResizableEls(".block-resizable").forEach((el) => {
+        el.style.width = "";
+        el.classList.remove("has-saved-size");
+        el.dataset.savedSizeApplied = "";
+      });
     },
 
     async fetchAssetSource() {
@@ -2106,6 +2115,7 @@ const BlockComponent = {
           :stopEditing="stopEditing"
           :deleteBlock="deleteBlock"
           :toggleBlockTodo="toggleBlockTodo"
+          :setBlockProperties="setBlockProperties"
           :formatContentWithTags="formatContentWithTags"
           :isBlockInContext="isBlockInContext"
           :isBlockSelected="isBlockSelected"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/LeftNav.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/LeftNav.js
@@ -648,6 +648,13 @@ window.LeftNav = {
       this.closeOnMobile();
     },
 
+    onPagesClick(event) {
+      if (this.shouldDeferToBrowser(event)) return;
+      event.preventDefault();
+      this.$emit("navigate-pages");
+      this.closeOnMobile();
+    },
+
     onSearchClick() {
       this.$emit("open-search");
       this.closeOnMobile();
@@ -937,6 +944,14 @@ window.LeftNav = {
           title="Saved views"
           aria-label="Saved views"
         >≡</a>
+        <a
+          href="/knowledge/pages/"
+          class="leftnav-rail-btn leftnav-rail-action"
+          @click="onPagesClick"
+          @auxclick="onPagesClick"
+          title="All pages"
+          aria-label="All pages"
+        >☰</a>
         <div class="leftnav-rail-spacer leftnav-rail-action"></div>
         <button
           type="button"
@@ -1071,6 +1086,16 @@ window.LeftNav = {
             >
               <span class="leftnav-icon" aria-hidden="true">≡</span>
               <span class="leftnav-label">saved views</span>
+            </a>
+            <a
+              href="/knowledge/pages/"
+              class="leftnav-item"
+              @click="onPagesClick"
+              @auxclick="onPagesClick"
+              title="Browse all pages"
+            >
+              <span class="leftnav-icon" aria-hidden="true">☰</span>
+              <span class="leftnav-label">all pages</span>
             </a>
           </nav>
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -918,7 +918,9 @@ const Page = {
           // Notify embeds that may still be displaying this block —
           // their saved view re-run will drop the now-gone row.
           this.broadcastBlockChanged(block.uuid);
-          await this.loadPage();
+          // Silent: swap in the fresh tree without flashing the whole
+          // page through the "Loading..." state.
+          await this.loadPage({ silent: true });
         }
       } catch (error) {
         console.error("failed to delete block:", error);
@@ -4057,6 +4059,14 @@ const Page = {
             <!-- Daily Note Header -->
             <div v-if="isDaily" class="daily-note-title current-note page-header-flex">
               <div class="daily-nav">
+                <button
+                  type="button"
+                  class="page-favorite-toggle"
+                  :class="{ 'is-favorited': isFavorited }"
+                  @click="toggleFavorited"
+                  :title="isFavorited ? 'Remove from favorites' : 'Add to favorites'"
+                  :aria-pressed="isFavorited"
+                >{{ isFavorited ? '★' : '☆' }}</button>
                 <a
                   :href="prevDayUrl"
                   class="daily-nav-btn"
@@ -4064,14 +4074,6 @@ const Page = {
                   aria-label="Go to previous day"
                 >‹</a>
                 <div class="title-left" @click="openDatePicker">
-                  <button
-                    type="button"
-                    class="page-favorite-toggle"
-                    :class="{ 'is-favorited': isFavorited }"
-                    @click="toggleFavorited"
-                    :title="isFavorited ? 'Remove from favorites' : 'Add to favorites'"
-                    :aria-pressed="isFavorited"
-                  >{{ isFavorited ? '★' : '☆' }}</button>
                   <input
                     ref="dateInput"
                     type="date"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -120,6 +120,12 @@ const Page = {
       shareModalOpen: false,
       shareSavingMode: null,
       shareLinkCopied: false,
+      // Block drag-and-drop (issue #133 follow-up). blockDrag holds the
+      // dragged uuid set while a drag is live; blockDropTarget is
+      // {uuid, zone} for the row under the pointer, where zone is
+      // 'before' | 'after' (sibling insert) or 'child' (nest under).
+      blockDrag: null,
+      blockDropTarget: null,
     };
   },
 
@@ -1252,6 +1258,196 @@ const Page = {
           "error"
         );
       }
+    },
+
+    async openMoveUnderPicker(block) {
+      // "Move under…": pick any block (on any page) and nest this
+      // block + its subtree as that block's last child. Complements
+      // openMovePagePicker, which can only drop at a page's root.
+      if (!window.appModals?.pickBlock) {
+        console.error("appModals.pickBlock is not available");
+        return;
+      }
+      const target = await window.appModals.pickBlock({
+        title: "move under block",
+        message: "the block (and its children) will nest under the pick:",
+        placeholder: "search block content…",
+        confirmLabel: "move",
+        excludeUuids: [block.uuid],
+      });
+      if (!target || !block) return;
+
+      try {
+        if (block.isEditing) {
+          await this.updateBlock(block, block.content, true);
+        }
+
+        const result = await window.apiService.moveBlockToPage(
+          block.uuid,
+          null,
+          target.uuid
+        );
+
+        if (!result.success) {
+          throw new Error(
+            result.errors?.non_field_errors?.[0] || "move failed"
+          );
+        }
+
+        const targetTitle = result.data?.target_page?.title || "page";
+        this.$parent?.addToast?.(
+          result.data?.moved
+            ? `moved block under "${this.truncateForToast(target.content)}" on ${targetTitle}`
+            : result.data?.message || "block already there",
+          result.data?.moved ? "success" : "info"
+        );
+
+        this.broadcastBlockChanged(block.uuid);
+        await this.loadPage({ silent: true });
+      } catch (error) {
+        console.error("failed to move block under target:", error);
+        this.$parent?.addToast?.(
+          `failed to move block: ${error.message || error}`,
+          "error"
+        );
+      }
+    },
+
+    truncateForToast(text, max = 40) {
+      const t = (text || "").trim();
+      return t.length > max ? `${t.slice(0, max)}…` : t || "(empty block)";
+    },
+
+    // ── Block drag-and-drop ─────────────────────────────────────────
+    // Desktop-only (HTML5 drag events don't fire on touch; mobile has
+    // the "move under…" picker instead). Dragging a block that's part
+    // of the current selection moves the whole selection.
+
+    onMoveDragStart(block, event) {
+      const uuids =
+        this.selectionMode && this.selectedBlockUuids.has(block.uuid)
+          ? [...this.selectedBlockUuids]
+          : [block.uuid];
+      this.blockDrag = { uuids: new Set(uuids) };
+      this.blockDropTarget = null;
+      if (event.dataTransfer) {
+        event.dataTransfer.effectAllowed = "move";
+        // Firefox refuses to start a drag with no data attached.
+        event.dataTransfer.setData("text/plain", block.uuid);
+      }
+    },
+
+    onMoveDragOver(block, event) {
+      if (!this.blockDrag) return; // not a block drag (e.g. an OS file)
+      if (this._dropForbidden(block)) {
+        this.blockDropTarget = null;
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+      const rect = event.currentTarget.getBoundingClientRect();
+      const ratio = (event.clientY - rect.top) / Math.max(rect.height, 1);
+      const zone = ratio < 0.3 ? "before" : ratio > 0.7 ? "after" : "child";
+      const current = this.blockDropTarget;
+      if (!current || current.uuid !== block.uuid || current.zone !== zone) {
+        this.blockDropTarget = { uuid: block.uuid, zone };
+      }
+    },
+
+    async onMoveDrop(block, event) {
+      if (!this.blockDrag) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const target = this.blockDropTarget;
+      const forbidden = this._dropForbidden(block);
+      const movers = this._draggedTopBlocks();
+      this.blockDrag = null;
+      this.blockDropTarget = null;
+      if (forbidden || !target || target.uuid !== block.uuid || !movers.length)
+        return;
+
+      try {
+        if (target.zone === "child") {
+          // Nest under the target row as its last children, in order.
+          for (const mover of movers) {
+            const result = await window.apiService.moveBlockToPage(
+              mover.uuid,
+              null,
+              block.uuid
+            );
+            if (!result.success) {
+              throw new Error(
+                result.errors?.non_field_errors?.[0] || "move failed"
+              );
+            }
+          }
+        } else {
+          // Insert as siblings before/after the target within its
+          // parent: shift the later siblings out of the way, then
+          // point each mover at the freed slots.
+          const parentUuid = block.parent ? block.parent.uuid : null;
+          const siblings = block.parent
+            ? block.parent.children
+            : this.directBlocks;
+          const moverUuids = new Set(movers.map((m) => m.uuid));
+          const insertOrder =
+            target.zone === "before" ? block.order : block.order + 1;
+          const shifts = siblings
+            .filter((b) => !moverUuids.has(b.uuid) && b.order >= insertOrder)
+            .map((b) => ({ uuid: b.uuid, order: b.order + movers.length }));
+          if (shifts.length) {
+            const reorder = await window.apiService.reorderBlocks(shifts);
+            if (!reorder.success) throw new Error("failed to reorder siblings");
+          }
+          for (let i = 0; i < movers.length; i++) {
+            const result = await window.apiService.updateBlock(movers[i].uuid, {
+              parent: parentUuid,
+              order: insertOrder + i,
+            });
+            if (!result.success) throw new Error("failed to move block");
+          }
+        }
+        this.clearBlockSelection();
+        movers.forEach((m) => this.broadcastBlockChanged(m.uuid));
+        await this.loadPage({ silent: true });
+      } catch (error) {
+        console.error("block drop failed:", error);
+        this.$parent?.addToast?.(
+          `failed to move: ${error.message || error}`,
+          "error"
+        );
+        // Reload regardless — some of the writes may have landed.
+        await this.loadPage({ silent: true });
+      }
+    },
+
+    onMoveDragEnd() {
+      this.blockDrag = null;
+      this.blockDropTarget = null;
+    },
+
+    _dropForbidden(block) {
+      // A dragged block can't drop onto itself or anything inside its
+      // own subtree — that would detach the subtree from the tree.
+      if (!this.blockDrag) return true;
+      let current = block;
+      while (current) {
+        if (this.blockDrag.uuids.has(current.uuid)) return true;
+        current = current.parent || null;
+      }
+      return false;
+    },
+
+    _draggedTopBlocks() {
+      // Dragged blocks whose parent isn't also dragged — the top of
+      // the dragged forest, in document order. Mirrors the backend's
+      // bulk-move logic; descendants ride along with their ancestor.
+      const uuids = this.blockDrag?.uuids;
+      if (!uuids) return [];
+      return this.flattenBlockTree(this.directBlocks).filter(
+        (b) => uuids.has(b.uuid) && !(b.parent && uuids.has(b.parent.uuid))
+      );
     },
 
     onBlockContentChange(block, newContent) {
@@ -3909,6 +4105,59 @@ const Page = {
       }
     },
 
+    async bulkMoveSelectedUnder() {
+      // Bulk "move under…": nest every selected top block (and its
+      // subtree) under a picked block. The backend skips any selected
+      // block that contains the target inside its own subtree.
+      const uuids = [...this.selectedBlockUuids];
+      if (uuids.length === 0) {
+        this.$parent?.addToast?.("no blocks selected", "info");
+        return;
+      }
+      if (!window.appModals?.pickBlock) {
+        console.error("appModals.pickBlock is not available");
+        return;
+      }
+
+      const target = await window.appModals.pickBlock({
+        title: "move selected under block",
+        message: "selected blocks will nest under the pick:",
+        placeholder: "search block content…",
+        confirmLabel: "move",
+        excludeUuids: uuids,
+      });
+      if (!target) return;
+
+      try {
+        const result = await window.apiService.bulkMoveBlocksToPage(
+          uuids,
+          null,
+          target.uuid
+        );
+        if (!result || !result.success) {
+          throw new Error(
+            result?.errors?.non_field_errors?.[0] || "bulk move failed"
+          );
+        }
+        const moved = result.data?.moved_count ?? 0;
+        const targetTitle = result.data?.target_page?.title || "page";
+        this.$parent?.addToast?.(
+          moved > 0
+            ? `moved ${moved} block${moved === 1 ? "" : "s"} under "${this.truncateForToast(target.content)}" on ${targetTitle}`
+            : "selected blocks already there",
+          moved > 0 ? "success" : "info"
+        );
+        this.clearBlockSelection();
+        await this.loadPage({ silent: true });
+      } catch (error) {
+        console.error("failed to bulk-move blocks under target:", error);
+        this.$parent?.addToast?.(
+          `failed to move selected blocks: ${error.message || error}`,
+          "error"
+        );
+      }
+    },
+
     bulkScheduleSelected() {
       // Reuse the single-block schedule popover for the whole selection.
       // We snapshot the selected uuids now; the popover's save handler
@@ -4236,6 +4485,13 @@ const Page = {
               type="button"
               class="btn btn-outline selection-toolbar-action"
               :disabled="selectedBlockCount === 0"
+              @click="bulkMoveSelectedUnder"
+              title="Nest selected blocks under any block…"
+            >move under…</button>
+            <button
+              type="button"
+              class="btn btn-outline selection-toolbar-action"
+              :disabled="selectedBlockCount === 0"
               @click="bulkScheduleSelected"
               title="Schedule selected blocks (set a due date / reminder)"
             >schedule…</button>
@@ -4288,6 +4544,7 @@ const Page = {
                 :moveBlockDown="moveBlockDown"
                 :moveBlockToToday="moveBlockToToday"
                 :openMovePagePicker="openMovePagePicker"
+                :openMoveUnderPicker="openMoveUnderPicker"
                 :openBlockInfoModal="openBlockInfoModal"
                 :onBlockPaste="onBlockPaste"
                 :onBlockDrop="onBlockDrop"
@@ -4348,6 +4605,13 @@ const Page = {
                 :moveBlockDown="moveBlockDown"
                 :moveBlockToToday="moveBlockToToday"
                 :openMovePagePicker="openMovePagePicker"
+                :openMoveUnderPicker="openMoveUnderPicker"
+                :moveDraggable="true"
+                :moveDropTarget="blockDropTarget"
+                :onMoveDragStart="onMoveDragStart"
+                :onMoveDragOver="onMoveDragOver"
+                :onMoveDrop="onMoveDrop"
+                :onMoveDragEnd="onMoveDragEnd"
                 :openBlockInfoModal="openBlockInfoModal"
                 :onBlockPaste="onBlockPaste"
                 :onBlockDrop="onBlockDrop"
@@ -4359,6 +4623,7 @@ const Page = {
                 :selectedBlockCount="selectedBlockCount"
                 :bulkDeleteSelected="bulkDeleteSelected"
                 :bulkMoveSelectedToToday="bulkMoveSelectedToToday"
+                :bulkMoveSelectedUnder="bulkMoveSelectedUnder"
                 :selectionMode="selectionMode"
               />
             </template>
@@ -4403,6 +4668,7 @@ const Page = {
                 :moveBlockDown="moveBlockDown"
                 :moveBlockToToday="moveBlockToToday"
                 :openMovePagePicker="openMovePagePicker"
+                :openMoveUnderPicker="openMoveUnderPicker"
                 :openBlockInfoModal="openBlockInfoModal"
                 :onBlockPaste="onBlockPaste"
                 :onBlockDrop="onBlockDrop"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -143,14 +143,6 @@ const Page = {
       return `/knowledge/page/${this.shiftDateString(this.page.date, 1)}/`;
     },
 
-    isViewingToday() {
-      return this.isDaily && this.page?.date === this.todayDateString();
-    },
-
-    todayUrl() {
-      return `/knowledge/page/${this.todayDateString()}/`;
-    },
-
     isWhiteboard() {
       return this.page?.page_type === "whiteboard";
     },
@@ -2819,13 +2811,6 @@ const Page = {
       return `${date.getFullYear()}-${m}-${d}`;
     },
 
-    todayDateString() {
-      const today = new Date();
-      const m = String(today.getMonth() + 1).padStart(2, "0");
-      const d = String(today.getDate()).padStart(2, "0");
-      return `${today.getFullYear()}-${m}-${d}`;
-    },
-
     openDatePicker(event) {
       // Wired on .title-left so the click is captured whether the user
       // hits the date text, the input padding, or the calendar glyph
@@ -4089,12 +4074,6 @@ const Page = {
                   title="Next day"
                   aria-label="Go to next day"
                 >›</a>
-                <a
-                  v-if="!isViewingToday"
-                  :href="todayUrl"
-                  class="daily-nav-btn daily-nav-today"
-                  title="Go to today's daily note"
-                >today</a>
               </div>
               <div class="header-controls">
                 <div class="context-menu-container page-sort-container">

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -128,6 +128,29 @@ const Page = {
       return this.page?.page_type === "daily";
     },
 
+    // Prev/next daily navigation (issue #133). Real <a> hrefs so
+    // middle/cmd-click opens the adjacent day in a new tab; plain
+    // clicks ride the default navigation since the app routes with
+    // hard page loads anyway. The backend materializes missing
+    // dailies on load, so any target date is valid.
+    prevDayUrl() {
+      if (!this.isDaily || !this.page?.date) return null;
+      return `/knowledge/page/${this.shiftDateString(this.page.date, -1)}/`;
+    },
+
+    nextDayUrl() {
+      if (!this.isDaily || !this.page?.date) return null;
+      return `/knowledge/page/${this.shiftDateString(this.page.date, 1)}/`;
+    },
+
+    isViewingToday() {
+      return this.isDaily && this.page?.date === this.todayDateString();
+    },
+
+    todayUrl() {
+      return `/knowledge/page/${this.todayDateString()}/`;
+    },
+
     isWhiteboard() {
       return this.page?.page_type === "whiteboard";
     },
@@ -2783,6 +2806,24 @@ const Page = {
       }
     },
 
+    // Shift a YYYY-MM-DD string by whole days in local time. Going
+    // through a local Date (not Date.parse of the bare string, which
+    // is UTC) keeps the result aligned with the user's calendar day.
+    shiftDateString(dateStr, days) {
+      const [year, month, day] = dateStr.split("-").map(Number);
+      const date = new Date(year, month - 1, day + days);
+      const m = String(date.getMonth() + 1).padStart(2, "0");
+      const d = String(date.getDate()).padStart(2, "0");
+      return `${date.getFullYear()}-${m}-${d}`;
+    },
+
+    todayDateString() {
+      const today = new Date();
+      const m = String(today.getMonth() + 1).padStart(2, "0");
+      const d = String(today.getDate()).padStart(2, "0");
+      return `${today.getFullYear()}-${m}-${d}`;
+    },
+
     openDatePicker(event) {
       // Wired on .title-left so the click is captured whether the user
       // hits the date text, the input padding, or the calendar glyph
@@ -4015,23 +4056,43 @@ const Page = {
           <div class="page-title-container">
             <!-- Daily Note Header -->
             <div v-if="isDaily" class="daily-note-title current-note page-header-flex">
-              <div class="title-left" @click="openDatePicker">
-                <button
-                  type="button"
-                  class="page-favorite-toggle"
-                  :class="{ 'is-favorited': isFavorited }"
-                  @click="toggleFavorited"
-                  :title="isFavorited ? 'Remove from favorites' : 'Add to favorites'"
-                  :aria-pressed="isFavorited"
-                >{{ isFavorited ? '★' : '☆' }}</button>
-                <input
-                  ref="dateInput"
-                  type="date"
-                  v-model="selectedDate"
-                  @change="onDateChange"
-                  class="date-picker"
-                  title="Navigate to date"
-                />
+              <div class="daily-nav">
+                <a
+                  :href="prevDayUrl"
+                  class="daily-nav-btn"
+                  title="Previous day"
+                  aria-label="Go to previous day"
+                >‹</a>
+                <div class="title-left" @click="openDatePicker">
+                  <button
+                    type="button"
+                    class="page-favorite-toggle"
+                    :class="{ 'is-favorited': isFavorited }"
+                    @click="toggleFavorited"
+                    :title="isFavorited ? 'Remove from favorites' : 'Add to favorites'"
+                    :aria-pressed="isFavorited"
+                  >{{ isFavorited ? '★' : '☆' }}</button>
+                  <input
+                    ref="dateInput"
+                    type="date"
+                    v-model="selectedDate"
+                    @change="onDateChange"
+                    class="date-picker"
+                    title="Navigate to date"
+                  />
+                </div>
+                <a
+                  :href="nextDayUrl"
+                  class="daily-nav-btn"
+                  title="Next day"
+                  aria-label="Go to next day"
+                >›</a>
+                <a
+                  v-if="!isViewingToday"
+                  :href="todayUrl"
+                  class="daily-nav-btn daily-nav-today"
+                  title="Go to today's daily note"
+                >today</a>
               </div>
               <div class="header-controls">
                 <div class="context-menu-container page-sort-container">

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/PagesListPage.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/PagesListPage.js
@@ -1,0 +1,266 @@
+/**
+ * PagesListPage — browsable list of every page the user owns
+ * (issue #133).
+ *
+ * Route: /knowledge/pages/ (SPA shell catches the path; app.js mounts
+ * this component for currentView === 'pages').
+ *
+ * The list is server-paginated through the existing
+ * /knowledge/api/pages/list/ endpoint (max 100 per fetch, "load more"
+ * appends) with page_type filter tabs and an order select. Typing in
+ * the search box switches to /knowledge/api/pages/search/ — a
+ * title/slug match capped at 20 rows, which is plenty for narrowing.
+ */
+const PagesListPage = {
+  data() {
+    return {
+      loading: true,
+      loadingMore: false,
+      error: null,
+      pages: [],
+      totalCount: 0,
+      hasMore: false,
+
+      // "all" is a UI-only sentinel — it maps to omitting page_type.
+      typeFilter: "all",
+      orderBy: "modified",
+      searchQuery: "",
+      searchTimeout: null,
+      // Bumped per load so a stale response (user changed filters
+      // while a fetch was in flight) can't clobber newer results.
+      requestSeq: 0,
+    };
+  },
+
+  computed: {
+    typeFilters() {
+      return [
+        { id: "all", label: "all" },
+        { id: "page", label: "pages" },
+        { id: "daily", label: "dailies" },
+        { id: "whiteboard", label: "whiteboards" },
+        { id: "template", label: "templates" },
+      ];
+    },
+
+    orderOptions() {
+      return [
+        { id: "modified", label: "recently modified" },
+        { id: "title", label: "title" },
+        { id: "date", label: "date" },
+      ];
+    },
+
+    isSearching() {
+      return this.searchQuery.trim().length > 0;
+    },
+
+    countLabel() {
+      if (this.loading) return "";
+      if (this.isSearching) {
+        return `${this.pages.length} match${this.pages.length === 1 ? "" : "es"}`;
+      }
+      return `${this.totalCount} page${this.totalCount === 1 ? "" : "s"}`;
+    },
+  },
+
+  async mounted() {
+    await this.reload();
+  },
+
+  beforeUnmount() {
+    if (this.searchTimeout) clearTimeout(this.searchTimeout);
+  },
+
+  methods: {
+    pageUrl(page) {
+      return `/knowledge/page/${encodeURIComponent(page.slug)}/`;
+    },
+
+    displayTitle(page) {
+      return page.title || "untitled page";
+    },
+
+    formatModified(page) {
+      if (!page.modified_at) return "";
+      const d = new Date(page.modified_at);
+      if (isNaN(d.getTime())) return "";
+      return d.toLocaleDateString();
+    },
+
+    setTypeFilter(id) {
+      if (this.typeFilter === id) return;
+      this.typeFilter = id;
+      // "date" ordering is the natural default for a dailies-only
+      // list; snap to it unless the user is mid-search (search
+      // results have their own relevance ordering).
+      if (id === "daily" && this.orderBy === "modified") {
+        this.orderBy = "date";
+      }
+      this.reload();
+    },
+
+    onOrderChange() {
+      this.reload();
+    },
+
+    onSearchInput() {
+      if (this.searchTimeout) clearTimeout(this.searchTimeout);
+      this.searchTimeout = setTimeout(() => this.reload(), 300);
+    },
+
+    clearSearch() {
+      this.searchQuery = "";
+      this.reload();
+    },
+
+    async reload() {
+      this.loading = true;
+      this.error = null;
+      const seq = ++this.requestSeq;
+      try {
+        const result = this.isSearching
+          ? await this._fetchSearch()
+          : await this._fetchList(0);
+        if (seq !== this.requestSeq) return;
+        if (result && result.success) {
+          this.pages = result.data.pages || [];
+          this.totalCount = result.data.total_count || this.pages.length;
+          this.hasMore = !this.isSearching && !!result.data.has_more;
+        } else {
+          this.error = "failed to load pages";
+        }
+      } catch (err) {
+        if (seq !== this.requestSeq) return;
+        console.error("PagesListPage load failed:", err);
+        this.error = "failed to load pages";
+      } finally {
+        if (seq === this.requestSeq) this.loading = false;
+      }
+    },
+
+    async loadMore() {
+      if (this.loadingMore || !this.hasMore || this.isSearching) return;
+      this.loadingMore = true;
+      const seq = ++this.requestSeq;
+      try {
+        const result = await this._fetchList(this.pages.length);
+        if (seq !== this.requestSeq) return;
+        if (result && result.success) {
+          this.pages = this.pages.concat(result.data.pages || []);
+          this.totalCount = result.data.total_count || this.totalCount;
+          this.hasMore = !!result.data.has_more;
+        } else {
+          this.error = "failed to load more pages";
+        }
+      } catch (err) {
+        if (seq !== this.requestSeq) return;
+        console.error("PagesListPage loadMore failed:", err);
+        this.error = "failed to load more pages";
+      } finally {
+        this.loadingMore = false;
+      }
+    },
+
+    _fetchList(offset) {
+      const pageType = this.typeFilter === "all" ? null : this.typeFilter;
+      // published_only=false — this surface's whole point is "the
+      // full list", so unpublished pages are included too.
+      return window.apiService.getPages(
+        false,
+        100,
+        offset,
+        pageType,
+        this.orderBy
+      );
+    },
+
+    _fetchSearch() {
+      const pageType = this.typeFilter === "all" ? null : this.typeFilter;
+      return window.apiService.searchPages(
+        this.searchQuery.trim(),
+        20,
+        pageType
+      );
+    },
+  },
+
+  template: `
+    <div class="pages-list-page">
+      <div class="pages-list-header">
+        <h1>all pages</h1>
+        <span class="pages-list-count">{{ countLabel }}</span>
+      </div>
+
+      <div class="pages-list-controls">
+        <div class="pages-list-search">
+          <input
+            v-model="searchQuery"
+            @input="onSearchInput"
+            type="text"
+            class="pages-list-search-input"
+            placeholder="filter by title…"
+            aria-label="Filter pages by title"
+          />
+          <button
+            v-if="isSearching"
+            type="button"
+            class="pages-list-search-clear"
+            @click="clearSearch"
+            title="Clear filter"
+            aria-label="Clear filter"
+          >×</button>
+        </div>
+        <div class="pages-list-type-filters" role="group" aria-label="Filter by page type">
+          <button
+            v-for="f in typeFilters"
+            :key="f.id"
+            type="button"
+            class="pages-list-type-btn"
+            :class="{ 'is-active': typeFilter === f.id }"
+            @click="setTypeFilter(f.id)"
+          >{{ f.label }}</button>
+        </div>
+        <label class="pages-list-order">
+          <span class="pages-list-order-label">sort</span>
+          <select v-model="orderBy" @change="onOrderChange" :disabled="isSearching">
+            <option v-for="o in orderOptions" :key="o.id" :value="o.id">{{ o.label }}</option>
+          </select>
+        </label>
+      </div>
+
+      <div v-if="loading" class="loading">Loading pages…</div>
+      <div v-else-if="error" class="form-error">{{ error }}</div>
+      <div v-else-if="!pages.length" class="empty-state">
+        <span v-if="isSearching">No pages match "{{ searchQuery.trim() }}".</span>
+        <span v-else>No pages yet.</span>
+      </div>
+
+      <ul v-else class="pages-list">
+        <li v-for="page in pages" :key="page.uuid">
+          <a :href="pageUrl(page)" class="pages-list-row">
+            <span class="pages-list-title">
+              <span v-if="page.favorited" class="pages-list-star" aria-hidden="true">★</span>
+              {{ displayTitle(page) }}
+            </span>
+            <span class="pages-list-meta">
+              <span class="page-type-badge">{{ page.page_type }}</span>
+              <span class="pages-list-modified" :title="'last modified ' + formatModified(page)">{{ formatModified(page) }}</span>
+            </span>
+          </a>
+        </li>
+      </ul>
+
+      <div v-if="!loading && hasMore" class="pages-list-more">
+        <button
+          type="button"
+          class="btn"
+          @click="loadMore"
+          :disabled="loadingMore"
+        >{{ loadingMore ? "loading…" : "load more" }}</button>
+      </div>
+    </div>
+  `,
+};
+
+window.PagesListPage = PagesListPage;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
@@ -205,7 +205,12 @@ window.QueryEmbedBlock = {
       // the matched rows. Expanding later triggers a full fetch (see the
       // collapsed watcher).
       const countOnly = this.collapsed;
-      this.loading = true;
+      // Stale-while-refresh: when rows are already on screen, keep them
+      // during the refetch instead of flipping to "Loading…". Blanking
+      // collapses the embed's height for the round-trip, which made the
+      // whole page jump every time a block was toggled anywhere.
+      const isRefresh = !countOnly && this.detailLoaded && !!this.result;
+      if (!isRefresh) this.loading = true;
       try {
         const r = await window.apiService.runSavedView({
           uuid: this.savedView.uuid,

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -166,10 +166,12 @@ class ApiService {
     publishedOnly = true,
     limit = 10,
     offset = 0,
-    pageType = null
+    pageType = null,
+    orderBy = null
   ) {
     let url = `/knowledge/api/pages/list/?published_only=${publishedOnly}&limit=${limit}&offset=${offset}`;
     if (pageType) url += `&page_type=${encodeURIComponent(pageType)}`;
+    if (orderBy) url += `&order_by=${encodeURIComponent(orderBy)}`;
     return await this.request(url);
   }
 

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -331,10 +331,16 @@ class ApiService {
     });
   }
 
-  async moveBlockToPage(blockUuid, targetPageUuid) {
+  async moveBlockToPage(blockUuid, targetPageUuid, targetParentUuid = null) {
+    // targetParentUuid nests the block under an existing block (the
+    // "move under…" flow); the backend derives the page from it, so
+    // targetPageUuid may be null in that case.
+    const body = { block: blockUuid };
+    if (targetPageUuid) body.target_page = targetPageUuid;
+    if (targetParentUuid) body.target_parent = targetParentUuid;
     return await this.request("/knowledge/api/blocks/move-to-page/", {
       method: "POST",
-      body: JSON.stringify({ block: blockUuid, target_page: targetPageUuid }),
+      body: JSON.stringify(body),
       headers: {
         "Content-Type": "application/json",
       },
@@ -365,13 +371,17 @@ class ApiService {
     });
   }
 
-  async bulkMoveBlocksToPage(blockUuids, targetPageUuid) {
+  async bulkMoveBlocksToPage(
+    blockUuids,
+    targetPageUuid,
+    targetParentUuid = null
+  ) {
+    const body = { blocks: blockUuids };
+    if (targetPageUuid) body.target_page = targetPageUuid;
+    if (targetParentUuid) body.target_parent = targetParentUuid;
     return await this.request("/knowledge/api/blocks/bulk-move-to-page/", {
       method: "POST",
-      body: JSON.stringify({
-        blocks: blockUuids,
-        target_page: targetPageUuid,
-      }),
+      body: JSON.stringify(body),
       headers: {
         "Content-Type": "application/json",
       },

--- a/packages/django-app/app/knowledge/templates/knowledge/base.html
+++ b/packages/django-app/app/knowledge/templates/knowledge/base.html
@@ -90,6 +90,7 @@
     <script src="{% static 'knowledge/js/components/SpotlightSearch.js' %}?v={{ STATIC_VERSION }}"></script>
     <script src="{% static 'knowledge/js/components/GraphView.js' %}?v={{ STATIC_VERSION }}"></script>
     <script src="{% static 'knowledge/js/components/SavedViewsPage.js' %}?v={{ STATIC_VERSION }}"></script>
+    <script src="{% static 'knowledge/js/components/PagesListPage.js' %}?v={{ STATIC_VERSION }}"></script>
 
     <!-- Main App -->
     <script src="{% static 'knowledge/js/app.js' %}?v={{ STATIC_VERSION }}"></script>

--- a/packages/django-app/app/knowledge/test/commands/test_bulk_move_blocks_to_page_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_bulk_move_blocks_to_page_command.py
@@ -141,3 +141,69 @@ class TestBulkMoveBlocksToPageCommand(TestCase):
         result = BulkMoveBlocksToPageCommand(form).execute()
         self.assertEqual(result["moved_count"], 0)
         self.assertEqual(result["skipped_count"], 0)
+
+
+class TestBulkMoveBlocksToPageWithTargetParent(TestCase):
+    """Bulk "move under…": every selected top block nests under the
+    target parent; intra-selection hierarchy is preserved."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.source_page = PageFactory(user=cls.user, title="Daily", slug="2026-01-02")
+        cls.target_page = PageFactory(user=cls.user, title="Project", slug="project-b")
+        cls.target_parent = BlockFactory(
+            user=cls.user, page=cls.target_page, content="epic", order=1
+        )
+
+    def _bulk_move(self, blocks, **extra):
+        form = BulkMoveBlocksToPageForm(
+            {
+                "user": self.user,
+                "blocks": [str(b.uuid) for b in blocks],
+                **extra,
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        return BulkMoveBlocksToPageCommand(form).execute()
+
+    def test_should_nest_selection_under_target_parent(self):
+        a = BlockFactory(user=self.user, page=self.source_page, content="a", order=1)
+        a_child = BlockFactory(
+            user=self.user, page=self.source_page, parent=a, content="a1"
+        )
+        b = BlockFactory(user=self.user, page=self.source_page, content="b", order=2)
+
+        result = self._bulk_move([a, a_child, b], target_parent=self.target_parent.uuid)
+
+        self.assertEqual(result["moved_count"], 2)  # a + b; a1 rides along
+        for blk in (a, a_child, b):
+            blk.refresh_from_db()
+        self.assertEqual(a.parent_id, self.target_parent.id)
+        self.assertEqual(b.parent_id, self.target_parent.id)
+        self.assertEqual(a_child.parent_id, a.id)
+        self.assertEqual(a_child.page_id, self.target_page.id)
+        # Relative order preserved under the new parent.
+        self.assertLess(a.order, b.order)
+
+    def test_should_skip_block_containing_target_parent(self):
+        # Selecting an ancestor of the target parent must not nuke the
+        # tree — that block is skipped, others still move.
+        container = BlockFactory(
+            user=self.user, page=self.target_page, content="container", order=2
+        )
+        nested_parent = BlockFactory(
+            user=self.user, page=self.target_page, parent=container, content="nest"
+        )
+        mover = BlockFactory(
+            user=self.user, page=self.source_page, content="mover", order=1
+        )
+
+        result = self._bulk_move([container, mover], target_parent=nested_parent.uuid)
+
+        self.assertEqual(result["moved_count"], 1)
+        self.assertEqual(result["skipped_count"], 1)
+        container.refresh_from_db()
+        mover.refresh_from_db()
+        self.assertIsNone(container.parent_id)
+        self.assertEqual(mover.parent_id, nested_parent.id)

--- a/packages/django-app/app/knowledge/test/commands/test_get_user_pages_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_get_user_pages_command.py
@@ -1,0 +1,116 @@
+from datetime import date, datetime
+
+import pytz
+from django.test import TestCase
+
+from knowledge.commands import GetUserPagesCommand
+from knowledge.forms import GetUserPagesForm
+from knowledge.models import Page
+
+from ..helpers import PageFactory, UserFactory
+
+
+def _set_modified(page: Page, when: datetime) -> None:
+    """Set modified_at explicitly; .update() bypasses auto_now."""
+    Page.objects.filter(pk=page.pk).update(modified_at=when)
+
+
+def _utc(*args: int) -> datetime:
+    return pytz.UTC.localize(datetime(*args))
+
+
+class TestGetUserPagesCommand(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.other_user = UserFactory()
+
+        cls.page_old = PageFactory(user=cls.user, title="Alpha", slug="alpha")
+        cls.page_new = PageFactory(user=cls.user, title="Zulu", slug="zulu")
+        cls.daily_old = PageFactory(
+            user=cls.user,
+            title="2026-06-01",
+            slug="2026-06-01",
+            page_type="daily",
+            date=date(2026, 6, 1),
+        )
+        cls.daily_new = PageFactory(
+            user=cls.user,
+            title="2026-06-15",
+            slug="2026-06-15",
+            page_type="daily",
+            date=date(2026, 6, 15),
+        )
+        cls.other_page = PageFactory(user=cls.other_user, title="Stranger")
+
+        _set_modified(cls.page_old, _utc(2026, 6, 1))
+        _set_modified(cls.page_new, _utc(2026, 6, 20))
+        # The old daily was touched most recently — distinguishes
+        # "date" ordering from "modified" ordering in the tests below.
+        _set_modified(cls.daily_old, _utc(2026, 6, 25))
+        _set_modified(cls.daily_new, _utc(2026, 6, 10))
+
+    def _run(self, **params):
+        data = {"user": self.user.id, **params}
+        form = GetUserPagesForm(data)
+        return GetUserPagesCommand(form).execute()
+
+    def _slugs(self, result):
+        return [p.slug for p in result["pages"]]
+
+    def test_should_default_to_recently_modified_ordering(self):
+        result = self._run()
+        self.assertEqual(
+            self._slugs(result),
+            ["2026-06-01", "zulu", "2026-06-15", "alpha"],
+        )
+        self.assertEqual(result["total_count"], 4)
+        self.assertFalse(result["has_more"])
+
+    def test_should_order_by_title(self):
+        result = self._run(order_by="title")
+        self.assertEqual(
+            self._slugs(result),
+            ["2026-06-01", "2026-06-15", "alpha", "zulu"],
+        )
+
+    def test_should_order_by_date_with_undated_pages_last(self):
+        result = self._run(order_by="date")
+        self.assertEqual(
+            self._slugs(result),
+            ["2026-06-15", "2026-06-01", "zulu", "alpha"],
+        )
+
+    def test_should_reject_unknown_order_by(self):
+        form = GetUserPagesForm({"user": self.user.id, "order_by": "bogus"})
+        self.assertFalse(form.is_valid())
+        self.assertIn("order_by", form.errors)
+
+    def test_should_filter_by_page_type(self):
+        result = self._run(page_type="daily")
+        self.assertEqual(set(self._slugs(result)), {"2026-06-01", "2026-06-15"})
+        self.assertEqual(result["total_count"], 2)
+
+    def test_should_paginate_with_has_more(self):
+        first = self._run(limit=3, offset=0)
+        self.assertEqual(len(first["pages"]), 3)
+        self.assertTrue(first["has_more"])
+
+        rest = self._run(limit=3, offset=3)
+        self.assertEqual(len(rest["pages"]), 1)
+        self.assertFalse(rest["has_more"])
+        self.assertEqual(rest["total_count"], 4)
+
+    def test_should_filter_unpublished_when_published_only(self):
+        unpublished = PageFactory(
+            user=self.user, title="Draft", slug="draft", is_published=False
+        )
+        result = self._run(published_only="true")
+        self.assertNotIn(unpublished.slug, self._slugs(result))
+
+        result_all = self._run(published_only="false")
+        self.assertIn(unpublished.slug, self._slugs(result_all))
+
+    def test_should_not_leak_other_users_pages(self):
+        result = self._run(limit=100)
+        self.assertNotIn(self.other_page.slug, self._slugs(result))

--- a/packages/django-app/app/knowledge/test/commands/test_move_block_to_page_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_move_block_to_page_command.py
@@ -169,3 +169,126 @@ class TestMoveBlockToPageCommand(TestCase):
         self.assertIsNone(child.parent_id)
         self.assertEqual(child.page_id, target_page.id)
         self.assertEqual(parent.page_id, source_page.id)
+
+
+class TestMoveBlockToPageWithTargetParent(TestCase):
+    """target_parent nests the moved subtree under an existing block
+    (the "move under…" flow) instead of promoting it to page root."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.source_page = PageFactory(user=cls.user, title="Daily", slug="2026-01-01")
+        cls.target_page = PageFactory(user=cls.user, title="Project", slug="project")
+        cls.target_parent = BlockFactory(
+            user=cls.user, page=cls.target_page, content="epic", order=1
+        )
+
+    def _move(self, block, **extra):
+        form = MoveBlockToPageForm({"user": self.user, "block": block.uuid, **extra})
+        self.assertTrue(form.is_valid(), form.errors)
+        return MoveBlockToPageCommand(form).execute()
+
+    def test_should_nest_block_under_target_parent(self):
+        block = BlockFactory(
+            user=self.user, page=self.source_page, content="todo", order=1
+        )
+        child = BlockFactory(
+            user=self.user, page=self.source_page, parent=block, content="sub"
+        )
+
+        result = self._move(block, target_parent=self.target_parent.uuid)
+
+        self.assertTrue(result["moved"])
+        block.refresh_from_db()
+        child.refresh_from_db()
+        self.assertEqual(block.page_id, self.target_page.id)
+        self.assertEqual(block.parent_id, self.target_parent.id)
+        # Descendants follow to the target page but keep their nesting.
+        self.assertEqual(child.page_id, self.target_page.id)
+        self.assertEqual(child.parent_id, block.id)
+
+    def test_should_derive_target_page_from_parent_when_omitted(self):
+        block = BlockFactory(user=self.user, page=self.source_page, content="x")
+
+        result = self._move(block, target_parent=self.target_parent.uuid)
+
+        self.assertEqual(result["target_page"]["slug"], "project")
+
+    def test_should_order_after_existing_children_of_parent(self):
+        BlockFactory(
+            user=self.user,
+            page=self.target_page,
+            parent=self.target_parent,
+            content="existing child",
+            order=5,
+        )
+        block = BlockFactory(user=self.user, page=self.source_page, content="x")
+
+        self._move(block, target_parent=self.target_parent.uuid)
+
+        block.refresh_from_db()
+        self.assertEqual(block.parent_id, self.target_parent.id)
+        self.assertEqual(block.order, 6)
+
+    def test_should_renest_within_same_page(self):
+        sibling = BlockFactory(
+            user=self.user, page=self.target_page, content="stray", order=9
+        )
+
+        self._move(sibling, target_parent=self.target_parent.uuid)
+
+        sibling.refresh_from_db()
+        self.assertEqual(sibling.page_id, self.target_page.id)
+        self.assertEqual(sibling.parent_id, self.target_parent.id)
+
+    def test_should_reject_move_under_own_descendant(self):
+        from django.core.exceptions import ValidationError
+
+        block = BlockFactory(user=self.user, page=self.source_page, content="root")
+        child = BlockFactory(
+            user=self.user, page=self.source_page, parent=block, content="child"
+        )
+
+        with self.assertRaises(ValidationError):
+            self._move(block, target_parent=child.uuid)
+
+    def test_should_reject_mismatched_page_and_parent(self):
+        other_page = PageFactory(user=self.user, title="Other", slug="other")
+        block = BlockFactory(user=self.user, page=self.source_page, content="x")
+
+        form = MoveBlockToPageForm(
+            {
+                "user": self.user,
+                "block": block.uuid,
+                "target_page": other_page.uuid,
+                "target_parent": self.target_parent.uuid,
+            }
+        )
+        self.assertFalse(form.is_valid())
+
+    def test_should_reject_target_parent_from_other_user(self):
+        other_user = UserFactory()
+        other_block = BlockFactory(user=other_user, content="theirs")
+        block = BlockFactory(user=self.user, page=self.source_page, content="x")
+
+        form = MoveBlockToPageForm(
+            {
+                "user": self.user,
+                "block": block.uuid,
+                "target_parent": other_block.uuid,
+            }
+        )
+        self.assertFalse(form.is_valid())
+
+    def test_should_be_noop_when_already_under_target_parent(self):
+        block = BlockFactory(
+            user=self.user,
+            page=self.target_page,
+            parent=self.target_parent,
+            content="already here",
+        )
+
+        result = self._move(block, target_parent=self.target_parent.uuid)
+
+        self.assertFalse(result["moved"])

--- a/packages/django-app/app/knowledge/test/commands/test_update_block_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_update_block_command.py
@@ -566,3 +566,45 @@ class TestUpdateBlockCommand(TestCase):
         self.block.refresh_from_db()
         self.assertEqual(self.block.properties.get("priority"), "high")
         self.assertEqual(self.block.properties.get("size"), {"width": 180})
+
+    def test_should_preserve_parent_on_properties_only_update(self):
+        """A partial update that omits `parent` (e.g. the image resize
+        handle persisting `properties.size`) must leave nesting alone.
+        The command used to re-root the block whenever the key was
+        missing, which silently flattened nested blocks on every
+        properties-only save."""
+        parent = BlockFactory(page=self.page, user=self.user)
+        child = BlockFactory(page=self.page, user=self.user, parent=parent)
+
+        form = UpdateBlockForm(
+            {
+                "user": self.user.id,
+                "block": str(child.uuid),
+                "properties": {"size": {"width": 320}},
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        UpdateBlockCommand(form).execute()
+
+        child.refresh_from_db()
+        self.assertEqual(child.parent_id, parent.id)
+        self.assertEqual(child.properties.get("size"), {"width": 320})
+
+    def test_should_clear_parent_on_explicit_null(self):
+        """Submitting `parent: null` is still the outdent path — the
+        omitted-key behavior above must not swallow explicit clears."""
+        parent = BlockFactory(page=self.page, user=self.user)
+        child = BlockFactory(page=self.page, user=self.user, parent=parent)
+
+        form = UpdateBlockForm(
+            {
+                "user": self.user.id,
+                "block": str(child.uuid),
+                "parent": None,
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        UpdateBlockCommand(form).execute()
+
+        child.refresh_from_db()
+        self.assertIsNone(child.parent_id)

--- a/packages/django-app/app/knowledge/urls.py
+++ b/packages/django-app/app/knowledge/urls.py
@@ -145,4 +145,7 @@ urlpatterns = [
     # the SavedViewPage component based on the slug).
     path("views/", views.index, name="views_index"),
     path("views/<str:slug>/", views.index, name="views_detail"),
+    # All-pages browser (issue #133) — SPA shell again; app.js mounts
+    # PagesListPage for this path.
+    path("pages/", views.index, name="pages_index"),
 ]


### PR DESCRIPTION
Closes #133

Adds prev/next day links (plus a "today" shortcut) around the daily header's date picker, and a new All Pages browser at `/knowledge/pages/` — type filter tabs, sort by modified/title/date, debounced title search, and load-more pagination — reachable from the left nav and spotlight. The pages list API gains `order_by`, with `GetUserPagesCommand` now routed through `PageRepository.get_user_pages`.

Also fixes image/diagram resize not persisting on nested blocks: the recursive block render never passed `setBlockProperties` down (saves were silent no-ops), and ancestor blocks stomped a nested block's applied width because resize queries spanned the whole subtree. `UpdateBlockCommand` now only touches `parent` when the key is submitted, so properties-only saves can't flatten nesting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYJZt3QFjDY99YPxF3y8eg