### PR TITLE
Rewrite README with product-focused narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,142 @@
 # Brainspread
 
-A web-based knowledge management system with hierarchical note-taking, daily journaling, and AI chat integration.
+A networked note-taking app I built for myself. It steals its two best ideas
+from elsewhere: from Logseq, the daily page — open the app and start typing,
+no folders, no "where should this go"; and from zettelkasten practice, tags
+as the organizing principle — tag things as you capture them, sort them into
+their proper pages later, if ever. It also speaks MCP, so Claude Code can
+work inside your notes.
 
 ![Brainspread screenshot](docs/images/screenshot2.png)
 
-## Features
+## Why
 
-### Knowledge Management
+Every notes system I've used dies the same way: the friction of deciding
+where a note belongs is just high enough that I stop writing notes. So in
+Brainspread everything lands in the same place — today's daily page, which
+already exists the moment you open the app. You write, you hit enter, you
+move on.
 
-- **Hierarchical notes** — create and organize deeply nested blocks of content, so ideas can live at whatever depth they belong.
-- **Daily notes** — every day gets its own page automatically, ready for journaling, standups, and task capture.
-- **TODO management** — built-in todos with the ability to roll undone items forward to the next day so nothing gets dropped.
-- **Pages and blocks** — flexible content model where pages contain nested blocks, giving you outlines, docs, and scratchpads in one place.
-- **Historical view** — browse past daily notes to revisit decisions, track progress, and see how thinking evolved over time.
+Organization happens through tags, and a tag here is just a page. Typing
+`#strength-training` in a block makes that block a member of the
+strength-training page; open the page and the block is there, alongside
+everything else you've tagged over the weeks. When a topic accumulates
+enough strays you can select them and move them onto the page for real.
+Organizing becomes a batch job you run when you're in the mood, not a tax
+you pay on every thought. `[[Wiki links]]` and backlinks tie the rest of the
+graph together.
 
-### AI Integration
+Beyond capture, the app is built around a few things I actually want from a
+tool like this:
 
-- **Multi-provider support** — works with OpenAI, Anthropic, and Google AI out of the box.
-- **Chat interface** — a built-in chat with persistent conversation history, right next to your notes.
-- **Configurable models** — pick the model per provider to match the task (fast vs. smart, cheap vs. capable).
-- **Agentic note tools** — the assistant can search, read, create, edit, reorder, and move pages and blocks directly in your knowledge base via tool calls.
-- **Web search** — the assistant can pull in fresh information from the web when your notes alone aren't enough.
-- **Approval flow for writes** — destructive or create/edit operations pause for your confirmation before they run, with an opt-in to auto-approve note writes when you want to move fast.
+- as little friction as possible when writing something down
+- something that keeps me on track, and can nudge me if I ask it to
+- a way to loop forgotten things back into my life instead of letting them
+  rot below the fold
+- a way to automate the stuff I do repeatedly
 
-### User Experience
+## The pieces
 
-- **Modern web interface** — clean, responsive UI built with vanilla JavaScript — no framework tax.
-- **Real-time interactions** — dynamic updates without full page refreshes.
-- **User authentication** — secure accounts with customizable themes and timezones.
-- **Settings management** — configure AI providers, preferences, and personalization from one place.
+### Blocks, todos, and days
 
-## Quick Start
+Everything is a block in a nested outline. Blocks can be plain bullets,
+todos (`todo` → `doing` → `done`, plus `later` and `wontdo`), headings,
+quotes, code, images, files. Every day gets its own page automatically, and
+past dailies stay browsable, so the app doubles as a journal.
 
-Prerequisites: [Docker](https://docs.docker.com/get-docker/) and [Just](https://github.com/casey/just).
+### Scheduling, rollover, and reminders
+
+Scheduling a block gives it a due date without moving it — it stays where
+you wrote it and *surfaces* on the daily page for that date. Anything that
+slips shows up in the built-in Overdue view, and undone todos can be rolled
+forward onto today so nothing silently disappears into last Tuesday.
+
+Reminders are the louder version: attach a time to a block and a scheduler
+delivers it to Discord, with a mention so it hits your phone. The message
+carries action links — mark done, mark doing, move to today, snooze for
+15m/30m/1h/1d — so you can deal with a reminder from the notification
+without opening the app. This is the "loop things back into my life" part,
+and it's the feature I'd keep if I had to throw out everything else.
+
+### Saved views
+
+Saved views are queries over your blocks: filter by block type, tags, due or
+completed dates, `key:: value` properties, or content, combined with
+and/or/not. Pin a view to the sidebar, or embed it directly on a page so its
+results render inline. Embeds can also be pinned to "the daily page" as a
+concept, so a *what's due today* embed follows you from day to day. Two
+views ship out of the box: Overdue and Done this week.
+
+Blocks parse `key:: value` lines into queryable properties, so views can
+slice on whatever structure you invent — `project:: roadmap`,
+`priority:: p1`, whatever.
+
+### Templates
+
+A template is a page whose block tree can be stamped onto any other page.
+Copies are independent (checking off a cloned todo doesn't touch the
+template), tags come along, and embedded views come along too — so a
+"morning routine" template can carry both its checklist and an open-todos
+embed in one apply.
+
+### The MCP server
+
+Brainspread exposes an MCP server at `/api/mcp/` (streamable HTTP), which
+means Claude Code — or any MCP client — can operate on your notes directly.
+This has turned out to be the integration that matters. The in-app chat is
+convenient, but pointing an actual agent at your knowledge base is a
+different thing entirely:
+
+- "what's on my plate today?"
+- "reschedule everything overdue to spread over the next week"
+- "read my dailies from last week and write a review on today's page"
+- "find my untagged workout notes and tag them #strength-training"
+
+It exposes a deliberately small surface — 16 tools covering pages, blocks,
+todos, search, scheduling, and tagging — each one a thin wrapper over the
+same commands the UI uses.
+
+Auth is the same token the web app gets when you log in (visible in the
+Django admin under Auth Tokens):
+
+```bash
+claude mcp add --transport http brainspread http://localhost:8001/api/mcp/ \
+  --header "Authorization: Token YOUR_TOKEN"
+```
+
+### The in-app chat
+
+There's also a chat panel next to your notes, with persistent history,
+bring-your-own-key support for Anthropic/OpenAI/Google, web search, and a
+larger agentic toolset with an approval gate on writes. It's useful, but
+it's not the point — every app has a chat panel now. The MCP server is the
+interesting half of the AI story.
+
+### Odds and ends
+
+Whiteboards (tldraw), web archives (save a readable copy of a link, attached
+to the block that mentions it), public share links for pages, favorites,
+a graph view, file attachments, completion stats and streaks, and a
+spotlight-style search on Cmd+Space.
+
+## Where it's headed
+
+The next big piece is automations
+([#143](https://github.com/steezeburger/brainspread/issues/143)): blocks
+tagged `#automation` whose `trigger:: / query:: / action::` properties make
+them *do* things — roll sticky todos onto today every morning, ping Discord
+every 15 minutes while a block is marked `doing` ("still on this?"), apply
+the morning-routine template on a schedule. Because automations live in the
+graph as ordinary blocks, a template containing one becomes a shareable
+automation pack. A declarative widget layer (habit heatmaps, streaks,
+countdowns) is sketched in
+[#168](https://github.com/steezeburger/brainspread/issues/168). Parts of the
+automation engine are built; it's landing in slices.
+
+## Quick start
+
+Prerequisites: [Docker](https://docs.docker.com/get-docker/) and
+[Just](https://github.com/casey/just).
 
 ```bash
 cd packages/django-app
@@ -54,30 +158,28 @@ Then open:
 - Admin: http://localhost:8001/admin/
 - Login: `admin@email.com` / `password`
 
-See [`.ai/PROJECT_SETUP.md`](.ai/PROJECT_SETUP.md) for the full setup walkthrough.
+For Discord reminders, set your webhook URL and Discord user ID in user
+settings and run with `REMINDERS_ENABLED=true` — the scheduler container
+checks for due reminders every minute.
+
+See [`.ai/PROJECT_SETUP.md`](.ai/PROJECT_SETUP.md) for the full setup
+walkthrough.
 
 ## Architecture
 
-- **Backend** — Django with PostgreSQL.
-- **Frontend** — vanilla JavaScript with modular components.
-- **Deployment** — Docker Compose with separate web and database containers.
-- **Patterns** — command pattern for business logic, repository pattern for data access.
+Django + PostgreSQL, vanilla JavaScript frontend, Docker Compose. Business
+logic lives in commands, data access in repositories — see
+[`CLAUDE.md`](CLAUDE.md) for the conventions.
 
 ## Development
 
 Common tasks (run from `packages/django-app/`):
 
-- `just up` / `just up-d` — start all services (foreground / detached).
-- `just down` — stop all services.
-- `just migrate` — apply database migrations.
-- `just makemigrations` — create new migrations.
-- `just shell` — Django shell.
-- `just test` — run the test suite.
-- `just reload-db` — reset the database and reload dev fixtures.
-- `just tail-logs web 100` — tail the last 100 lines of web logs.
-- `just prepush` — run the pre-push checks (run this before pushing).
-
-## Further Documentation
-
-- [`CLAUDE.md`](CLAUDE.md) — project conventions and architectural patterns.
-- [`.ai/PROJECT_SETUP.md`](.ai/PROJECT_SETUP.md) — detailed setup guide.
+- `just up` / `just up-d` — start all services (foreground / detached)
+- `just down` — stop all services
+- `just migrate` / `just makemigrations` — database migrations
+- `just shell` — Django shell
+- `just test` — run the test suite
+- `just reload-db` — reset the database and reload dev fixtures
+- `just tail-logs web 100` — tail the last 100 lines of web logs
+- `just prepush` — run the pre-push checks (run this before pushing)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ I want a notes app that gives me:
 
 - as little friction as possible when writing something down and keeping it
   organized
+- powerful sorting and filtering of tags
 - something that keeps me on track, and can nudge me if I ask it to
 - a way to loop forgotten things back into my life instead of letting them
   rot below the fold

--- a/README.md
+++ b/README.md
@@ -105,14 +105,35 @@ template can carry both its checklist and an open-todos embed in one apply.
 
 ### The MCP server
 
-Brainspread exposes an MCP server at `/api/mcp/` (streamable HTTP), so
-Claude Code or any other MCP client can operate on your notes directly. This
-is where a lot of the leverage is. Some real prompts:
+To be clear, the app doesn't need AI to be worth using. The daily page,
+tags, views, and (soon) automations carry it on their own. But it exposes an
+MCP server at `/api/mcp/` (streamable HTTP), so Claude Code or any other MCP
+client can operate on your notes directly, and that turns out to be a big
+multiplier. Some real prompts:
 
 - "what's on my plate today?"
 - "reschedule everything overdue to spread over the next week"
 - "read my dailies from last week and write a review on today's page"
 - "find my untagged workout notes and tag them #strength-training"
+
+It gets better when you connect the server to a Claude Code remote session,
+because that session is reachable from the Claude mobile/desktop/web apps.
+Your notes become something you can talk to from anywhere, including by
+voice. Stuff I actually use this for:
+
+- hands-free capture: "hey brainspread, remind me to flip the laundry in 30
+  minutes"
+- sitting back down and asking "what was I doing?"
+- pasting garbage in and getting structure out. I once pasted an HTML table
+  as plain text and asked for a block; it made a CSV table because it knew
+  brainspread renders those nicely.
+- the usual assistant stuff (research, planning a trip, packing lists) works
+  too, with the difference that the results land in my notes instead of
+  dying in a chat log
+
+And once automations land, creating one by voice is the endgame: "every
+Tuesday and Thursday, copy my workout to the daily page" said out loud on a
+walk, and it exists.
 
 It's a small surface, 16 tools covering pages, blocks, todos, search,
 scheduling, and tagging, each a thin wrapper over the same commands the UI

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ I want a notes app that gives me:
   - copy my workout to the daily page on Tuesday and Thursday
   - estimate calories and macros whenever a new block tagged `#food-log` is
     created
-  - summarize a pasted web page with AI and nest the summary under the link
+  - write up new recipes and generate this week's grocery list from past
+    grocery lists and whatever I'm planning to cook
   - sweep everything tagged `#recipe` onto the recipes page once a week
 
 ## Capture and tags

--- a/README.md
+++ b/README.md
@@ -1,100 +1,122 @@
 # Brainspread
 
-A networked note-taking app I built for myself. It steals its two best ideas
-from elsewhere: from Logseq, the daily page — open the app and start typing,
-no folders, no "where should this go"; and from zettelkasten practice, tags
-as the organizing principle — tag things as you capture them, sort them into
-their proper pages later, if ever. It also speaks MCP, so Claude Code can
-work inside your notes.
+A note-taking app I built for myself. The two big influences are Logseq
+(every day gets its own page, and that's where you write) and zettelkasten
+(tags do the organizing). It also has an MCP server, so Claude Code can read
+and write your notes.
 
 ![Brainspread screenshot](docs/images/screenshot2.png)
 
 ## Why
 
-Every notes system I've used dies the same way: the friction of deciding
-where a note belongs is just high enough that I stop writing notes. So in
-Brainspread everything lands in the same place — today's daily page, which
-already exists the moment you open the app. You write, you hit enter, you
-move on.
+I want a notes app that gives me:
 
-Organization happens through tags, and a tag here is just a page. Typing
-`#strength-training` in a block makes that block a member of the
-strength-training page; open the page and the block is there, alongside
-everything else you've tagged over the weeks. When a topic accumulates
-enough strays you can select them and move them onto the page for real.
-Organizing becomes a batch job you run when you're in the mood, not a tax
-you pay on every thought. `[[Wiki links]]` and backlinks tie the rest of the
-graph together.
-
-Beyond capture, the app is built around a few things I actually want from a
-tool like this:
-
-- as little friction as possible when writing something down
+- as little friction as possible when writing something down and keeping it
+  organized
 - something that keeps me on track, and can nudge me if I ask it to
 - a way to loop forgotten things back into my life instead of letting them
   rot below the fold
-- a way to automate the stuff I do repeatedly
+- a way to automate the stuff I do repeatedly, like:
+  - copy my workout to the daily page on Tuesday and Thursday
+  - estimate calories and macros whenever a new block tagged `#food-log` is
+    created
+  - summarize a pasted web page with AI and nest the summary under the link
+  - sweep everything tagged `#recipe` onto the recipes page once a week
+
+## Capture and tags
+
+Everything you write lands on today's daily page, which already exists when
+you open the app. Organization comes from tags, and a tag is a page (and a
+page is a tag). Typing `#strength-training` in a block makes that block a
+member of the strength-training page. Open the page and every block you've
+ever tagged with it is sitting there. A block can belong to as many pages as
+you tag it with.
+
+Blocks can also be moved onto a page for real, one-off or in bulk. The goal
+is for an automation to do that sorting for you: everything matching some
+tag or `key:: value` gets swept onto its page on a schedule.
+
+There's also `[[wiki link]]` syntax that gives you backlinks between pages.
+Honestly I never use it. Tags cover it for me.
+
+## Where it's headed
+
+The next big piece is automations
+([#143](https://github.com/steezeburger/brainspread/issues/143)): blocks
+tagged `#automation` whose `trigger:: / query:: / action::` properties make
+them do things. The automation examples in the Why section are all this
+feature. A few more:
+
+- roll sticky todos onto today every morning
+- ping Discord every 15 minutes while a block is marked `doing`
+  ("still on this?")
+- apply the morning routine template on a schedule
+
+This is also the plan for looping forgotten things back in: an automation
+(or Claude Code over MCP) queries for stale stuff and resurfaces it, so it
+doesn't depend on me remembering to go look. Automations live in the graph
+as ordinary blocks, which means a template containing one becomes a
+shareable automation pack. A declarative widget layer (habit heatmaps,
+streaks, countdowns) is sketched in
+[#168](https://github.com/steezeburger/brainspread/issues/168). Parts of the
+engine are built and it's landing in slices.
 
 ## The pieces
 
 ### Blocks, todos, and days
 
-Everything is a block in a nested outline. Blocks can be plain bullets,
-todos (`todo` → `doing` → `done`, plus `later` and `wontdo`), headings,
-quotes, code, images, files. Every day gets its own page automatically, and
-past dailies stay browsable, so the app doubles as a journal.
+Everything is a block in a nested outline. Blocks can be bullets, todos
+(`todo` / `doing` / `done`, plus `later` and `wontdo`), headings, quotes,
+code, images, files. Every day gets its own page automatically, and past
+dailies stay browsable, so the app doubles as a journal.
 
 ### Scheduling, rollover, and reminders
 
-Scheduling a block gives it a due date without moving it — it stays where
-you wrote it and *surfaces* on the daily page for that date. Anything that
-slips shows up in the built-in Overdue view, and undone todos can be rolled
-forward onto today so nothing silently disappears into last Tuesday.
+Scheduling a block gives it a due date without moving it. It stays where you
+wrote it and surfaces on the daily page for that date. Anything that slips
+shows up in the built-in Overdue view, and undone todos can be rolled
+forward onto today.
 
-Reminders are the louder version: attach a time to a block and a scheduler
-delivers it to Discord, with a mention so it hits your phone. The message
-carries action links — mark done, mark doing, move to today, snooze for
-15m/30m/1h/1d — so you can deal with a reminder from the notification
-without opening the app. This is the "loop things back into my life" part,
-and it's the feature I'd keep if I had to throw out everything else.
+Reminders are the louder version. Attach a time to a block and a scheduler
+posts it to Discord with a mention, so it hits your phone. The message
+carries action links (mark done, mark doing, move to today, snooze
+15m/30m/1h/1d), so you can handle it from the notification without opening
+the app.
 
 ### Saved views
 
 Saved views are queries over your blocks: filter by block type, tags, due or
 completed dates, `key:: value` properties, or content, combined with
-and/or/not. Pin a view to the sidebar, or embed it directly on a page so its
-results render inline. Embeds can also be pinned to "the daily page" as a
-concept, so a *what's due today* embed follows you from day to day. Two
-views ship out of the box: Overdue and Done this week.
+and/or/not. Pin a view to the sidebar, or embed it on a page so its results
+render inline. An embed can also be pinned to the daily page as a concept,
+so a "due today" embed follows you from day to day. Two ship out of the box:
+Overdue and Done this week.
 
 Blocks parse `key:: value` lines into queryable properties, so views can
-slice on whatever structure you invent — `project:: roadmap`,
-`priority:: p1`, whatever.
+slice on whatever structure you invent (`project:: roadmap`,
+`priority:: p1`, etc).
 
 ### Templates
 
 A template is a page whose block tree can be stamped onto any other page.
-Copies are independent (checking off a cloned todo doesn't touch the
-template), tags come along, and embedded views come along too — so a
-"morning routine" template can carry both its checklist and an open-todos
-embed in one apply.
+Copies are independent, so checking off a cloned todo doesn't touch the
+template. Tags and embedded views come along too, so a morning routine
+template can carry both its checklist and an open-todos embed in one apply.
 
 ### The MCP server
 
-Brainspread exposes an MCP server at `/api/mcp/` (streamable HTTP), which
-means Claude Code — or any MCP client — can operate on your notes directly.
-This has turned out to be the integration that matters. The in-app chat is
-convenient, but pointing an actual agent at your knowledge base is a
-different thing entirely:
+Brainspread exposes an MCP server at `/api/mcp/` (streamable HTTP), so
+Claude Code or any other MCP client can operate on your notes directly. This
+is where a lot of the leverage is. Some real prompts:
 
 - "what's on my plate today?"
 - "reschedule everything overdue to spread over the next week"
 - "read my dailies from last week and write a review on today's page"
 - "find my untagged workout notes and tag them #strength-training"
 
-It exposes a deliberately small surface — 16 tools covering pages, blocks,
-todos, search, scheduling, and tagging — each one a thin wrapper over the
-same commands the UI uses.
+It's a small surface, 16 tools covering pages, blocks, todos, search,
+scheduling, and tagging, each a thin wrapper over the same commands the UI
+uses.
 
 Auth is the same token the web app gets when you log in (visible in the
 Django admin under Auth Tokens):
@@ -108,30 +130,14 @@ claude mcp add --transport http brainspread http://localhost:8001/api/mcp/ \
 
 There's also a chat panel next to your notes, with persistent history,
 bring-your-own-key support for Anthropic/OpenAI/Google, web search, and a
-larger agentic toolset with an approval gate on writes. It's useful, but
-it's not the point — every app has a chat panel now. The MCP server is the
-interesting half of the AI story.
+bigger toolset with an approval gate on writes. Good for quick stuff like
+"what did I get done this week?" without leaving the app.
 
 ### Odds and ends
 
 Whiteboards (tldraw), web archives (save a readable copy of a link, attached
-to the block that mentions it), public share links for pages, favorites,
-a graph view, file attachments, completion stats and streaks, and a
-spotlight-style search on Cmd+Space.
-
-## Where it's headed
-
-The next big piece is automations
-([#143](https://github.com/steezeburger/brainspread/issues/143)): blocks
-tagged `#automation` whose `trigger:: / query:: / action::` properties make
-them *do* things — roll sticky todos onto today every morning, ping Discord
-every 15 minutes while a block is marked `doing` ("still on this?"), apply
-the morning-routine template on a schedule. Because automations live in the
-graph as ordinary blocks, a template containing one becomes a shareable
-automation pack. A declarative widget layer (habit heatmaps, streaks,
-countdowns) is sketched in
-[#168](https://github.com/steezeburger/brainspread/issues/168). Parts of the
-automation engine are built; it's landing in slices.
+to the block that mentions it), public share links for pages, favorites, a
+graph view, file attachments, and search on Cmd+K.
 
 ## Quick start
 
@@ -159,7 +165,7 @@ Then open:
 - Login: `admin@email.com` / `password`
 
 For Discord reminders, set your webhook URL and Discord user ID in user
-settings and run with `REMINDERS_ENABLED=true` — the scheduler container
+settings and run with `REMINDERS_ENABLED=true`. The scheduler container
 checks for due reminders every minute.
 
 See [`.ai/PROJECT_SETUP.md`](.ai/PROJECT_SETUP.md) for the full setup
@@ -168,18 +174,18 @@ walkthrough.
 ## Architecture
 
 Django + PostgreSQL, vanilla JavaScript frontend, Docker Compose. Business
-logic lives in commands, data access in repositories — see
+logic lives in commands, data access in repositories. See
 [`CLAUDE.md`](CLAUDE.md) for the conventions.
 
 ## Development
 
 Common tasks (run from `packages/django-app/`):
 
-- `just up` / `just up-d` — start all services (foreground / detached)
-- `just down` — stop all services
-- `just migrate` / `just makemigrations` — database migrations
-- `just shell` — Django shell
-- `just test` — run the test suite
-- `just reload-db` — reset the database and reload dev fixtures
-- `just tail-logs web 100` — tail the last 100 lines of web logs
-- `just prepush` — run the pre-push checks (run this before pushing)
+- `just up` / `just up-d` - start all services (foreground / detached)
+- `just down` - stop all services
+- `just migrate` / `just makemigrations` - database migrations
+- `just shell` - Django shell
+- `just test` - run the test suite
+- `just reload-db` - reset the database and reload dev fixtures
+- `just tail-logs web 100` - tail the last 100 lines of web logs
+- `just prepush` - run the pre-push checks (run this before pushing)

--- a/README.md
+++ b/README.md
@@ -109,12 +109,18 @@ To be clear, the app doesn't need AI to be worth using. The daily page,
 tags, views, and (soon) automations carry it on their own. But it exposes an
 MCP server at `/api/mcp/` (streamable HTTP), so Claude Code or any other MCP
 client can operate on your notes directly, and that turns out to be a big
-multiplier. Some real prompts:
+multiplier. Every AI note app can summarize your week or answer questions
+about your notes. What's different here is that the agent gets the same
+primitives the app is built on: due dates, tags that are pages,
+`key:: value` properties, saved views, templates, reminders. So the prompts
+worth typing look like:
 
-- "what's on my plate today?"
-- "reschedule everything overdue to spread over the next week"
-- "read my dailies from last week and write a review on today's page"
-- "find my untagged workout notes and tag them #strength-training"
+- "reschedule everything overdue, spread it over the next week"
+- "sweep the recipe blocks scattered across my dailies onto the recipes
+  page"
+- "put priority:: p1 on the deploy todos and pin a view of open p1s"
+- "apply my packing template to today and set a reminder for 7am to start
+  on it"
 
 It gets better when you connect the server to a Claude Code remote session,
 because that session is reachable from the Claude mobile/desktop/web apps.

--- a/README.md
+++ b/README.md
@@ -26,16 +26,21 @@ I want a notes app that gives me:
 
 ## Capture and tags
 
-Everything you write lands on today's daily page, which already exists when
-you open the app. Organization comes from tags, and a tag is a page (and a
-page is a tag). Typing `#strength-training` in a block makes that block a
+The app opens to today's daily page, which already exists and is where most
+writing happens. You can go to any page and create blocks there directly;
+the daily is just the default landing spot when you don't want to think
+about where something goes. Organization comes from tags, and a tag is a
+page (and a page is a tag). Typing `#strength-training` in a block makes that block a
 member of the strength-training page. Open the page and every block you've
 ever tagged with it is sitting there. A block can belong to as many pages as
 you tag it with.
 
-Blocks can also be moved onto a page for real, one-off or in bulk. The goal
-is for an automation to do that sorting for you: everything matching some
-tag or `key:: value` gets swept onto its page on a schedule.
+Blocks can also be moved onto a page for real, one-off or in bulk. A
+pattern I use constantly: write a pile of notes nested under a single block
+on the daily, tag that block with the page I want them to end up on, and
+move the whole thing over later. The goal is for an automation to do that
+sorting for you: everything matching some tag or `key:: value` gets swept
+onto its page on a schedule.
 
 There's also `[[wiki link]]` syntax that gives you backlinks between pages.
 Honestly I never use it. Tags cover it for me.


### PR DESCRIPTION
Replaced the feature-list README with a product narrative that explains *why* Brainspread exists and how its core ideas (daily pages + tags as organization) solve the friction problem that kills most note-taking systems.

The new README:
- Opens with the problem statement and design philosophy instead of a bulleted feature list
- Organizes content by user-facing concepts (blocks, scheduling, views, templates, MCP, chat) rather than technical categories
- Adds concrete examples of what the app enables ("what's on my plate today?", "reschedule everything overdue")
- Explains the MCP server as the primary AI integration, with in-app chat as secondary
- Includes setup instructions for Discord reminders and MCP client configuration
- Condenses architecture and development sections to essentials, cross-referencing CLAUDE.md for conventions
- Previews upcoming work (automations, widgets) with issue links

This positions the tool as a coherent product with a clear philosophy rather than a feature checklist.

https://claude.ai/code/session_012TtS8euKJdRbW5xVfj6jv4