### PR TITLE
Show multiselect toolbar as soon as a 2nd block is selected

### DIFF
--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -4668,7 +4668,8 @@ a.sidebar-item:visited {
 
 /* --- Multi-select mode (page menu → "select multiple") --- */
 
-/* Sticky toolbar shown above the block list while selection mode is on. */
+/* Sticky toolbar shown above the block list while selection mode is on,
+   or as soon as 2+ blocks are selected via shift/cmd-click. */
 .selection-toolbar {
   position: sticky;
   top: 0;

--- a/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
+++ b/packages/django-app/app/knowledge/static/knowledge/js/components/Page.js
@@ -242,6 +242,13 @@ const Page = {
       return this.selectedBlockUuids.size;
     },
 
+    // Surfaces the bulk-action toolbar either when the user has explicitly
+    // entered selection mode (page menu -> "select multiple"), or as soon
+    // as an ad-hoc shift/cmd-click selection has 2+ blocks in it.
+    showSelectionToolbar() {
+      return this.selectionMode || this.selectedBlockCount >= 2;
+    },
+
     // Sharing is meaningful for regular pages only. Daily notes and
     // whiteboards are intentionally excluded — sharing a moving date or a
     // tldraw snapshot has different UX considerations we can revisit later.
@@ -4719,7 +4726,7 @@ const Page = {
         </div>
 
         <!-- Selection Mode Toolbar -->
-        <div v-if="selectionMode" class="selection-toolbar" role="toolbar" aria-label="Selection actions">
+        <div v-if="showSelectionToolbar" class="selection-toolbar" role="toolbar" aria-label="Selection actions">
           <div class="selection-toolbar-status">
             <span class="selection-toolbar-count">{{ selectedBlockCount }}</span>
             <span class="selection-toolbar-label">selected</span>


### PR DESCRIPTION
Shift/cmd-click block selection and the page-menu "select multiple" mode already share the same `selectedBlockUuids` state and bulk-action methods, but only explicit selection mode showed the bulk-action toolbar — an ad-hoc shift/cmd-click selection gave no proactive UI until you right-clicked a selected block. This widens the toolbar's visibility condition to also show as soon as 2+ blocks are selected via shift/cmd-click, so both selection paths get the same immediate feedback.

Verified locally: shift/cmd-clicking two blocks now surfaces the toolbar with the correct count and all bulk actions, and both "done" and Escape correctly dismiss it and clear the selection.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJ9T4DXSjRSSpu7GKawn2A)_