### PR TITLE
Allow block type transitions for later and wontdo states

### DIFF
--- a/packages/django-app/app/knowledge/commands/update_block_command.py
+++ b/packages/django-app/app/knowledge/commands/update_block_command.py
@@ -116,10 +116,19 @@ class UpdateBlockCommand(AbstractBaseCommand):
         self, content: str, current_block_type: str
     ) -> str:
         """Auto-detect block type from content patterns"""
-        # Only auto-detect for bullet, todo, doing, and done types
-        # Don't override other explicit types like heading, code, etc.
-        # Don't auto-detect for later and wontdo - these are explicit states
-        if current_block_type not in ["bullet", "todo", "doing", "done"]:
+        # Only auto-detect for bullet and the todo-family states. All five
+        # states carry their keyword as a content prefix (see
+        # SetBlockTypeCommand.STATE_PREFIXES), so editing "LATER x" to
+        # "TODO x" must move the type too. Don't override other explicit
+        # types like heading, code, etc.
+        if current_block_type not in [
+            "bullet",
+            "todo",
+            "doing",
+            "done",
+            "later",
+            "wontdo",
+        ]:
             return current_block_type
 
         # Only auto-detect if we have content
@@ -150,7 +159,7 @@ class UpdateBlockCommand(AbstractBaseCommand):
             return "wontdo"
 
         # If none of the patterns match, return bullet for todo-family types
-        if current_block_type in ["todo", "doing", "done"]:
+        if current_block_type in ["todo", "doing", "done", "later", "wontdo"]:
             return "bullet"
         return current_block_type
 

--- a/packages/django-app/app/knowledge/test/commands/test_update_block_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_update_block_command.py
@@ -157,6 +157,76 @@ class TestUpdateBlockCommand(TestCase):
         self.assertEqual(updated.block_type, "todo")
         self.assertIsNone(updated.completed_at)
 
+    def test_should_change_from_later_to_todo_via_content_update(self):
+        """Editing "LATER x" to "TODO x" must move the type to todo. The
+        later state is itself enterable by typing "LATER", so content
+        edits have to be able to detect their way back out of it too."""
+        later_block = BlockFactory(
+            page=self.page,
+            user=self.user,
+            content="LATER write the report",
+            block_type="later",
+        )
+
+        form_data = {
+            "user": self.user.id,
+            "block": str(later_block.uuid),
+            "content": "TODO write the report",
+        }
+        form = UpdateBlockForm(form_data)
+        form.is_valid()
+        updated_block = UpdateBlockCommand(form).execute()
+
+        self.assertEqual(updated_block.block_type, "todo")
+        self.assertEqual(updated_block.content, "TODO write the report")
+
+    def test_should_change_from_later_to_bullet_when_keyword_removed(self):
+        """Removing the LATER keyword entirely demotes the block to a
+        bullet, matching the todo/doing/done behavior."""
+        later_block = BlockFactory(
+            page=self.page,
+            user=self.user,
+            content="LATER write the report",
+            block_type="later",
+        )
+
+        form_data = {
+            "user": self.user.id,
+            "block": str(later_block.uuid),
+            "content": "write the report",
+        }
+        form = UpdateBlockForm(form_data)
+        form.is_valid()
+        updated_block = UpdateBlockCommand(form).execute()
+
+        self.assertEqual(updated_block.block_type, "bullet")
+
+    def test_should_clear_completed_at_when_content_leaves_wontdo(self):
+        """wontdo is a terminal state — editing it back to "TODO x" must
+        clear completed_at along with the type change."""
+        form_data = {
+            "user": self.user.id,
+            "page": self.page.uuid,
+            "content": "WONTDO chase that lead",
+        }
+        form = CreateBlockForm(form_data)
+        form.is_valid()
+        wontdo_block = CreateBlockCommand(form).execute()
+        self.assertEqual(wontdo_block.block_type, "wontdo")
+        self.assertIsNotNone(wontdo_block.completed_at)
+
+        form_data = {
+            "user": self.user.id,
+            "block": str(wontdo_block.uuid),
+            "content": "TODO chase that lead",
+        }
+        form = UpdateBlockForm(form_data)
+        form.is_valid()
+        updated_block = UpdateBlockCommand(form).execute()
+
+        self.assertEqual(updated_block.block_type, "todo")
+        self.assertIsNone(updated_block.completed_at)
+
     def test_should_not_override_heading_block_type(self):
         """Test that auto-detection doesn't override heading type"""
         # Create a heading block


### PR DESCRIPTION
Enable content-based block type detection for `later` and `wontdo` states, allowing users to transition between these states and other todo-family types via content edits.

Previously, the `_detect_block_type_from_content` method only auto-detected types for `bullet`, `todo`, `doing`, and `done`. This prevented users from editing "LATER x" to "TODO x" or "WONTDO x" to "TODO x" — the block type would remain unchanged even though the content keyword changed.

**Key changes:**
- Updated `_detect_block_type_from_content` to include `later` and `wontdo` in the list of auto-detectable types
- Updated the fallback logic to demote `later` and `wontdo` blocks to `bullet` when their keywords are removed
- Added three test cases covering the new transitions:
  - Changing from `later` to `todo` via content edit
  - Removing the `later` keyword to demote to `bullet`
  - Clearing `completed_at` when transitioning from `wontdo` to `todo`

This aligns with the existing behavior where all five todo-family states carry their keyword as a content prefix, making content edits the natural way to transition between them.

https://claude.ai/code/session_01GFFGnqRSLDPiathyjE46hM