### PR TITLE
Add block-save conflict detection and read-only monitor mode

### DIFF
--- a/packages/django-app/app/knowledge/commands/__init__.py
+++ b/packages/django-app/app/knowledge/commands/__init__.py
@@ -65,7 +65,7 @@ from .sync_block_tags_command import SyncBlockTagsCommand
 from .tag_blocks_command import TagBlocksCommand, UntagBlocksCommand
 from .toggle_block_todo_command import ToggleBlockTodoCommand
 from .touch_page_command import TouchPageCommand
-from .update_block_command import UpdateBlockCommand
+from .update_block_command import BlockUpdateConflictError, UpdateBlockCommand
 from .update_page_command import UpdatePageCommand
 from .update_page_embedded_view_command import UpdatePageEmbeddedViewCommand
 from .update_saved_view_command import UpdateSavedViewCommand

--- a/packages/django-app/app/knowledge/commands/update_block_command.py
+++ b/packages/django-app/app/knowledge/commands/update_block_command.py
@@ -11,6 +11,17 @@ from .sync_block_tags_command import SyncBlockTagsCommand
 from .touch_page_command import TouchPageCommand
 
 
+class BlockUpdateConflictError(Exception):
+    """Raised when a save carries `expected_content` that no longer matches
+    the block's stored content — another session saved in between. Carries
+    the current server-side block so the API can return it with the 409,
+    letting the client show both versions instead of clobbering one."""
+
+    def __init__(self, block: Block) -> None:
+        self.block = block
+        super().__init__("Block was modified by another session")
+
+
 class UpdateBlockCommand(AbstractBaseCommand):
     """Command to update an existing block"""
 
@@ -23,6 +34,14 @@ class UpdateBlockCommand(AbstractBaseCommand):
 
         user = self.form.cleaned_data["user"]
         block = self.form.cleaned_data["block"]
+
+        # Optimistic-concurrency check. BaseForm.clean prunes unsubmitted
+        # keys, so presence here means the caller opted in (an empty-string
+        # baseline is a valid expectation for a block that was empty).
+        if "expected_content" in self.form.cleaned_data:
+            expected = self.form.cleaned_data["expected_content"]
+            if expected != block.content:
+                raise BlockUpdateConflictError(block)
 
         # Update fields. Parent only changes when the caller submitted
         # the key: an explicit null re-roots the block (outdent), while

--- a/packages/django-app/app/knowledge/forms/update_block_form.py
+++ b/packages/django-app/app/knowledge/forms/update_block_form.py
@@ -17,6 +17,13 @@ class UpdateBlockForm(BaseForm):
     user = forms.ModelChoiceField(queryset=UserRepository.get_queryset())
     block = UUIDModelChoiceField(queryset=BlockRepository.get_queryset(), required=True)
     content = forms.CharField(required=False)
+    # Optimistic-concurrency guard: the content this client last loaded
+    # from the server. When present, UpdateBlockCommand refuses the save
+    # (raises BlockUpdateConflictError → HTTP 409) if the block's stored
+    # content no longer matches — i.e. another tab/device/AI edit landed
+    # in between — instead of silently clobbering it. strip=False so the
+    # comparison is byte-exact against what the server previously sent.
+    expected_content = forms.CharField(required=False, strip=False)
     content_type = forms.CharField(max_length=50, required=False)
     block_type = forms.CharField(max_length=50, required=False)
     order = forms.IntegerField(min_value=0, required=False)

--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -971,6 +971,65 @@ body {
   max-width: 14rem;
 }
 
+/* choose dialog — stacked decision options, used by the block-save
+ * conflict resolver. Wider than the default modal so the two content
+ * versions can be read side by side without wrapping badly. */
+.app-modal-choose {
+  max-width: 560px;
+}
+
+.app-modal-choose-section-label {
+  font-size: 0.75rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 0.25rem;
+}
+
+.app-modal-choose-section-text {
+  margin: 0;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--border-primary);
+  border-radius: 0;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 9rem;
+  overflow-y: auto;
+}
+
+.app-modal-choose-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.app-modal-choose-option {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  text-align: left;
+  padding: 0.55rem 0.8rem;
+  border-radius: 0;
+}
+
+.app-modal-choose-option-label {
+  font-weight: bold;
+  font-size: 0.9rem;
+}
+
+.app-modal-choose-option-desc {
+  font-size: 0.78rem;
+  font-weight: normal;
+  opacity: 0.85;
+}
+
 .confirm-modal-content {
   background: var(--bg-primary);
   border: 1px solid var(--border-primary);
@@ -8809,4 +8868,54 @@ a.hashtag-mention:hover,
     .later
   ):not(.wontdo) {
   cursor: grab;
+}
+
+/* ---- Monitor mode (?monitor=1) ------------------------------------
+ * Read-only wall-display mode for pinning a page (typically the daily
+ * note) on a big screen. The Page component polls for fresh data and
+ * blocks all writes; these rules strip interactive chrome and disable
+ * pointer interaction so the display can't be edited by a stray click.
+ * The app shell already skips rendering the left nav and chat panel. */
+body.monitor-mode .header-controls,
+body.monitor-mode .page-actions,
+body.monitor-mode .add-block-btn {
+  display: none;
+}
+
+body.monitor-mode .page-header,
+body.monitor-mode .embedded-views-section,
+body.monitor-mode .blocks-container,
+body.monitor-mode .linked-references-section {
+  pointer-events: none;
+}
+
+/* Give the content the full column width the sidebar/chat freed up. */
+body.monitor-mode .main-content-area {
+  max-width: 72rem;
+  margin: 0 auto;
+}
+
+.monitor-badge {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 1000;
+  padding: 0.35rem 0.7rem;
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 3px solid var(--border-primary);
+  border-radius: 0;
+  box-shadow: 4px 4px 0 var(--border-primary);
+  cursor: pointer;
+  opacity: 0.75;
+}
+
+.monitor-badge:hover {
+  opacity: 1;
+  background: var(--hover-bg);
 }

--- a/packages/django-app/app/knowledge/static/knowledge/js/app.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/app.js
@@ -47,6 +47,11 @@ const KnowledgeApp = createApp({
       user: cachedUser, // Load user immediately from cache
       isAuthenticated: isAuth, // Check immediately
       currentView: initialView, // Set view immediately
+      // Monitor mode (?monitor=1): the Page component handles read-only
+      // + polling; the shell's job is to strip the sidebar and chat
+      // chrome so a wall display shows only the note itself.
+      monitorMode:
+        new URLSearchParams(window.location.search).get("monitor") === "1",
       loading: isAuth && !cachedUser, // Only show loading if we have token but no cached user
       showSettings: false, // Settings modal state
       settingsActiveTab: "general", // Default tab for settings modal
@@ -112,6 +117,7 @@ const KnowledgeApp = createApp({
       // Whiteboards, graph view, and the saved-views / all-pages /
       // templates surfaces use the full column width; chat is noise
       // there.
+      if (this.monitorMode) return false;
       if (this.currentView === "graph") return false;
       if (this.currentView === "views") return false;
       if (this.currentView === "pages") return false;
@@ -316,8 +322,10 @@ const KnowledgeApp = createApp({
       const day = String(today.getDate()).padStart(2, "0");
       const todayString = `${year}-${month}-${day}`;
 
-      // Redirect to today's page
-      window.location.href = `/knowledge/page/${todayString}/`;
+      // Redirect to today's page, preserving the query string so
+      // /knowledge/?monitor=1 lands on today's daily still in monitor
+      // mode.
+      window.location.href = `/knowledge/page/${todayString}/${window.location.search}`;
     },
 
     // Theme and settings methods
@@ -1200,6 +1208,7 @@ const KnowledgeApp = createApp({
                     </div>
                     <div v-else class="content-layout">
                         <LeftNav
+                            v-if="!monitorMode"
                             ref="leftNav"
                             :user="user"
                             @navigate-to-slug="onNavigateToSlug"

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/AppModals.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/AppModals.js
@@ -12,10 +12,14 @@
 //   const name = await window.appModals.prompt("page title:");
 //   await window.appModals.alert("upload failed");
 //   const page = await window.appModals.pickPage({title: "embed on a page"});
+//   const choice = await window.appModals.choose({options: [...]});
 //
 // Each method returns a promise that resolves on user action. pickPage
 // resolves with the selected page object (uuid, slug, title, ...) or
-// null when the user dismisses.
+// null when the user dismisses. choose renders a stacked list of
+// options (plus optional read-only text sections, e.g. two versions of
+// a conflicting block) and resolves with the chosen option's value, or
+// null on dismiss.
 
 window.AppModals = {
   name: "AppModals",
@@ -70,6 +74,13 @@ window.AppModals = {
           const ok = this.$refs.alertOk;
           if (ok) ok.focus();
         });
+      } else if (next && next.kind === "choose") {
+        this.$nextTick(() => {
+          // The component root is a <teleport>, so $el isn't an element —
+          // the dialog itself lives under document.body.
+          const first = document.querySelector(".app-modal-choose-option");
+          if (first) first.focus();
+        });
       } else if (
         next &&
         (next.kind === "pickPage" || next.kind === "pickBlock")
@@ -99,6 +110,7 @@ window.AppModals = {
       alert: this.alert.bind(this),
       pickPage: this.pickPage.bind(this),
       pickBlock: this.pickBlock.bind(this),
+      choose: this.choose.bind(this),
     };
   },
 
@@ -159,6 +171,31 @@ window.AppModals = {
             title: normalized.title || "",
             message: normalized.message || "",
             confirmLabel: normalized.confirmLabel || "ok",
+          },
+          resolve,
+        });
+      });
+    },
+
+    choose(opts) {
+      // Multi-option decision dialog. `options` is a list of
+      // {value, label, description?, kind?} rendered as stacked buttons
+      // (kind: "primary" | "danger" | default outline). `sections` is an
+      // optional list of {label, text} rendered read-only above the
+      // options — used by the block-conflict dialog to show both
+      // versions. Resolves with the chosen value, or null on
+      // dismiss/cancel.
+      const normalized = opts || {};
+      return new Promise((resolve) => {
+        this.queue.push({
+          id: ++this._idCounter,
+          kind: "choose",
+          opts: {
+            title: normalized.title || "",
+            message: normalized.message || "",
+            sections: normalized.sections || [],
+            options: normalized.options || [],
+            cancelLabel: normalized.cancelLabel || "cancel",
           },
           resolve,
         });
@@ -444,6 +481,7 @@ window.AppModals = {
       if (top.kind === "confirm") this.onCancel();
       else if (top.kind === "prompt") this.onPromptCancel();
       else if (top.kind === "alert") this.onAlertOk();
+      else if (top.kind === "choose") this.finish(null);
       else if (top.kind === "pickPage" || top.kind === "pickBlock")
         this.onPickerCancel();
     },
@@ -460,6 +498,7 @@ window.AppModals = {
         if (top.kind === "confirm") this.onCancel();
         else if (top.kind === "prompt") this.onPromptCancel();
         else if (top.kind === "alert") this.onAlertOk();
+        else if (top.kind === "choose") this.finish(null);
         return;
       }
       if (event.key === "Enter") {
@@ -565,6 +604,46 @@ window.AppModals = {
               @keydown="onKeydown"
             >
               {{ active.opts.confirmLabel }}
+            </button>
+          </div>
+        </div>
+
+        <div
+          v-else-if="active.kind === 'choose'"
+          class="app-modal app-modal-choose"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div v-if="active.opts.title" class="app-modal-header">
+            {{ active.opts.title }}
+          </div>
+          <div v-if="active.opts.message" class="app-modal-body">
+            {{ active.opts.message }}
+          </div>
+          <div
+            v-for="section in active.opts.sections"
+            :key="section.label"
+            class="app-modal-choose-section"
+          >
+            <div class="app-modal-choose-section-label">{{ section.label }}</div>
+            <pre class="app-modal-choose-section-text">{{ section.text }}</pre>
+          </div>
+          <div class="app-modal-choose-options">
+            <button
+              v-for="option in active.opts.options"
+              :key="option.value"
+              type="button"
+              class="btn app-modal-choose-option"
+              :class="option.kind === 'primary' ? 'btn-primary' : option.kind === 'danger' ? 'btn-danger' : 'btn-outline'"
+              @click="finish(option.value)"
+            >
+              <span class="app-modal-choose-option-label">{{ option.label }}</span>
+              <span v-if="option.description" class="app-modal-choose-option-desc">{{ option.description }}</span>
+            </button>
+          </div>
+          <div class="app-modal-actions">
+            <button type="button" class="btn btn-secondary" @click="finish(null)">
+              {{ active.opts.cancelLabel }}
             </button>
           </div>
         </div>

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/BlockComponent.js
@@ -1426,6 +1426,12 @@ const BlockComponent = {
         if (!result || !result.success) {
           throw new Error("updateBlock did not succeed");
         }
+        // Keep the optimistic-concurrency baseline in sync — this save
+        // bumped the server content, so a later edit in this tab must
+        // compare against the new value, not the pre-chip one.
+        if (result.data && result.data.content !== undefined) {
+          this.block._baseContent = result.data.content;
+        }
         if (result.data && Array.isArray(result.data.tags)) {
           this.block.tags = result.data.tags;
         }

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -445,6 +445,10 @@ const Page = {
         }
       }
       this.loadPage({ silent: true });
+      // Saved-view embeds own their query results — poking them here is
+      // what keeps a todo toggled elsewhere live inside an embed on the
+      // display (see QueryEmbedBlock's refresh-embeds listener).
+      document.dispatchEvent(new CustomEvent("brainspread:refresh-embeds"));
     },
 
     enterMonitorMode() {

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -61,6 +61,10 @@ const Page = {
       // Page data
       pageSlug: this.getSlugFromURL(),
       currentDate: this.getDateFromURL(),
+      // Monitor mode (?monitor=1): read-only wall-display mode. Editing
+      // is disabled, the page silently re-fetches every few seconds, and
+      // the app shell hides the sidebar / chat chrome.
+      monitorMode: this.getMonitorFromURL(),
       page: null,
       directBlocks: [], // Blocks that belong directly to this page
       referencedBlocks: [], // Blocks from other pages that reference this page
@@ -325,6 +329,24 @@ const Page = {
     // the current page), the URL hash changes without a reload. Listen
     // so we still scroll the matching block into view.
     window.addEventListener("hashchange", this.scrollToHashBlock);
+    // Monitor mode: poll for fresh data. The interval is configurable
+    // via ?refresh=<seconds> (min 2, default 5). The body class lets
+    // app-level CSS strip interactive chrome without threading a prop
+    // through every component.
+    if (this.monitorMode) {
+      document.body.classList.add("monitor-mode");
+      // Follow "today" across midnight only when the display was opened
+      // on today's daily note — a deliberately pinned past date stays.
+      this._monitorFollowsToday =
+        !!this.currentDate && this.currentDate === this.localDateString();
+      const params = new URLSearchParams(window.location.search);
+      const refresh = parseInt(params.get("refresh"), 10);
+      const seconds = Number.isFinite(refresh) && refresh >= 2 ? refresh : 5;
+      this._monitorTimer = setInterval(
+        () => this.monitorTick(),
+        seconds * 1000
+      );
+    }
     // Load page data
     await this.loadPage();
   },
@@ -370,6 +392,11 @@ const Page = {
       clearTimeout(this._blockChangedTimer);
       this._blockChangedTimer = null;
     }
+    if (this._monitorTimer) {
+      clearInterval(this._monitorTimer);
+      this._monitorTimer = null;
+    }
+    document.body.classList.remove("monitor-mode");
   },
 
   methods: {
@@ -388,6 +415,49 @@ const Page = {
         return slug;
       }
       return null;
+    },
+
+    getMonitorFromURL() {
+      return new URLSearchParams(window.location.search).get("monitor") === "1";
+    },
+
+    localDateString() {
+      const now = new Date();
+      return (
+        now.getFullYear() +
+        "-" +
+        String(now.getMonth() + 1).padStart(2, "0") +
+        "-" +
+        String(now.getDate()).padStart(2, "0")
+      );
+    },
+
+    monitorTick() {
+      // Don't burn requests while nobody can see the screen.
+      if (document.hidden) return;
+      if (this._monitorFollowsToday) {
+        const today = this.localDateString();
+        if (this.currentDate && today !== this.currentDate) {
+          // Midnight rolled over — jump the display to the new daily
+          // note, keeping ?monitor=1 (and any refresh override).
+          window.location.href = `/knowledge/page/${today}/${window.location.search}`;
+          return;
+        }
+      }
+      this.loadPage({ silent: true });
+    },
+
+    enterMonitorMode() {
+      const url = new URL(window.location.href);
+      url.searchParams.set("monitor", "1");
+      window.location.href = url.toString();
+    },
+
+    exitMonitorMode() {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("monitor");
+      url.searchParams.delete("refresh");
+      window.location.href = url.toString();
     },
 
     // Build a real anchor href for jumping to another page (and
@@ -614,6 +684,11 @@ const Page = {
           ...blockData,
           parent: parent,
           children: [],
+          // Server-confirmed content baseline for the optimistic-
+          // concurrency check — updated on every successful content
+          // save, sent as expected_content so a stale tab gets a 409
+          // instead of clobbering another session's edit.
+          _baseContent: blockData.content,
         };
 
         if (blockData.children && blockData.children.length > 0) {
@@ -651,7 +726,7 @@ const Page = {
       order = null,
       autoFocus = true
     ) {
-      if (!this.page) return;
+      if (!this.page || this.monitorMode) return;
 
       try {
         const blockOrder = order !== null ? order : this.getNextOrder(parent);
@@ -668,6 +743,7 @@ const Page = {
           const newBlock = {
             uuid: result.data.uuid || `temp-${Date.now()}`,
             content: result.data.content || content,
+            _baseContent: result.data.content ?? content ?? "",
             content_type: result.data.content_type || "text",
             block_type: result.data.block_type || "bullet",
             order: result.data.order || blockOrder,
@@ -717,6 +793,7 @@ const Page = {
     },
 
     async setBlockProperties(block, partial) {
+      if (this.monitorMode) return;
       // Shallow-merge `partial` into the block's existing properties
       // (so toggling one flag doesn't drop the others) and persist.
       // Pass a key with `null` to clear it — useful for "reset size"
@@ -742,14 +819,40 @@ const Page = {
     },
 
     async updateBlock(block, newContent, skipReload = false) {
+      // Monitor mode is strictly read-only — never write from a display.
+      if (this.monitorMode) return;
+      // Unchanged content → nothing to save. Besides skipping a useless
+      // PUT on every blur, this guarantees a block the user didn't touch
+      // in this tab can never raise a conflict dialog.
+      if (
+        block._baseContent !== undefined &&
+        newContent === block._baseContent
+      ) {
+        block.content = newContent;
+        if (!skipReload) {
+          await this.loadPage();
+        }
+        return;
+      }
       try {
-        const result = await window.apiService.updateBlock(block.uuid, {
+        const payload = {
           content: newContent,
           parent: block.parent ? block.parent.uuid : null,
-        });
+        };
+        // Opt in to the server-side conflict check with the content this
+        // tab last saw from the server. JSON.stringify drops undefined,
+        // so blocks without a baseline degrade to last-write-wins.
+        if (block._baseContent !== undefined) {
+          payload.expected_content = block._baseContent;
+        }
+        const result = await window.apiService.updateBlock(block.uuid, payload);
 
         if (result.success) {
           block.content = newContent;
+          block._baseContent =
+            result.data && result.data.content !== undefined
+              ? result.data.content
+              : newContent;
           if (result.data && result.data.block_type) {
             block.block_type = result.data.block_type;
             // A content prefix (e.g. typing "DONE ") can flip the type
@@ -780,8 +883,133 @@ const Page = {
           }
         }
       } catch (error) {
+        if (error && error.status === 409) {
+          // Another session saved this block after we loaded it. Nothing
+          // was written — hand both versions to the user.
+          await this.resolveBlockConflict(
+            block,
+            newContent,
+            error.payload && error.payload.data ? error.payload.data : null
+          );
+          return;
+        }
         console.error("failed to update block:", error);
         this.error = "failed to update block";
+      }
+    },
+
+    async resolveBlockConflict(block, localContent, serverData) {
+      const serverContent = serverData ? serverData.content : null;
+      const choice = await window.appModals.choose({
+        title: "this block changed elsewhere",
+        message:
+          "another tab, device, or the AI saved a different version of this block after you loaded it. nothing has been overwritten yet — pick what happens to your text.",
+        sections: [
+          { label: "your unsaved version", text: localContent || "(empty)" },
+          {
+            label: "currently saved version",
+            text: serverContent != null ? serverContent : "(unavailable)",
+          },
+        ],
+        options: [
+          {
+            value: "new-block",
+            label: "keep both",
+            description:
+              "save your text as a new block below; the saved version stays here",
+            kind: "primary",
+          },
+          {
+            value: "mine",
+            label: "use mine",
+            description: "overwrite the saved version with your text",
+          },
+          {
+            value: "theirs",
+            label: "use theirs",
+            description: "discard your text and keep the saved version",
+            kind: "danger",
+          },
+        ],
+        cancelLabel: "decide later",
+      });
+
+      const takeServerVersion = () => {
+        if (serverContent == null) return;
+        block.content = serverContent;
+        block._baseContent = serverContent;
+        if (serverData.block_type) block.block_type = serverData.block_type;
+      };
+
+      if (choice === "mine") {
+        try {
+          const payload = {
+            content: localContent,
+            parent: block.parent ? block.parent.uuid : null,
+          };
+          // Re-arm the check against the version we just showed, so a
+          // save landing while the dialog was open re-prompts instead of
+          // clobbering silently.
+          if (serverContent != null) {
+            payload.expected_content = serverContent;
+          }
+          const result = await window.apiService.updateBlock(
+            block.uuid,
+            payload
+          );
+          if (result.success) {
+            block.content = localContent;
+            block._baseContent =
+              result.data && result.data.content !== undefined
+                ? result.data.content
+                : localContent;
+            await this.loadPage({ silent: true });
+          }
+        } catch (error) {
+          if (error && error.status === 409) {
+            await this.resolveBlockConflict(
+              block,
+              localContent,
+              error.payload && error.payload.data ? error.payload.data : null
+            );
+            return;
+          }
+          console.error("failed to overwrite conflicted block:", error);
+          this.emitToast("failed to save block", "error");
+        }
+      } else if (choice === "new-block") {
+        try {
+          // The saved version keeps this block; the local text becomes a
+          // sibling right below it, on the block's own page (which for a
+          // linked reference isn't the page being viewed).
+          takeServerVersion();
+          const result = await window.apiService.createBlock({
+            page:
+              (serverData && serverData.page_uuid) ||
+              block.page_uuid ||
+              this.page.uuid,
+            content: localContent,
+            parent: block.parent ? block.parent.uuid : null,
+            block_type: "bullet",
+            content_type: "text",
+            order: (block.order ?? 0) + 1,
+          });
+          if (!result.success) throw new Error("create block failed");
+          await this.loadPage({ silent: true });
+        } catch (error) {
+          console.error("failed to save conflict copy as new block:", error);
+          this.emitToast("failed to save your text as a new block", "error");
+        }
+      } else if (choice === "theirs") {
+        takeServerVersion();
+        await this.loadPage({ silent: true });
+      } else {
+        // Dismissed — leave the local text in the block, unsaved. The
+        // next blur re-raises the conflict.
+        this.emitToast(
+          "not saved — this block still holds your unsaved text",
+          "info"
+        );
       }
     },
 
@@ -889,6 +1117,7 @@ const Page = {
     },
 
     async deleteBlock(block) {
+      if (this.monitorMode) return;
       // Mark the block as being deleted BEFORE we open the confirm
       // dialog. The same guard mattered for the native confirm() — it
       // dismissed the soft keyboard on mobile and blurred the active
@@ -976,11 +1205,15 @@ const Page = {
     },
 
     async toggleBlockTodo(block) {
+      if (this.monitorMode) return;
       try {
         const result = await window.apiService.toggleBlockTodo(block.uuid);
         if (result.success) {
           block.block_type = result.data.block_type;
           block.content = result.data.content;
+          // The toggle rewrote the content server-side — move the
+          // concurrency baseline along with it.
+          block._baseContent = result.data.content;
           // Keep completed_at in sync so the block-info modal shows the
           // right time without a reload: entering done/wontdo stamps it,
           // cycling back out clears it to null.
@@ -2117,6 +2350,7 @@ const Page = {
     },
 
     startEditing(block) {
+      if (this.monitorMode) return;
       this.lastEditingBlockUuid = block.uuid;
       // Clear any block selection when entering edit mode
       if (this.selectionAnchorUuid) {
@@ -3375,6 +3609,10 @@ const Page = {
         });
         if (!result.success) throw new Error("update block failed");
         block.content = url;
+        block._baseContent =
+          result.data && result.data.content !== undefined
+            ? result.data.content
+            : url;
         block.content_type = "embed";
         block.media_url = url;
         // Keep the user in the block, focused in the embed's label field.
@@ -4364,6 +4602,10 @@ const Page = {
                       <span class="context-menu-icon">★</span>
                       <span>{{ isFavorited ? 'unfavorite' : 'favorite' }}</span>
                     </button>
+                    <button @click="enterMonitorMode" class="context-menu-item" role="menuitem">
+                      <span class="context-menu-icon">⛶</span>
+                      <span>monitor mode</span>
+                    </button>
                     <button @click="deletePage" class="context-menu-item context-menu-danger" role="menuitem">
                        <span class="context-menu-icon">×</span>
                        <span>delete</span>
@@ -4456,6 +4698,10 @@ const Page = {
                     <button v-if="!isTemplate" @click="addFromTemplate" class="context-menu-item" role="menuitem">
                       <span class="context-menu-icon">+</span>
                       <span>add from template…</span>
+                    </button>
+                    <button @click="enterMonitorMode" class="context-menu-item" role="menuitem">
+                      <span class="context-menu-icon">⛶</span>
+                      <span>monitor mode</span>
                     </button>
                     <button @click="deletePage" class="context-menu-item context-menu-danger" role="menuitem">
                       <span v-if="isTemplate">delete template</span>
@@ -4645,6 +4891,16 @@ const Page = {
         </div>
 
       </div>
+
+      <!-- Monitor mode badge: the one interactive element on a wall
+           display. Click exits back to the normal editable page. -->
+      <button
+        v-if="monitorMode"
+        type="button"
+        class="monitor-badge"
+        @click="exitMonitorMode"
+        title="monitor mode: read-only, auto-refreshing. click to exit."
+      >◉ live</button>
 
       <!-- Schedule popover (issue #59 phase 4) -->
       <ScheduleBlockPopover

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/QueryEmbedBlock.js
@@ -163,6 +163,24 @@ window.QueryEmbedBlock = {
       "brainspread:block-changed",
       this._onBlocksChanged
     );
+    // Monitor mode's poll (Page.monitorTick) fires this after each
+    // silent reload. The block tree re-fetches itself, but embeds own
+    // their query results — without this hook a DOING toggled from
+    // another session never updates inside an embed on the wall
+    // display. Unlike block-changed, collapsed embeds also refresh so
+    // their count badge stays live; fetch() picks count-vs-rows mode
+    // from `collapsed` on its own.
+    this._onRefreshEmbeds = () => {
+      if (this._refetchTimer) clearTimeout(this._refetchTimer);
+      this._refetchTimer = setTimeout(() => {
+        this._refetchTimer = null;
+        this.fetch();
+      }, 150);
+    };
+    document.addEventListener(
+      "brainspread:refresh-embeds",
+      this._onRefreshEmbeds
+    );
   },
 
   beforeUnmount() {
@@ -170,6 +188,12 @@ window.QueryEmbedBlock = {
       document.removeEventListener(
         "brainspread:block-changed",
         this._onBlocksChanged
+      );
+    }
+    if (this._onRefreshEmbeds) {
+      document.removeEventListener(
+        "brainspread:refresh-embeds",
+        this._onRefreshEmbeds
       );
     }
     if (this._refetchTimer) {

--- a/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/services/api.js
@@ -48,9 +48,15 @@ class ApiService {
       const data = await response.json();
 
       if (!response.ok) {
-        throw new Error(
+        const error = new Error(
           data.detail || data.errors?.non_field_errors?.[0] || "Request failed"
         );
+        // Attach the status and parsed body so callers can react to
+        // specific failures (e.g. 409 block-save conflicts carry the
+        // current server-side block in payload.data).
+        error.status = response.status;
+        error.payload = data;
+        throw error;
       }
 
       return data;

--- a/packages/django-app/app/knowledge/test/commands/test_update_block_command.py
+++ b/packages/django-app/app/knowledge/test/commands/test_update_block_command.py
@@ -4,7 +4,11 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from assets.models import Asset
-from knowledge.commands import CreateBlockCommand, UpdateBlockCommand
+from knowledge.commands import (
+    BlockUpdateConflictError,
+    CreateBlockCommand,
+    UpdateBlockCommand,
+)
 from knowledge.forms import CreateBlockForm, UpdateBlockForm
 
 from ..helpers import BlockFactory, PageFactory, UserFactory
@@ -659,6 +663,85 @@ class TestUpdateBlockCommand(TestCase):
         child.refresh_from_db()
         self.assertEqual(child.parent_id, parent.id)
         self.assertEqual(child.properties.get("size"), {"width": 320})
+
+    def test_should_raise_conflict_when_expected_content_is_stale(self):
+        """A save carrying an expected_content baseline that no longer
+        matches the stored content must 409 instead of clobbering the
+        other session's edit."""
+        block = BlockFactory(page=self.page, user=self.user, content="edited elsewhere")
+
+        form = UpdateBlockForm(
+            {
+                "user": self.user.id,
+                "block": str(block.uuid),
+                "content": "my stale tab's version",
+                "expected_content": "what my tab loaded this morning",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        with self.assertRaises(BlockUpdateConflictError) as ctx:
+            UpdateBlockCommand(form).execute()
+
+        # The exception carries the current server block so the API can
+        # return it with the 409, and nothing was written.
+        self.assertEqual(str(ctx.exception.block.uuid), str(block.uuid))
+        block.refresh_from_db()
+        self.assertEqual(block.content, "edited elsewhere")
+
+    def test_should_save_when_expected_content_matches(self):
+        block = BlockFactory(page=self.page, user=self.user, content="original")
+
+        form = UpdateBlockForm(
+            {
+                "user": self.user.id,
+                "block": str(block.uuid),
+                "content": "updated from a fresh tab",
+                "expected_content": "original",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        updated = UpdateBlockCommand(form).execute()
+
+        self.assertEqual(updated.content, "updated from a fresh tab")
+
+    def test_should_treat_empty_expected_content_as_a_real_baseline(self):
+        """An empty-string baseline is meaningful — the tab loaded an
+        empty block. If someone else has since filled it in, that's a
+        conflict, not a free pass."""
+        block = BlockFactory(
+            page=self.page, user=self.user, content="filled in elsewhere"
+        )
+
+        form = UpdateBlockForm(
+            {
+                "user": self.user.id,
+                "block": str(block.uuid),
+                "content": "typed into what I thought was empty",
+                "expected_content": "",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        with self.assertRaises(BlockUpdateConflictError):
+            UpdateBlockCommand(form).execute()
+
+    def test_should_skip_conflict_check_when_expected_content_omitted(self):
+        """Callers that don't opt in (property saves, indent/outdent,
+        forced overwrites) keep last-write-wins semantics."""
+        block = BlockFactory(page=self.page, user=self.user, content="edited elsewhere")
+
+        form = UpdateBlockForm(
+            {
+                "user": self.user.id,
+                "block": str(block.uuid),
+                "content": "forced overwrite",
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        updated = UpdateBlockCommand(form).execute()
+
+        self.assertEqual(updated.content, "forced overwrite")
 
     def test_should_clear_parent_on_explicit_null(self):
         """Submitting `parent: null` is still the outdent path — the

--- a/packages/django-app/app/knowledge/views.py
+++ b/packages/django-app/app/knowledge/views.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 from assets.models import Asset
 from knowledge.commands import (
     AddTemplateBlocksToPageCommand,
+    BlockUpdateConflictError,
     BulkDeleteBlocksCommand,
     BulkMoveBlocksCommand,
     BulkMoveBlocksToPageCommand,
@@ -1028,6 +1029,18 @@ def update_block(request):
                 "errors": form.errors,
             }
             return Response(response, status=status.HTTP_400_BAD_REQUEST)
+
+    except BlockUpdateConflictError as e:
+        # Another session changed this block since the caller loaded it.
+        # Ship the current server-side block back with the 409 so the
+        # client can offer a merge (keep mine / new block / take theirs)
+        # instead of losing either version.
+        response: BlockResponse = {
+            "success": False,
+            "data": e.block.to_dict(),
+            "errors": {"non_field_errors": ["block was modified in another session"]},
+        }
+        return Response(response, status=status.HTTP_409_CONFLICT)
 
     except ValidationError as e:
         return Response(


### PR DESCRIPTION
Fixes the stale-tab clobbering problem and adds a wall-display mode for the daily note.

Block saves now send `expected_content` (what the tab last loaded); if another session saved in between, the server returns 409 instead of overwriting, and a dialog shows both versions with three choices — **keep both** (your text becomes a new block below), **use mine**, or **use theirs** — so typed content is never silently lost. Blurs with unchanged content no longer save at all.

**Monitor mode** (`?monitor=1`, or "monitor mode" in the page ⋮ menu) makes any page a read-only display: sidebar/chat chrome hidden, editing disabled, silent re-fetch every 5s (`?refresh=N` to tune), and a daily note opened on today follows the date across midnight. Click the ◉ live badge to exit.

To test on mobile: open today's daily with `?monitor=1`, then edit the same block from two tabs to see the conflict dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StH4GhRP9j2DRfHMq5u1Bx

---
_Generated by [Claude Code](https://claude.ai/code/session_01StH4GhRP9j2DRfHMq5u1Bx)_